### PR TITLE
Lizenzierung und DSGVO hinzugefügt im Code und in readme

### DIFF
--- a/App/PrivacyInfo.xcprivacy
+++ b/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/App/Sources/DawnyApp.swift
+++ b/App/Sources/DawnyApp.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  DawnyApp.swift
 //  Dawny

--- a/App/Sources/Extensions/HapticFeedback.swift
+++ b/App/Sources/Extensions/HapticFeedback.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  HapticFeedback.swift
 //  Dawny

--- a/App/Sources/Intents/AddTaskIntent.swift
+++ b/App/Sources/Intents/AddTaskIntent.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  AddTaskIntent.swift
 //  Dawny

--- a/App/Sources/Intents/AddTaskTodayIntent.swift
+++ b/App/Sources/Intents/AddTaskTodayIntent.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  AddTaskTodayIntent.swift
 //  Dawny

--- a/App/Sources/Intents/DawnyShortcuts.swift
+++ b/App/Sources/Intents/DawnyShortcuts.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  DawnyShortcuts.swift
 //  Dawny

--- a/App/Sources/Models/AppSettings.swift
+++ b/App/Sources/Models/AppSettings.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  AppSettings.swift
 //  Dawny

--- a/App/Sources/Models/Backlog.swift
+++ b/App/Sources/Models/Backlog.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  Backlog.swift
 //  Dawny

--- a/App/Sources/Models/BacklogTaskTransfer.swift
+++ b/App/Sources/Models/BacklogTaskTransfer.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  BacklogTaskTransfer.swift
 //  Dawny

--- a/App/Sources/Models/Category.swift
+++ b/App/Sources/Models/Category.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  Category.swift
 //  Dawny

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  Task.swift
 //  Dawny

--- a/App/Sources/Models/TaskCategory.swift
+++ b/App/Sources/Models/TaskCategory.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TaskCategory.swift
 //  Dawny

--- a/App/Sources/Models/TaskStatus.swift
+++ b/App/Sources/Models/TaskStatus.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TaskStatus.swift
 //  Dawny

--- a/App/Sources/PreviewSupport.swift
+++ b/App/Sources/PreviewSupport.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  PreviewSupport.swift
 //  Dawny

--- a/App/Sources/Protocols/CalendarServiceProtocol.swift
+++ b/App/Sources/Protocols/CalendarServiceProtocol.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  CalendarServiceProtocol.swift
 //  Dawny

--- a/App/Sources/Protocols/TimeProvider.swift
+++ b/App/Sources/Protocols/TimeProvider.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TimeProvider.swift
 //  Dawny

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  CategoryService.swift
 //  Dawny

--- a/App/Sources/Services/EventKitCalendarService.swift
+++ b/App/Sources/Services/EventKitCalendarService.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  EventKitCalendarService.swift
 //  Dawny

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  ResetEngine.swift
 //  Dawny

--- a/App/Sources/Services/SyncEngine.swift
+++ b/App/Sources/Services/SyncEngine.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  SyncEngine.swift
 //  Dawny

--- a/App/Sources/Utilities/SelectTodayTabEnvironment.swift
+++ b/App/Sources/Utilities/SelectTodayTabEnvironment.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  SelectTodayTabEnvironment.swift
 //  Dawny

--- a/App/Sources/Utilities/TriggerWelcomeFlowEnvironment.swift
+++ b/App/Sources/Utilities/TriggerWelcomeFlowEnvironment.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TriggerWelcomeFlowEnvironment.swift
 //  Dawny

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  BacklogViewModel.swift
 //  Dawny

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  DailyFocusViewModel.swift
 //  Dawny

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  BacklogView.swift
 //  Dawny

--- a/App/Sources/Views/Components/AddCategoryRow.swift
+++ b/App/Sources/Views/Components/AddCategoryRow.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  AddCategoryRow.swift
 //  Dawny

--- a/App/Sources/Views/Components/CategoryHeaderView.swift
+++ b/App/Sources/Views/Components/CategoryHeaderView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  CategoryHeaderView.swift
 //  Dawny

--- a/App/Sources/Views/Components/CategorySelectionMenu.swift
+++ b/App/Sources/Views/Components/CategorySelectionMenu.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  CategorySelectionMenu.swift
 //  Dawny

--- a/App/Sources/Views/Components/CategorySymbolPicker.swift
+++ b/App/Sources/Views/Components/CategorySymbolPicker.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  CategorySymbolPicker.swift
 //  Dawny

--- a/App/Sources/Views/Components/EmptyStateView.swift
+++ b/App/Sources/Views/Components/EmptyStateView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  EmptyStateView.swift
 //  Dawny

--- a/App/Sources/Views/Components/ErrorBannerView.swift
+++ b/App/Sources/Views/Components/ErrorBannerView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  ErrorBannerView.swift
 //  Dawny

--- a/App/Sources/Views/Components/QuickEntryRow.swift
+++ b/App/Sources/Views/Components/QuickEntryRow.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  QuickEntryRow.swift
 //  Dawny

--- a/App/Sources/Views/Components/SyncStatusIndicator.swift
+++ b/App/Sources/Views/Components/SyncStatusIndicator.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  SyncStatusIndicator.swift
 //  Dawny

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  ContentView.swift
 //  Dawny

--- a/App/Sources/Views/DailyFocusView.swift
+++ b/App/Sources/Views/DailyFocusView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  DailyFocusView.swift
 //  Dawny

--- a/App/Sources/Views/QuickAddView.swift
+++ b/App/Sources/Views/QuickAddView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  QuickAddView.swift
 //  Dawny

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  SettingsView.swift
 //  Dawny

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TaskRowView.swift
 //  Dawny

--- a/App/Sources/Views/WelcomeView.swift
+++ b/App/Sources/Views/WelcomeView.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  WelcomeView.swift
 //  Dawny

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Dawny
+
+Thanks for your interest in Dawny. This is a small, opinionated, single-developer
+project, but contributions are welcome — within the constraints below.
+
+## License of Contributions (important)
+
+Dawny is **source-available**, not open source. The project is licensed under the
+[PolyForm Noncommercial License 1.0.0](LICENSE). This affects how contributions
+are handled.
+
+By submitting a pull request, an issue with code suggestions, or any other
+contribution to this repository, you agree that:
+
+1. **Inbound = Outbound.** Your contribution is licensed to the project under the
+   exact same terms as the rest of the project — currently the PolyForm
+   Noncommercial License 1.0.0. You cannot submit code that is incompatible with
+   that license (for example, GPL-licensed code).
+
+2. **Relicensing grant.** You also grant Florian Schneider (the project owner) a
+   perpetual, worldwide, irrevocable, royalty-free license to use, reproduce,
+   modify, publish, distribute, sublicense, and **relicense** your contribution
+   under any other license — including a commercial license.
+
+   This is necessary so the project owner can offer Dawny under a commercial
+   license to paying customers, or change the project license in the future,
+   without having to track down every contributor.
+
+3. **You have the right to contribute.** You confirm that the contribution is
+   your own original work, or that you have the rights to submit it under these
+   terms. If your employer has rights to your work, you confirm you have
+   permission to contribute.
+
+If you do not agree with these terms, please do not submit code. Bug reports and
+feature discussions in issues are still welcome and not subject to clause 2.
+
+## What kind of contributions fit Dawny
+
+Dawny is deliberately small. The "Zero Overdue" philosophy and the two-list
+model (Backlog + Daily Focus) are non-negotiable. Before opening a large PR,
+please open an issue to discuss whether the change fits the product direction.
+
+Good fits:
+
+- Bug fixes and crash fixes.
+- Localization improvements (the app ships in 9 languages).
+- Accessibility (Dynamic Type, VoiceOver, Reduce Motion).
+- Test coverage, especially around the 3 AM reset and EventKit sync edges.
+- Performance improvements.
+
+Probably not a fit:
+
+- Recurring tasks, subtasks, tags, due dates, multiple projects.
+- Cross-platform code (Android, web, watchOS unless specifically scoped).
+- Third-party dependencies. Dawny intentionally has none.
+
+## How to contribute
+
+1. Fork the repo and create a feature branch.
+2. Make your change. Follow the existing code style. Run the tests.
+3. Open a PR against `main` with a clear description of what changed and why.
+4. Be patient — this is a side project.
+
+## Development setup
+
+Requirements:
+
+- Xcode 26.2 or later.
+- macOS able to run Xcode 26.2.
+- An iPhone or simulator running iOS 26.2 or later.
+- An Apple Developer account is needed only for device deploys, not for
+  building or running tests on the simulator.
+
+No package manager setup is needed. Dawny has zero third-party dependencies.
+
+## Reporting security issues
+
+Do not open public issues for security reports. Email **dawny@posteo.de** with
+details. I will respond as fast as a single developer can.

--- a/DawnyTests/Integration/PersistenceTests.swift
+++ b/DawnyTests/Integration/PersistenceTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  PersistenceTests.swift
 //  DawnyTests

--- a/DawnyTests/Integration/TaskLifecycleTests.swift
+++ b/DawnyTests/Integration/TaskLifecycleTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TaskLifecycleTests.swift
 //  DawnyTests

--- a/DawnyTests/Mocks/MockCalendarService.swift
+++ b/DawnyTests/Mocks/MockCalendarService.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  MockCalendarService.swift
 //  DawnyTests

--- a/DawnyTests/Mocks/MockTimeProvider.swift
+++ b/DawnyTests/Mocks/MockTimeProvider.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  MockTimeProvider.swift
 //  DawnyTests

--- a/DawnyTests/Mocks/TestModelContainer.swift
+++ b/DawnyTests/Mocks/TestModelContainer.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TestModelContainer.swift
 //  DawnyTests

--- a/DawnyTests/Models/AppSettingsTests.swift
+++ b/DawnyTests/Models/AppSettingsTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  AppSettingsTests.swift
 //  DawnyTests

--- a/DawnyTests/Models/BacklogModelTests.swift
+++ b/DawnyTests/Models/BacklogModelTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  BacklogModelTests.swift
 //  DawnyTests

--- a/DawnyTests/Models/TaskModelTests.swift
+++ b/DawnyTests/Models/TaskModelTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TaskModelTests.swift
 //  DawnyTests

--- a/DawnyTests/Services/CategoryServiceTests.swift
+++ b/DawnyTests/Services/CategoryServiceTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  CategoryServiceTests.swift
 //  DawnyTests

--- a/DawnyTests/Services/ResetEngineTests.swift
+++ b/DawnyTests/Services/ResetEngineTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  ResetEngineTests.swift
 //  DawnyTests

--- a/DawnyTests/Services/SyncEngineTests.swift
+++ b/DawnyTests/Services/SyncEngineTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  SyncEngineTests.swift
 //  DawnyTests

--- a/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
+++ b/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  BacklogViewModelPlacementTests.swift
 //  DawnyTests

--- a/DawnyTests/Views/TabSelectionLogicTests.swift
+++ b/DawnyTests/Views/TabSelectionLogicTests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  TabSelectionLogicTests.swift
 //  DawnyTests

--- a/DawnyUITests/DawnyUITests.swift
+++ b/DawnyUITests/DawnyUITests.swift
@@ -1,3 +1,7 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
 //
 //  DawnyUITests.swift
 //  DawnyUITests

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,133 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+Required Notice: Copyright (c) 2025-2026 Florian Schneider (dawny@posteo.de)
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose. However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software. Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice. Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization. **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,58 @@
+Dawny
+=====
+
+Required Notice: Copyright (c) 2025-2026 Florian Schneider (dawny@posteo.de)
+
+Source code in this repository is licensed under the PolyForm Noncommercial
+License 1.0.0. See the LICENSE file in the root of this repository, or visit
+https://polyformproject.org/licenses/noncommercial/1.0.0 for the full text.
+
+This is a SOURCE-AVAILABLE project, not Open Source in the OSI sense.
+Personal study, hobby use, research, and contributions are welcome.
+Any commercial use - including, but not limited to, distributing the
+software (in original or modified form) as a paid app, a free app that
+generates revenue through ads or in-app purchases, or as part of any
+service or product that generates revenue - is NOT permitted under this
+license. For commercial licensing, contact dawny@posteo.de.
+
+------------------------------------------------------------------------
+
+Trademarks
+----------
+
+"Dawny", the Dawny name, and the Dawny logo and app icon are trademarks
+of Florian Schneider. The PolyForm Noncommercial License 1.0.0 grants
+copyright and patent licenses, but it does NOT grant any trademark license.
+
+If you fork this project, modify it, or build derivative works, you MUST:
+
+  - Rename the project so it cannot be confused with "Dawny".
+  - Use your own app icon and brand assets. Do not reuse the Dawny icon
+    or visual identity.
+  - Remove or replace references to "Dawny" in user-facing strings,
+    bundle identifiers, and marketing materials.
+
+------------------------------------------------------------------------
+
+Assets and Content
+------------------
+
+The following are NOT licensed under PolyForm Noncommercial 1.0.0 and
+remain under "All Rights Reserved":
+
+  - All image assets in App/Assets.xcassets/ (app icon, accent colors,
+    image assets), including the file
+    "Dawny Icon Gemini 1024x1024 300dpi.png".
+  - The marketing copy and prose in README.md.
+  - Any screenshots, App Store metadata, and TestFlight materials.
+
+You may not redistribute these assets, even for noncommercial purposes,
+without separate written permission.
+
+------------------------------------------------------------------------
+
+Contact
+-------
+
+Commercial licensing, trademark questions, security reports, or anything
+else legal: dawny@posteo.de

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <img alt="Persistence" src="https://img.shields.io/badge/Data-SwiftData-34C759">
   <a href="https://testflight.apple.com/join/h9JSWasd"><img alt="TestFlight" src="https://img.shields.io/badge/TestFlight-Join%20Beta-000000?logo=apple"></a>
   <img alt="Status" src="https://img.shields.io/badge/status-beta-yellow">
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-lightgrey"></a>
 </p>
 
 <p align="center">
@@ -141,6 +142,28 @@ Intentionally small for now. Possible future additions are welcome only if they 
 Explicitly **not** on the roadmap: recurring tasks, subtasks, tags, arbitrary due dates, and cross platform clients. The goal is a clear mind and a clean daily planning surface, not a bigger feature set.
 
 ---
+
+## License
+
+Dawny is **source-available, not open source**.
+
+The source code in this repository is licensed under the
+[PolyForm Noncommercial License 1.0.0](LICENSE). In short: you may read,
+study, modify, and use the code for personal, educational, research, hobby,
+and other noncommercial purposes. You may **not** use the code (in original
+or modified form) as part of any product or service that generates revenue,
+including paid apps, ad-supported apps, or apps with in-app purchases.
+
+The name "Dawny", the Dawny logo, and the app icon are **trademarks** of
+Florian Schneider and are not licensed under PolyForm. Forks must be renamed
+and rebranded. See [NOTICE](NOTICE) for details on trademarks, asset
+licensing, and contact info.
+
+For commercial licensing inquiries, write to **dawny@posteo.de**.
+
+Contributions are welcome under the terms described in
+[CONTRIBUTING.md](CONTRIBUTING.md), which include an inbound-equals-outbound
+clause and a relicensing grant to the project owner.
 
 ---
 

--- a/docs/APP_STORE_CONNECT_CHECKLIST.md
+++ b/docs/APP_STORE_CONNECT_CHECKLIST.md
@@ -1,0 +1,115 @@
+# App Store Connect — Lizenz- und Datenschutz-Checkliste
+
+Diese Schritte musst du **manuell in App Store Connect** erledigen. Sie sind
+Teil der rechtlichen Lizenzierung der App, lassen sich aber nicht aus dem
+Repository heraus automatisieren.
+
+## 1. EULA — Apples Standard verwenden
+
+1. Gehe zu **App Store Connect → My Apps → Dawny → App Information**.
+2. Scrolle zu **License Agreement**.
+3. Stelle sicher, dass **"Use Apple's Standard License Agreement for Apps"**
+   aktiviert ist (kein Custom-EULA hochgeladen).
+4. Damit gilt automatisch das
+   [Apple Standard License Agreement (EA1602)](https://www.apple.com/legal/internet-services/itunes/dev/stdeula/)
+   für jeden, der Dawny aus dem App Store oder über TestFlight installiert.
+
+**Wenn du später eine eigene EULA willst** (z. B. für Pro-Features mit
+In-App-Käufen), kannst du den Custom-EULA-Slot dort befüllen. Aktuell nicht nötig.
+
+## 2. Privacy Policy URL hinterlegen
+
+Pflichtfeld in App Store Connect für **jede** App, auch wenn keine Daten
+erhoben werden. Ohne URL geht keine Review durch.
+
+1. Hoste eine der folgenden Dateien (oder beide) öffentlich erreichbar:
+   - `docs/PRIVACY.de.md`
+   - `docs/PRIVACY.en.md`
+2. **Vor dem Hosting** die mit `[BITTE ERGÄNZEN: …]` / `[PLEASE FILL IN: …]`
+   markierten Stellen ausfüllen — insbesondere **deine ladungsfähige
+   Postanschrift** (DSGVO Art. 13 Pflicht).
+3. Empfohlene Hosting-Optionen:
+   - **GitHub Pages** des Repos (kostenlos, ein Klick): aktiviere unter
+     *Settings → Pages → Source: main branch / docs folder*. Die URL wäre dann
+     `https://flrnsndr.github.io/Dawny/PRIVACY.de` bzw. `.../PRIVACY.en`.
+   - Eigene Domain.
+4. In App Store Connect: **App Information → Privacy Policy URL** eintragen.
+   - Wenn du nur eine Sprache hosten willst: Englisch wählen, das ist die
+     "Primary Language" deiner App.
+   - Wenn du beide hostest, kannst du in App Store Connect pro Lokalisierung
+     unterschiedliche URLs angeben (App Privacy → Privacy Policy URL je Locale).
+
+## 3. App Privacy Details ausfüllen
+
+Pflicht seit Dezember 2020. Diese Angaben erscheinen als **Privacy Nutrition
+Labels** auf der App-Store-Produktseite.
+
+1. Gehe zu **App Store Connect → My Apps → Dawny → App Privacy**.
+2. **Data Collection**: Wähle **"No, we do not collect data from this app"**.
+   - Dawny erhebt keine personenbezogenen Daten beim Entwickler. Alles bleibt
+     auf dem Gerät bzw. in iCloud des Nutzers.
+   - Apple zählt Daten, die **nur lokal** auf dem Gerät bleiben oder im
+     **eigenen iCloud-Account** des Nutzers landen (Reminders, EventKit), nicht
+     als "Data Collection" durch dich als Entwickler. Daher ist "No" korrekt.
+3. Speichern und veröffentlichen.
+
+## 4. Privacy Manifest — passt es noch?
+
+Die Datei `App/PrivacyInfo.xcprivacy` ist Teil dieses Repos und wird
+automatisch in den App-Bundle eingebunden (das `App/`-Verzeichnis ist eine
+File-System-Synchronized Group in Xcode 16+). Aktuell deklariert sie:
+
+- **Tracking**: nein.
+- **Tracking-Domains**: keine.
+- **Erhobene Datenarten**: keine.
+- **Required-Reason-APIs**: nur `NSPrivacyAccessedAPICategoryUserDefaults` mit
+  Reason `CA92.1` (App-eigene Settings).
+
+**Wenn du später** Folgendes hinzufügst, musst du das Manifest erweitern:
+
+| Neue Funktion / API | Manifest-Update |
+|---|---|
+| `FileManager` mit `modificationDate` / `creationDate` | `NSPrivacyAccessedAPICategoryFileTimestamp` mit `C617.1` |
+| `ProcessInfo().systemUptime` | `NSPrivacyAccessedAPICategorySystemBootTime` mit `35F9.1` |
+| `URL.resourceValues` mit `volumeAvailableCapacityKey` o. ä. | `NSPrivacyAccessedAPICategoryDiskSpace` mit `E174.1` |
+| `UITextInputMode.activeInputModes` | `NSPrivacyAccessedAPICategoryActiveKeyboards` mit `54BD.1` |
+| Drittanbieter-SDKs | Jedes SDK muss eigenes Privacy Manifest mitliefern. Bei Hinzufügen prüfen. |
+| Tracking, Analytics, Werbung | `NSPrivacyTracking` auf `true` und Datenkategorien deklarieren. **Nicht** ohne ATT-Dialog! |
+
+Apple-Referenz:
+[Describing data use in privacy manifests](https://developer.apple.com/documentation/bundleresources/describing-data-use-in-privacy-manifests).
+
+## 5. Export-Compliance (jeder TestFlight-Build)
+
+Bei jedem neuen Build fragt App Store Connect nach **Export Compliance**.
+Dawny verwendet **keine eigene Verschlüsselung** außer dem, was iOS / Apples
+Standard-APIs (HTTPS, SwiftData, Keychain) bereitstellen.
+
+- Wähle **"None of the algorithms mentioned above"** bzw.
+  **"Yes, but limited to Apple's standard exemptions"**.
+- Optional: trage in der `Info.plist` einmalig `ITSAppUsesNonExemptEncryption`
+  = `false` ein, dann erscheint die Frage nicht mehr bei jedem Build.
+
+## 6. Markenrechtlicher Hinweis (optional, langfristig)
+
+Der Name "Dawny" und das Logo sind in diesem Repo als **Common-Law-Marke** über
+die `NOTICE`-Datei dokumentiert. Für stärkeren Schutz:
+
+- **DPMA (DE)**: Anmeldung einer Wortmarke ab ca. 290 € Gebühr (online).
+- **EUIPO (EU)**: ab ca. 850 € (eine Klasse), deckt 27 Länder.
+
+Vorher prüfen, ob "Dawny" markenrechtlich frei ist
+([TMview](https://www.tmdn.org/tmview/)). Reine Empfehlung, keine Pflicht
+für die App-Store-Veröffentlichung.
+
+---
+
+## Quick-Reference
+
+| Was | Wo | Status |
+|---|---|---|
+| EULA = Apple Standard EA1602 | App Information → License Agreement | manuell |
+| Privacy Policy URL | App Information → Privacy Policy URL | manuell |
+| Privacy Nutrition Labels | App Privacy → Data Collection | manuell |
+| Privacy Manifest im Bundle | `App/PrivacyInfo.xcprivacy` | automatisch via Xcode |
+| Export Compliance | Build-Upload-Dialog oder `Info.plist` | manuell |

--- a/docs/PRIVACY.de.md
+++ b/docs/PRIVACY.de.md
@@ -1,0 +1,131 @@
+# Datenschutzerklärung für Dawny
+
+**Stand:** 19. April 2026  
+**Sprache:** Deutsch ([English version](PRIVACY.en.md))
+
+> ⚠️ **Hinweis an den Entwickler vor Veröffentlichung:**
+> Vor dem Hosting dieser Seite (z. B. via GitHub Pages) müssen die mit
+> `[BITTE ERGÄNZEN: …]` markierten Stellen ausgefüllt werden. Insbesondere
+> die ladungsfähige Postanschrift ist nach DSGVO Art. 13 Pflicht und kann
+> nicht weggelassen werden.
+
+---
+
+## 1. Verantwortlicher
+
+Verantwortlicher im Sinne der DSGVO ist:
+
+**Florian Schneider**  
+[BITTE ERGÄNZEN: Straße und Hausnummer]  
+[BITTE ERGÄNZEN: PLZ und Ort]  
+[BITTE ERGÄNZEN: Land]
+
+E-Mail: dawny@posteo.de
+
+## 2. Überblick
+
+Dawny ist eine native iOS-App zur persönlichen Aufgabenplanung. Dawny ist
+**privacy-first** entworfen:
+
+- Es gibt **keinen Server und kein Backend** seitens des Entwicklers.
+- Es findet **keine Erhebung personenbezogener Daten** durch den Entwickler statt.
+- Es gibt **kein Tracking, keine Analytics, keine Werbung, keine Drittanbieter-SDKs**.
+- Alle Daten verbleiben **auf deinem Gerät** bzw. – falls du iCloud nutzt – in
+  deinem persönlichen iCloud-Konto, das ausschließlich von Apple verwaltet wird.
+
+## 3. Welche Daten werden verarbeitet?
+
+### 3.1 Lokale App-Daten (SwiftData)
+
+Dawny speichert deine Aufgaben, Backlog-Einträge, Kategorien und
+App-Einstellungen lokal auf deinem iPhone mit dem von Apple bereitgestellten
+**SwiftData**-Framework. Diese Daten verlassen dein Gerät nicht – außer du hast
+in den iOS-Einstellungen die App-übergreifende iCloud-Synchronisation aktiviert,
+in welchem Fall Apple die Daten verschlüsselt zwischen deinen eigenen Apple-
+Geräten synchronisiert. Der Entwickler hat in keinem Fall Zugriff darauf.
+
+### 3.2 Apple Reminders / Apple Calendar (EventKit)
+
+Wenn du die Synchronisation mit Apple Reminders aktivierst, schreibt Dawny die
+Aufgaben deiner aktuellen Tagesliste in deine lokale Apple-Reminders-Datenbank
+und liest Änderungen von dort zurück. Die Berechtigung dafür wird beim ersten
+Verwendungswunsch über den iOS-Standarddialog erfragt
+(`NSRemindersUsageDescription`). Du kannst sie jederzeit unter
+*Einstellungen → Datenschutz & Sicherheit → Erinnerungen → Dawny* widerrufen.
+
+Diese Daten werden **ausschließlich lokal bzw. innerhalb deines eigenen
+iCloud-Kontos** verarbeitet. Es findet kein Versand an den Entwickler oder
+Dritte statt.
+
+### 3.3 Siri und App Intents
+
+Dawny stellt Siri-Kurzbefehle bereit (z. B. „Add milk to Dawny today"). Die
+Berechtigung für Siri wird beim ersten Verwendungswunsch über den iOS-
+Standarddialog erfragt (`NSSiriUsageDescription`). Die Sprachverarbeitung
+erfolgt durch Apple gemäß
+[Apples Datenschutzrichtlinie](https://www.apple.com/legal/privacy/de-ww/).
+Der Entwickler erhält weder die Audiodaten noch die transkribierten Befehle.
+
+### 3.4 Hintergrundausführung (BackgroundTasks)
+
+Dawny verwendet das `BackgroundTasks`-Framework von Apple, um den
+3-Uhr-morgens-Reset (Verschieben offener Tagesaufgaben zurück ins Backlog)
+durchzuführen. Dabei werden **keine Daten verschickt**; es handelt sich um
+eine rein lokale Operation auf deinen App-Daten.
+
+### 3.5 App-Einstellungen (UserDefaults)
+
+App-Einstellungen wie deine bevorzugte Reset-Uhrzeit, Sichtbarkeit von
+Kategorien etc. werden in `UserDefaults` deines App-Containers gespeichert –
+ebenfalls rein lokal.
+
+## 4. Daten, die NICHT verarbeitet werden
+
+Dawny erhebt **keine** der folgenden Daten:
+
+- Name, E-Mail, Telefonnummer, Adresse oder andere Kontaktdaten.
+- Standortdaten.
+- Crash-Reports oder Diagnose-Telemetrie an den Entwickler.
+- Werbe-IDs (IDFA), Geräte-IDs oder Fingerprints.
+- Verhaltens- oder Nutzungs-Analytics.
+
+Die App enthält **keine Drittanbieter-SDKs** (kein Firebase, kein Sentry,
+kein Mixpanel, kein Facebook SDK, etc.).
+
+## 5. App-Tracking-Transparenz
+
+Dawny tracked nicht und ruft daher den
+**App-Tracking-Transparenz-Dialog (ATT)** nicht auf.
+
+## 6. Apple als Plattform
+
+Dawny läuft auf iOS und nutzt Apple-Dienste (App Store, TestFlight, iCloud,
+Siri, Reminders, Calendar). Für die Datenverarbeitung durch Apple gilt
+[Apples Datenschutzrichtlinie](https://www.apple.com/legal/privacy/de-ww/),
+auf die der Entwickler keinen Einfluss hat.
+
+## 7. Deine Rechte
+
+Da Dawny keine personenbezogenen Daten beim Entwickler verarbeitet, sind
+viele DSGVO-Rechte (Auskunft, Löschung, Berichtigung etc.) faktisch von
+Apple bzw. von dir selbst auf deinem Gerät auszuüben:
+
+- **Löschung aller Dawny-Daten**: Lösche die App; damit werden alle lokalen
+  App-Daten entfernt. Daten in deinen Apple-Reminders bleiben in Reminders
+  bestehen, da sie zu deiner Reminders-Datenbank gehören.
+- **Auskunft**: Alle Daten sind in der App selbst und (bei aktivierter
+  Synchronisation) in der Reminders-App auf deinem Gerät einsehbar.
+- **Beschwerde**: Du hast das Recht, dich bei einer Datenschutz-Aufsichts-
+  behörde zu beschweren, in Deutschland z. B. bei der für dein Bundesland
+  zuständigen Landesdatenschutzbehörde.
+
+## 8. Kontakt
+
+Bei Fragen zum Datenschutz: **dawny@posteo.de**
+
+## 9. Änderungen dieser Datenschutzerklärung
+
+Diese Datenschutzerklärung kann angepasst werden, wenn sich die App ändert.
+Die jeweils aktuelle Version ist über die App Store Connect URL und das
+Repository einsehbar. Wesentliche Änderungen werden mit dem nächsten
+App-Update mitgeteilt.

--- a/docs/PRIVACY.en.md
+++ b/docs/PRIVACY.en.md
@@ -1,0 +1,124 @@
+# Privacy Policy for Dawny
+
+**Last updated:** April 19, 2026  
+**Language:** English ([Deutsche Version](PRIVACY.de.md))
+
+> ⚠️ **Note to the developer before publishing:**
+> Before hosting this page (e.g. via GitHub Pages), the placeholders marked
+> `[PLEASE FILL IN: …]` must be completed. In particular, the postal address
+> is required under GDPR Art. 13 and cannot be omitted.
+
+---
+
+## 1. Data Controller
+
+The data controller under the GDPR is:
+
+**Florian Schneider**  
+[PLEASE FILL IN: Street and number]  
+[PLEASE FILL IN: Postal code and city]  
+[PLEASE FILL IN: Country]
+
+Email: dawny@posteo.de
+
+## 2. Overview
+
+Dawny is a native iOS app for personal task planning. Dawny is designed to be
+**privacy-first**:
+
+- There is **no server and no backend** operated by the developer.
+- The developer does **not collect any personal data** from you.
+- There is **no tracking, no analytics, no advertising, no third-party SDKs**.
+- All data stays **on your device** or — if you use iCloud — inside your
+  personal iCloud account, managed exclusively by Apple.
+
+## 3. What data is processed?
+
+### 3.1 Local app data (SwiftData)
+
+Dawny stores your tasks, backlog entries, categories, and app settings
+locally on your iPhone using Apple's **SwiftData** framework. This data
+never leaves your device — unless you have iOS-wide iCloud sync enabled,
+in which case Apple syncs the data, encrypted, between your own Apple
+devices. The developer never has access to it.
+
+### 3.2 Apple Reminders / Apple Calendar (EventKit)
+
+If you enable Apple Reminders sync, Dawny writes the tasks of your current
+Daily Focus list into your local Apple Reminders database and reads changes
+back from it. iOS asks for permission via the standard system dialog the
+first time (`NSRemindersUsageDescription`). You can revoke it at any time
+under *Settings → Privacy & Security → Reminders → Dawny*.
+
+This data is processed **only locally and within your own iCloud account**.
+Nothing is sent to the developer or to third parties.
+
+### 3.3 Siri and App Intents
+
+Dawny offers Siri shortcuts (e.g. "Add milk to Dawny today"). iOS asks for
+permission for Siri via the standard system dialog the first time
+(`NSSiriUsageDescription`). Voice processing is done by Apple under
+[Apple's Privacy Policy](https://www.apple.com/legal/privacy/en-ww/).
+The developer receives neither the audio nor the transcribed commands.
+
+### 3.4 Background execution (BackgroundTasks)
+
+Dawny uses Apple's `BackgroundTasks` framework to perform the 3 AM reset
+(moving unfinished Daily Focus tasks back to the backlog). **No data is
+sent anywhere** during this; it is a purely local operation on your app
+data.
+
+### 3.5 App preferences (UserDefaults)
+
+App preferences such as your preferred reset hour and category visibility
+are stored in your app container's `UserDefaults` — also purely local.
+
+## 4. Data that is NOT processed
+
+Dawny does **not** collect any of the following:
+
+- Name, email, phone number, address, or other contact details.
+- Location data.
+- Crash reports or diagnostic telemetry sent to the developer.
+- Advertising identifiers (IDFA), device IDs, or fingerprints.
+- Behavioral or usage analytics.
+
+The app contains **no third-party SDKs** (no Firebase, no Sentry, no
+Mixpanel, no Facebook SDK, etc.).
+
+## 5. App Tracking Transparency
+
+Dawny does not track and therefore does not present the
+**App Tracking Transparency (ATT)** dialog.
+
+## 6. Apple as the platform
+
+Dawny runs on iOS and uses Apple services (App Store, TestFlight, iCloud,
+Siri, Reminders, Calendar). For data processing by Apple,
+[Apple's Privacy Policy](https://www.apple.com/legal/privacy/en-ww/)
+applies, over which the developer has no control.
+
+## 7. Your rights
+
+Because Dawny does not process personal data on the developer's side, many
+GDPR rights (access, deletion, correction, etc.) are effectively exercised
+either against Apple or by you directly on your device:
+
+- **Delete all Dawny data**: Delete the app — all local app data is
+  removed. Items in your Apple Reminders remain in Reminders, since they
+  belong to your Reminders database.
+- **Access**: All data is visible inside the app itself and (if sync is
+  enabled) in the Reminders app on your device.
+- **Complaint**: You have the right to lodge a complaint with a data
+  protection supervisory authority — in Germany, for example, the data
+  protection authority of your federal state.
+
+## 8. Contact
+
+For privacy-related questions: **dawny@posteo.de**
+
+## 9. Changes to this privacy policy
+
+This privacy policy may be updated as the app evolves. The current version
+is available via the App Store Connect URL and in the repository.
+Material changes will be announced with the next app update.

--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Adds a PolyForm Noncommercial 1.0.0 license header to every .swift file
+# in the project. Idempotent: skips files that already contain the header.
+#
+# Usage:
+#   ./scripts/add-license-headers.sh         # dry-run, lists files that would change
+#   ./scripts/add-license-headers.sh --write # actually modify files
+#
+# Run from the repository root.
+
+set -euo pipefail
+
+WRITE=0
+if [[ "${1:-}" == "--write" ]]; then
+  WRITE=1
+fi
+
+HEADER_MARKER="Licensed under PolyForm Noncommercial 1.0.0"
+
+HEADER=$'// Dawny\n// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.\n// Licensed under PolyForm Noncommercial 1.0.0 \xe2\x80\x94 see LICENSE in the repository root.\n\n'
+
+DIRS=("App" "DawnyTests" "DawnyUITests")
+
+changed=0
+skipped=0
+total=0
+
+for dir in "${DIRS[@]}"; do
+  if [[ ! -d "$dir" ]]; then
+    continue
+  fi
+  while IFS= read -r -d '' file; do
+    total=$((total + 1))
+    # Idempotency: only check the first ~10 lines for the marker.
+    if head -n 10 "$file" | grep -qF "$HEADER_MARKER"; then
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [[ "$WRITE" -eq 1 ]]; then
+      tmp="$(mktemp)"
+      printf '%s' "$HEADER" > "$tmp"
+      cat "$file" >> "$tmp"
+      mv "$tmp" "$file"
+    fi
+    changed=$((changed + 1))
+    echo "  [$([[ $WRITE -eq 1 ]] && echo 'WROTE' || echo 'WOULD WRITE')] $file"
+  done < <(find "$dir" -type f -name "*.swift" -print0)
+done
+
+echo
+echo "Summary: $total Swift files scanned, $changed updated, $skipped already had the header."
+
+if [[ "$WRITE" -ne 1 ]]; then
+  echo "Dry run. Re-run with --write to apply changes."
+fi


### PR DESCRIPTION
## Summary
- Führt einen vollständigen Lizenz- und Compliance-Rahmen für das öffentliche Repository ein: `LICENSE` (PolyForm Noncommercial 1.0.0), `NOTICE` (Copyright/Trademark/Asset-Exceptions) und `CONTRIBUTING.md` (Inbound=Outbound + Relicensing-Grant).
- Aktualisiert die öffentliche Projektdokumentation in `README.md` mit klarer Source-available-Positionierung, Lizenz-Badge und Verweis auf kommerzielle Lizenzanfragen.
- Ergänzt Datenschutz- und Store-Compliance-Artefakte: `docs/PRIVACY.de.md`, `docs/PRIVACY.en.md`, `docs/APP_STORE_CONNECT_CHECKLIST.md` sowie `App/PrivacyInfo.xcprivacy` (kein Tracking, keine Data Collection, Required-Reason-API für `UserDefaults`).
- Fügt einheitliche Lizenz-Header in allen Swift-Dateien (App, Unit Tests, UI Tests) hinzu und liefert mit `scripts/add-license-headers.sh` ein idempotentes Skript für zukünftige Dateien.

## Test plan
- [x] `xcodebuild -project Dawny.xcodeproj -scheme Dawny -destination 'generic/platform=iOS' -configuration Debug -derivedDataPath ./.derivedData build CODE_SIGNING_ALLOWED=NO`
- [x] Validiert, dass `App/PrivacyInfo.xcprivacy` syntaktisch korrekt ist (`plutil -lint`).
- [x] Verifiziert, dass `PrivacyInfo.xcprivacy` im gebauten App-Bundle enthalten ist.
- [x] Skript-Check: `scripts/add-license-headers.sh --write` ist idempotent (zweiter Lauf erzeugt keine Änderungen).