### PR TITLE
Backlog-Badge aus Backlog-Ansicht entfernt, Daily-Ausnahme beibehalten

### DIFF
--- a/Dawn/Sources/Views/BacklogView.swift
+++ b/Dawn/Sources/Views/BacklogView.swift
@@ -64,7 +64,8 @@ struct BacklogView: View {
                         _Concurrency.Task {
                             await viewModel.deleteTask(task)
                         }
-                    }
+                    },
+                    showBacklogBadge: false
                 )
                 .swipeActions(edge: .leading) {
                     Button {

--- a/Dawn/Sources/Views/DailyFocusView.swift
+++ b/Dawn/Sources/Views/DailyFocusView.swift
@@ -65,7 +65,8 @@ struct DailyFocusView: View {
                                     await viewModel.completeTask(task)
                                 }
                             },
-                            onDelete: nil
+                            onDelete: nil,
+                            showDragHandle: true
                         )
                         .swipeActions(edge: .trailing) {
                             Button {
@@ -79,6 +80,7 @@ struct DailyFocusView: View {
                             .tint(.gray)
                         }
                     }
+                    .onMove(perform: viewModel.moveTasks)
                 }
             }
             

--- a/Dawn/Sources/Views/TaskRowView.swift
+++ b/Dawn/Sources/Views/TaskRowView.swift
@@ -11,11 +11,35 @@ struct TaskRowView: View {
     let task: Task
     let onToggle: (() -> Void)?
     let onDelete: (() -> Void)?
+    let showDragHandle: Bool
+    let showBacklogBadge: Bool
     
     @State private var showingDetail = false
     
+    init(
+        task: Task,
+        onToggle: (() -> Void)? = nil,
+        onDelete: (() -> Void)? = nil,
+        showDragHandle: Bool = false,
+        showBacklogBadge: Bool = true
+    ) {
+        self.task = task
+        self.onToggle = onToggle
+        self.onDelete = onDelete
+        self.showDragHandle = showDragHandle
+        self.showBacklogBadge = showBacklogBadge
+    }
+    
     var body: some View {
         HStack(spacing: 12) {
+            // Drag Handle
+            if showDragHandle {
+                Image(systemName: "line.3.horizontal")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.trailing, 4)
+            }
+            
             // Checkbox
             if let toggle = onToggle {
                 Button {
@@ -51,13 +75,15 @@ struct TaskRowView: View {
                             .foregroundStyle(.blue)
                     }
                     
-                    Text(task.status.displayName)
-                        .font(.caption2)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(statusColor.opacity(0.2))
-                        .foregroundStyle(statusColor)
-                        .cornerRadius(4)
+                    if shouldShowStatusBadge {
+                        Text(task.status.displayName)
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(statusColor.opacity(0.2))
+                            .foregroundStyle(statusColor)
+                            .cornerRadius(4)
+                    }
                 }
             }
             
@@ -99,6 +125,10 @@ struct TaskRowView: View {
         case .completed:
             return .green
         }
+    }
+    
+    private var shouldShowStatusBadge: Bool {
+        task.status != .inBacklog || showBacklogBadge
     }
 }
 
@@ -154,10 +184,11 @@ struct TaskDetailView: View {
         parentBacklogID: UUID()
     )
     
-    return TaskRowView(
+    TaskRowView(
         task: task,
         onToggle: {},
-        onDelete: {}
+        onDelete: {},
+        showDragHandle: true
     )
     .padding()
 }


### PR DESCRIPTION
Sortable Tiles in Daily view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds lightweight UI controls and ordering behavior to improve task management.
> 
> - Daily: `DailyFocusView` enables reordering of open tasks via `.onMove(perform: viewModel.moveTasks)` and shows a drag handle by passing `showDragHandle: true` to `TaskRowView`
> - Backlog: `BacklogView` passes `showBacklogBadge: false` to `TaskRowView` to suppress the backlog status badge
> - `TaskRowView`: new flags `showDragHandle` and `showBacklogBadge` with conditional UI (drag handle icon, `shouldShowStatusBadge` gating of status pill); updated preview
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad9b3193f361ee6cb2d6007653bf5742d8a566f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->