### PR TITLE
alles sehr viel kompatker dargestellt

### DIFF
--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -14,11 +14,8 @@ struct BacklogView: View {
     @Bindable var settings: AppSettings = .shared
     @Environment(\.modelContext) private var modelContext
     @Environment(\.syncEngine) private var syncEngine
-    @Environment(\.triggerWelcomeFlow) private var triggerWelcomeFlow
-    
-    @State private var showingSettings = false
+
     @State private var expandedCategories: Set<UUID> = []
-    @State private var showingClearAllConfirm = false
 
     // MARK: - Category Editing State
 
@@ -31,14 +28,6 @@ struct BacklogView: View {
     /// Kategorie, die gerade gelöscht werden soll (Confirmation Dialog).
     @State private var pendingDeleteCategory: Category?
 
-    private var clearAllAction: (() -> Void)? {
-        #if DEBUG
-        return { showingClearAllConfirm = true }
-        #else
-        return nil
-        #endif
-    }
-    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -52,29 +41,7 @@ struct BacklogView: View {
                     }
                 }
             }
-            .navigationTitle(viewModel.currentBacklog?.title ?? String(localized: "backlog.title", defaultValue: "Backlog"))
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        showingSettings = true
-                    } label: {
-                        Image(systemName: "gearshape.fill")
-                    }
-                    .accessibilityLabel(String(localized: "settings.title", defaultValue: "Einstellungen"))
-                }
-            }
-            .sheet(isPresented: $showingSettings) {
-                SettingsView(
-                    onRequestAddTestItems: {
-                        triggerTestWorkflow()
-                    },
-                    onRequestDeleteAll: clearAllAction,
-                    onRequestShowWelcome: {
-                        showingSettings = false
-                        triggerWelcomeFlow()
-                    }
-                )
-            }
+            .toolbar(.hidden, for: .navigationBar)
             .sheet(item: $iconPickerCategory) { category in
                 CategorySymbolPicker(currentSymbol: category.displayIconName) { newSymbol in
                     if viewModel.updateCategoryIcon(category, to: newSymbol) {
@@ -98,21 +65,6 @@ struct BacklogView: View {
                     }
                 )
             )
-            #if DEBUG
-            .alert(
-                String(localized: "quickadd.deleteall", defaultValue: "Alle Tasks löschen"),
-                isPresented: $showingClearAllConfirm
-            ) {
-                Button(String(localized: "quickadd.cancel", defaultValue: "Abbrechen"), role: .cancel) {}
-                Button(String(localized: "common.delete", defaultValue: "Löschen"), role: .destructive) {
-                    _Concurrency.Task {
-                        await clearAllBacklogTasks()
-                    }
-                }
-            } message: {
-                Text(String(localized: "backlog.debug.clear.message", defaultValue: "Alle Tasks (Backlog und Heute) werden gelöscht."))
-            }
-            #endif
             .onAppear {
                 viewModel.loadBacklogs()
                 viewModel.loadCategories()
@@ -130,8 +82,11 @@ struct BacklogView: View {
                     initializeExpandedCategories()
                 }
             }
-            .onChange(of: viewModel.taskCount) { _, newCount in
-                if newCount == 0 && settings.showCategories {
+            .onChange(of: viewModel.taskCount) { oldCount, newCount in
+                guard settings.showCategories else { return }
+                // Re-init bei "leer" und ebenso wenn Tasks neu reinkommen
+                // (z.B. nach Debug-Reset oder Hinzufügen von Test-Items aus den Settings).
+                if newCount == 0 || (oldCount == 0 && newCount > 0) {
                     initializeExpandedCategories()
                 }
             }
@@ -194,7 +149,9 @@ struct BacklogView: View {
                 }
             }
         }
-        .listStyle(.insetGrouped)
+        .listStyle(.plain)
+        .listSectionSpacing(.compact)
+        .environment(\.defaultMinListRowHeight, 36)
     }
 
     @ViewBuilder
@@ -222,6 +179,7 @@ struct BacklogView: View {
                 }
             }
         )
+        .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
     }
 
     @ViewBuilder
@@ -247,10 +205,14 @@ struct BacklogView: View {
         // Drop-Target nur deaktivieren, wenn diese Zeile gerade editiert wird –
         // damit das TextField den Tap exklusiv bekommt und keine Tasks
         // versehentlich auf den Header gezogen werden.
+        let configured = header
+            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+            .listRowSeparator(.hidden)
+
         if isEditingName {
-            header
+            configured
         } else {
-            header.dropDestination(for: BacklogTaskTransfer.self) { items, _ in
+            configured.dropDestination(for: BacklogTaskTransfer.self) { items, _ in
                 return handleCategoryHeaderDrop(items, targetCategory: category)
             }
         }
@@ -281,8 +243,11 @@ struct BacklogView: View {
                     }
                 }
             )
+            .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
         }
-        .listStyle(.insetGrouped)
+        .listStyle(.plain)
+        .listSectionSpacing(.compact)
+        .environment(\.defaultMinListRowHeight, 36)
     }
     
     @ViewBuilder
@@ -349,38 +314,6 @@ struct BacklogView: View {
         return true
     }
 
-    private func triggerTestWorkflow() {
-        #if DEBUG
-        viewModel.addDebugTestItems(settings: settings)
-        viewModel.loadBacklogs()
-        viewModel.loadCategories()
-        initializeExpandedCategories()
-        #endif
-    }
-
-    private func clearAllBacklogTasks() async {
-        #if DEBUG
-        let backlogTasks = viewModel.backlogTasks
-        let todayTasks = dailyFocusViewModel?.dailyTasks ?? []
-
-        dailyFocusViewModel?.clearTasksFromDisplayOnly()
-
-        for task in backlogTasks {
-            await viewModel.deleteTask(task)
-        }
-
-        if let dfvm = dailyFocusViewModel {
-            for task in todayTasks {
-                await dfvm.deleteTask(task)
-            }
-        }
-
-        viewModel.loadBacklogs()
-        viewModel.loadCategories()
-        initializeExpandedCategories()
-        #endif
-    }
-    
     // MARK: - Helper Methods
     
     /// Initialisiert aufgeklappte Kategorien: Ohne Backlog-Tasks sind alle Standardkategorien

--- a/App/Sources/Views/Components/AddCategoryRow.swift
+++ b/App/Sources/Views/Components/AddCategoryRow.swift
@@ -69,7 +69,7 @@ struct AddCategoryRow: View {
             Image(systemName: "tag")
                 .font(.subheadline)
                 .foregroundStyle(Color.accentColor)
-                .frame(width: 32, height: 32)
+                .frame(width: 28, height: 28)
                 .background(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .fill(Color.accentColor.opacity(0.15))

--- a/App/Sources/Views/Components/CategoryHeaderView.swift
+++ b/App/Sources/Views/Components/CategoryHeaderView.swift
@@ -29,7 +29,7 @@ struct CategoryHeaderView: View {
 
     var body: some View {
         // Kein `Button`: sonst blockiert die Interaktion oft SwiftUI-`dropDestination` auf dem Header (Cross-Category-Drag).
-        HStack {
+        HStack(spacing: 8) {
             iconView
 
             if isEditingName {
@@ -50,10 +50,10 @@ struct CategoryHeaderView: View {
 
             if taskCount > 0 {
                 Text("\(taskCount)")
-                    .font(.caption)
+                    .font(.caption2)
                     .foregroundColor(.secondary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
                     .background(Color.secondary.opacity(0.2))
                     .clipShape(Capsule())
                     .opacity(isEditingName ? 0.5 : 1.0)
@@ -109,7 +109,7 @@ struct CategoryHeaderView: View {
         } else {
             Image(systemName: category.displayIconName)
                 .foregroundColor(.secondary)
-                .frame(width: 20)
+                .frame(width: 18)
                 .opacity(isEditingName ? 0.5 : 1.0)
         }
     }

--- a/App/Sources/Views/Components/QuickEntryRow.swift
+++ b/App/Sources/Views/Components/QuickEntryRow.swift
@@ -34,10 +34,10 @@ struct QuickEntryRow: View {
     }
 
     private var rowContent: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 10) {
             TextField(placeholder, text: $draft, axis: .vertical)
-                .lineLimit(1...4)
-                .font(.body)
+                .lineLimit(1...3)
+                .font(.callout)
                 .foregroundStyle(textFieldForeground)
                 .textInputAutocapitalization(.sentences)
                 .autocorrectionDisabled(false)
@@ -50,10 +50,10 @@ struct QuickEntryRow: View {
                     commitFromUser()
                 } label: {
                     Image(systemName: "arrow.turn.down.left")
-                        .font(.body.weight(.semibold))
+                        .font(.subheadline.weight(.semibold))
                         .symbolRenderingMode(.monochrome)
                         .foregroundStyle(canCommit ? Color.accentColor : Color.secondary)
-                        .frame(minWidth: 36, minHeight: 36)
+                        .frame(minWidth: 28, minHeight: 28)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.borderless)
@@ -63,7 +63,7 @@ struct QuickEntryRow: View {
                 )
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 2)
         .contentShape(Rectangle())
         .onTapGesture {
             fieldFocused = true

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -19,6 +19,19 @@ struct ContentView: View {
     @State private var hasSetInitialTab = false
     @State private var showWelcome = false
     @State private var isDraggingHorizontally = false
+    @State private var showingSettings = false
+    @Bindable private var settings: AppSettings = .shared
+    #if DEBUG
+    @State private var showingClearAllConfirm = false
+    #endif
+
+    private var clearAllAction: (() -> Void)? {
+        #if DEBUG
+        return { showingClearAllConfirm = true }
+        #else
+        return nil
+        #endif
+    }
     
     enum Tab: Int {
         case backlog = 0
@@ -59,6 +72,33 @@ struct ContentView: View {
                 showWelcome = false
             }
         }
+        .sheet(isPresented: $showingSettings) {
+            SettingsView(
+                onRequestAddTestItems: {
+                    triggerTestWorkflow()
+                },
+                onRequestDeleteAll: clearAllAction,
+                onRequestShowWelcome: {
+                    showingSettings = false
+                    showWelcome = true
+                }
+            )
+        }
+        #if DEBUG
+        .alert(
+            String(localized: "quickadd.deleteall", defaultValue: "Alle Tasks löschen"),
+            isPresented: $showingClearAllConfirm
+        ) {
+            Button(String(localized: "quickadd.cancel", defaultValue: "Abbrechen"), role: .cancel) {}
+            Button(String(localized: "common.delete", defaultValue: "Löschen"), role: .destructive) {
+                _Concurrency.Task {
+                    await clearAllBacklogTasks()
+                }
+            }
+        } message: {
+            Text(String(localized: "backlog.debug.clear.message", defaultValue: "Alle Tasks (Backlog und Heute) werden gelöscht."))
+        }
+        #endif
         .onAppear {
             initializeViewModels()
             
@@ -75,21 +115,35 @@ struct ContentView: View {
     }
 
     private var tabSwitcher: some View {
-        HStack(spacing: 6) {
-            tabSwitchButton(
-                title: String(localized: "tabs.backlog", defaultValue: "Backlog"),
-                tab: .backlog
-            )
-            tabSwitchButton(
-                title: String(localized: "tabs.today", defaultValue: "Heute"),
-                tab: .today
-            )
+        HStack(spacing: 8) {
+            Button {
+                showingSettings = true
+            } label: {
+                Image(systemName: "gearshape.fill")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "settings.title", defaultValue: "Einstellungen"))
+
+            HStack(spacing: 4) {
+                tabSwitchButton(
+                    title: String(localized: "tabs.backlog", defaultValue: "Backlog"),
+                    tab: .backlog
+                )
+                tabSwitchButton(
+                    title: String(localized: "tabs.today", defaultValue: "Heute"),
+                    tab: .today
+                )
+            }
+            .padding(2)
+            .background(Color(UIColor.secondarySystemFill), in: Capsule())
         }
-        .padding(4)
-        .background(Color(UIColor.secondarySystemFill), in: Capsule())
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
-        .padding(.bottom, 4)
+        .padding(.horizontal, 12)
+        .padding(.top, 4)
+        .padding(.bottom, 2)
         .background(.thinMaterial)
     }
 
@@ -100,7 +154,7 @@ struct ContentView: View {
             Text(title)
                 .font(.footnote.weight(.semibold))
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
+                .padding(.vertical, 4)
                 .background(
                     selectedTab == tab
                     ? Color(UIColor.systemBackground)
@@ -140,6 +194,40 @@ struct ContentView: View {
             }
     }
     
+    // MARK: - Debug Actions
+
+    private func triggerTestWorkflow() {
+        #if DEBUG
+        guard let backlogVM = backlogViewModel else { return }
+        backlogVM.addDebugTestItems(settings: settings)
+        backlogVM.loadBacklogs()
+        backlogVM.loadCategories()
+        #endif
+    }
+
+    private func clearAllBacklogTasks() async {
+        #if DEBUG
+        guard let backlogVM = backlogViewModel else { return }
+        let backlogTasks = backlogVM.backlogTasks
+        let todayTasks = dailyFocusViewModel?.dailyTasks ?? []
+
+        dailyFocusViewModel?.clearTasksFromDisplayOnly()
+
+        for task in backlogTasks {
+            await backlogVM.deleteTask(task)
+        }
+
+        if let dfvm = dailyFocusViewModel {
+            for task in todayTasks {
+                await dfvm.deleteTask(task)
+            }
+        }
+
+        backlogVM.loadBacklogs()
+        backlogVM.loadCategories()
+        #endif
+    }
+
     private func initializeViewModels() {
         guard let syncEngine = syncEngine,
               let resetEngine = resetEngine else {

--- a/App/Sources/Views/DailyFocusView.swift
+++ b/App/Sources/Views/DailyFocusView.swift
@@ -23,7 +23,7 @@ struct DailyFocusView: View {
                     syncIndicatorView
                 }
             }
-            .navigationTitle(String(localized: "today.title", defaultValue: "Heute"))
+            .toolbar(.hidden, for: .navigationBar)
             .refreshable {
                 await viewModel.refresh()
             }
@@ -75,6 +75,7 @@ struct DailyFocusView: View {
                         }
                     }
                 )
+                .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
             }
 
             if !viewModel.completedTasks.isEmpty {
@@ -93,7 +94,9 @@ struct DailyFocusView: View {
                 }
             }
         }
-        .listStyle(.insetGrouped)
+        .listStyle(.plain)
+        .listSectionSpacing(.compact)
+        .environment(\.defaultMinListRowHeight, 36)
     }
     
     @ViewBuilder

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -48,6 +48,7 @@ struct TaskRowView: View {
                     Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
                         .font(checkboxFont)
                         .foregroundStyle(task.isCompleted ? .green : .gray)
+                        .frame(minWidth: 32, minHeight: 32)
                 }
                 .buttonStyle(.plain)
             }
@@ -55,8 +56,6 @@ struct TaskRowView: View {
             titleAndMetaColumn
             
             Spacer()
-            
-            detailChevron
         }
         .padding(.vertical, verticalPadding)
         
@@ -65,6 +64,7 @@ struct TaskRowView: View {
             .onTapGesture {
                 showingDetail = true
             }
+            .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
             .modifier(TrailingSwipeDeleteModifier(onDelete: onDelete))
         .sheet(isPresented: $showingDetail) {
             TaskDetailView(task: task)
@@ -111,13 +111,6 @@ struct TaskRowView: View {
         column
     }
     
-    @ViewBuilder
-    private var detailChevron: some View {
-        Image(systemName: "chevron.right")
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
-    }
-    
     private var statusColor: Color {
         switch task.status {
         case .inBacklog:
@@ -139,12 +132,12 @@ struct TaskRowView: View {
     
     /// Horizontal spacing zwischen Elementen
     private var horizontalSpacing: CGFloat {
-        task.isCompleted ? 8 : 12
+        task.isCompleted ? 6 : 10
     }
     
     /// Vertical padding der gesamten Zeile
     private var verticalPadding: CGFloat {
-        task.isCompleted ? 2 : 4
+        task.isCompleted ? 1 : 2
     }
     
     /// Schriftgröße für den Titel
@@ -162,9 +155,9 @@ struct TaskRowView: View {
         task.isCompleted ? 2 : 4
     }
     
-    /// Sollten Notizen angezeigt werden?
+    /// Notizen werden in der Zeile bewusst nicht mehr angezeigt – nur im Detail.
     private var shouldShowNotes: Bool {
-        !task.isCompleted || task.notes?.isEmpty == false
+        false
     }
     
     /// Line limit für Notizen bei erledigten Tasks


### PR DESCRIPTION
## Kompakteres UI-Layout

Backlog- und Heute-Ansicht zeigen jetzt deutlich mehr Tasks pro Bildschirm, ohne gequetscht zu wirken.

### Highlights
- **List-Style auf `.plain`** (vorher `.insetGrouped`) + `.listSectionSpacing(.compact)` und `defaultMinListRowHeight = 36`
- **Task-Zeile schlanker**: Chevron entfernt (Tap auf Zeile öffnet ohnehin Detail), Notizen-Vorschau raus, Padding/Spacing reduziert, kompakte `listRowInsets`
- **QuickEntry kompakter**: kleinerer Send-Button (28×28), `.callout`-Font, weniger vertikales Padding
- **Section-Header schlanker**: kleineres Count-Badge (`.caption2`, weniger Padding), Icon-Frame 18 pt
- **Settings-Zahnrad** wandert aus der NavigationBar in den globalen App-Header — links neben dem Tab-Switcher
- **NavigationBar-Titel entfernt** in beiden Tabs (`.toolbar(.hidden, for: .navigationBar)`) — spart eine ganze Bar-Höhe (~44 pt)
- **AddCategoryRow** angepasst (28×28 Icon-Frame), damit Höhe zu Task-Zeilen passt

### Geänderte Dateien
- `App/Sources/Views/ContentView.swift` — neuer Header (Zahnrad + Tab-Switcher), Settings-Sheet + Debug-Aktionen umgezogen
- `App/Sources/Views/BacklogView.swift` — `.plain` List, NavigationBar versteckt, Settings-Sheet/Debug-Helper entfernt
- `App/Sources/Views/DailyFocusView.swift` — `.plain` List, NavigationBar versteckt
- `App/Sources/Views/TaskRowView.swift` — Chevron + Notizen-Vorschau raus, Padding/Spacing reduziert
- `App/Sources/Views/Components/QuickEntryRow.swift` — kompakterer Send-Button, kleinere Fonts/Paddings
- `App/Sources/Views/Components/CategoryHeaderView.swift` — Badge/Icon/Spacing kompakter
- `App/Sources/Views/Components/AddCategoryRow.swift` — Icon-Frame an Task-Zeilen-Höhe angeglichen

### Trade-offs
- Karten-Look (`.insetGrouped`) ist weg — flacher, "Reminders"-artiger Stil
- Section-Header sind jetzt sticky (Bonus: Kontext bleibt beim Scrollen sichtbar)
- Notizen sind nur noch im Detail-Sheet sichtbar
- Eine zweite Toolbar-Aktion müsste künftig in den neuen App-Header wandern

### Test plan
- [ ] Backlog-Tab: Sections lassen sich auf-/zuklappen, QuickEntry funktioniert
- [ ] Heute-Tab: Tasks erscheinen, Swipe-Aktionen funktionieren
- [ ] Zahnrad öffnet Settings auf beiden Tabs
- [ ] DEBUG-Aktionen ("Test-Items hinzufügen" / "Alle löschen") funktionieren weiterhin
- [ ] Drag&Drop von Tasks zwischen Kategorien noch intakt
- [ ] Inline-Rename + Symbol-Picker für Kategorien funktionieren