### PR TITLE
Geister-Zeile zum Anlegen benutzerdefinierter Kategorien

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -172,6 +172,57 @@
         }
       }
     },
+    "category.add.accessibility" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Kategorie hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add new category"
+          }
+        }
+      }
+    },
+    "category.add.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Kategorie"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New category"
+          }
+        }
+      }
+    },
+    "category.custom.name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Kategorie"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New category"
+          }
+        }
+      }
+    },
     "category.delete.confirm" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/App/Sources/Models/TaskCategory.swift
+++ b/App/Sources/Models/TaskCategory.swift
@@ -26,6 +26,9 @@ enum TaskCategory: String, Codable, CaseIterable {
     
     /// Unkategorisiert (speziell)
     case uncategorized
+
+    /// Benutzerdefinierte Kategorie (mehrfach anlegbar; Anzeige aus `Category.name` / `iconName`)
+    case custom
     
     /// Lokalisierter Display-Name
     var displayName: String {
@@ -42,6 +45,8 @@ enum TaskCategory: String, Codable, CaseIterable {
             return String(localized: "category.someday.name", defaultValue: "Irgendwann")
         case .uncategorized:
             return String(localized: "category.uncategorized.name", defaultValue: "Unkategorisiert")
+        case .custom:
+            return String(localized: "category.custom.name", defaultValue: "Neue Kategorie")
         }
     }
     
@@ -59,6 +64,8 @@ enum TaskCategory: String, Codable, CaseIterable {
         case .someday:
             return "infinity"
         case .uncategorized:
+            return "tag"
+        case .custom:
             return "tag"
         }
     }
@@ -78,6 +85,8 @@ enum TaskCategory: String, Codable, CaseIterable {
             return 4
         case .uncategorized:
             return 5
+        case .custom:
+            return 6
         }
     }
 }

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -132,6 +132,34 @@ final class CategoryService {
         }
     }
     
+    /// Legt eine neue benutzerdefinierte Kategorie an (erscheint nach bestehenden Einträgen, typisch unter „Unkategorisiert“).
+    func createCustom(name: String) throws -> Category {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw CategoryEditError.nameEmpty
+        }
+        guard trimmed.count <= Self.maxNameLength else {
+            throw CategoryEditError.nameTooLong(maxLength: Self.maxNameLength)
+        }
+
+        let descriptor = FetchDescriptor<Category>()
+        let existing = try modelContext.fetch(descriptor)
+        let nextOrderIndex = (existing.map(\.orderIndex).max() ?? -1) + 1
+
+        let category = Category(
+            categoryType: .custom,
+            name: trimmed,
+            iconName: TaskCategory.custom.iconName,
+            orderIndex: nextOrderIndex,
+            isUncategorized: false,
+            isNameCustomized: true,
+            isIconCustomized: true
+        )
+        modelContext.insert(category)
+        try save()
+        return category
+    }
+
     /// Gibt eine Kategorie nach Typ zurück
     func getCategory(type: TaskCategory) -> Category? {
         // SwiftData Predicates unterstützen keine Enum-Vergleiche,

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -366,6 +366,23 @@ final class BacklogViewModel {
             return false
         }
     }
+
+    /// Legt eine neue benutzerdefinierte Kategorie an.
+    @discardableResult
+    func createCategory(name: String) -> Category? {
+        do {
+            let category = try categoryService.createCustom(name: name)
+            loadCategories()
+            HapticFeedback.success()
+            return category
+        } catch let error as CategoryEditError {
+            errorMessage = error.errorDescription
+            return nil
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
     
     /// Verschiebt Tasks innerhalb einer Kategorie (Drag & Drop)
     func moveTasksWithinCategory(category: Category, from source: IndexSet, to destination: Int) {

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -222,6 +222,14 @@ struct BacklogView: View {
                         )
                     }
             }
+
+            Section {
+                AddCategoryRow { name in
+                    if let created = viewModel.createCategory(name: name) {
+                        expandedCategories.insert(created.id)
+                    }
+                }
+            }
         }
         .listStyle(.insetGrouped)
     }

--- a/App/Sources/Views/Components/AddCategoryRow.swift
+++ b/App/Sources/Views/Components/AddCategoryRow.swift
@@ -1,0 +1,134 @@
+//
+//  AddCategoryRow.swift
+//  Dawny
+//
+//  „Geister-Zeile“ zum Anlegen einer neuen Kategorie (Placeholder → aktives Textfeld).
+//
+
+import SwiftUI
+
+struct AddCategoryRow: View {
+    let onCreate: (String) -> Void
+
+    @State private var isEditing = false
+    @State private var draft = ""
+    @FocusState private var isFocused: Bool
+
+    private let maxLength = CategoryService.maxNameLength
+
+    private var trimmed: String {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isValid: Bool {
+        !trimmed.isEmpty && trimmed.count <= maxLength
+    }
+
+    private var placeholder: String {
+        String(localized: "category.add.placeholder", defaultValue: "Neue Kategorie")
+    }
+
+    var body: some View {
+        Group {
+            if isEditing {
+                activeRow
+            } else {
+                ghostRow
+            }
+        }
+    }
+
+    private var ghostRow: some View {
+        HStack {
+            Image(systemName: "plus")
+                .foregroundStyle(.secondary)
+                .opacity(0.6)
+                .frame(width: 20)
+
+            Text(placeholder)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+                .opacity(0.6)
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            isEditing = true
+            draft = ""
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            String(localized: "category.add.accessibility", defaultValue: "Neue Kategorie hinzufügen")
+        )
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var activeRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "tag")
+                .font(.subheadline)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 32, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.15))
+                )
+
+            TextField(placeholder, text: $draft)
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .textInputAutocapitalization(.sentences)
+                .autocorrectionDisabled(false)
+                .submitLabel(.done)
+                .focused($isFocused)
+                .onSubmit { submit() }
+
+            Button {
+                submit()
+            } label: {
+                Text(String(localized: "common.done", defaultValue: "Fertig"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(isValid ? Color.accentColor : Color.secondary)
+            }
+            .buttonStyle(.borderless)
+            .disabled(!isValid)
+            .accessibilityLabel(String(localized: "common.done", defaultValue: "Fertig"))
+        }
+        .onAppear {
+            HapticFeedback.light()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                isFocused = true
+            }
+        }
+        .onChange(of: isFocused) { wasFocused, isNowFocused in
+            guard wasFocused, !isNowFocused else { return }
+            if isValid {
+                submit()
+            } else {
+                cancel()
+            }
+        }
+    }
+
+    private func submit() {
+        guard isValid else {
+            HapticFeedback.error()
+            return
+        }
+        onCreate(trimmed)
+        resetAfterCreate()
+    }
+
+    private func cancel() {
+        draft = ""
+        isEditing = false
+    }
+
+    /// Zuerst `draft` leeren, dann Fokus entfernen – sonst feuert `onChange` noch mit altem Text und legt doppelt an.
+    private func resetAfterCreate() {
+        draft = ""
+        isFocused = false
+        isEditing = false
+    }
+}

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -147,7 +147,7 @@ struct SettingsView: View {
             
             if settings.showCategories {
                 Picker(String(localized: "settings.category.default", defaultValue: "Standard-Kategorie für neue Tasks"), selection: $settings.defaultCategoryType) {
-                    ForEach(TaskCategory.allCases.filter { $0 != .uncategorized }, id: \.self) { category in
+                    ForEach(TaskCategory.allCases.filter { $0 != .uncategorized && $0 != .custom }, id: \.self) { category in
                         HStack {
                             Image(systemName: category.iconName)
                             Text(category.displayName)


### PR DESCRIPTION
Kurz
Am Ende der Backlog-Kategorienliste gibt es eine dezente „Neue Kategorie“-Zeile (graues Plus, reduzierte Deckkraft). Beim Tippen wechselt sie in den Bearbeitungsmodus mit Tag-Standard-Icon, Fokus auf dem Textfeld und Tastatur. Mit Fertig oder Fokusverlust bei gültigem Namen wird eine neue Kategorie angelegt; leerer Name beim Verlassen des Feldes bricht still ab.

Technisch
TaskCategory.custom für nutzererstellte Kategorien; Anzeige über gespeicherten Namen/Icon (tag als Default).
CategoryService.createCustom: Validierung wie beim Umbenennen, orderIndex = höchster Index + 1 (Einfügen nach den festen Kategorien inkl. Unkategorisiert).
BacklogViewModel.createCategory, UI in AddCategoryRow (@FocusState), Einbindung als letzte Section in BacklogView; neue Kategorie wird aufgeklappt.
Einstellungen: .custom aus dem Picker für die Standard-Kategorie ausgeschlossen.
Lokalisierung: category.custom.name, category.add.placeholder, category.add.accessibility.