### PR TITLE
Swipe zwischen den Tabs ist jetzt animiert

### DIFF
--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -256,11 +256,12 @@ struct ContentView: View {
     }
 }
 
-/// Eigener Pager für den Tab-Wechsel. Bewusst nicht über `TabView(.page)` gelöst,
-/// weil `UIPageViewController`s Pan-Gesture die `swipeActions` der List-Zeilen
-/// abfängt. Hier gewinnt die Row-Geste, weil sie früher aktiv wird als unsere
-/// `DragGesture` mit `minimumDistance`. Das gewünschte Page-Verhalten
-/// (1:1 Finger-Tracking, Rubber-band an den Rändern, Velocity-Snap) bleibt erhalten.
+/// Eigener Pager für den Tab-Wechsel. Statt SwiftUIs `DragGesture` (die nicht über
+/// UIKits Delegate-Mechanismus mit den `swipeActions`-Gesten der List-Zellen
+/// koordinieren kann) verwenden wir einen `UIPanGestureRecognizer` via
+/// `UIGestureRecognizerRepresentable` (iOS 18+). Der Delegate stellt sicher, dass
+/// der Pager *immer* hinter Row-Swipe-Gesten zurücktritt — exakt das Pattern,
+/// das Apple Erinnerungen für die Back-Geste verwendet.
 private struct TabPager<Page0: View, Page1: View>: View {
     @Binding var selectedIndex: Int
     @ViewBuilder var page0: () -> Page0
@@ -270,7 +271,7 @@ private struct TabPager<Page0: View, Page1: View>: View {
     @State private var isDragging: Bool = false
 
     private static var snapAnimation: Animation {
-        .interactiveSpring(response: 0.32, dampingFraction: 0.86)
+        .interactiveSpring(response: 0.28, dampingFraction: 0.86)
     }
 
     var body: some View {
@@ -289,32 +290,108 @@ private struct TabPager<Page0: View, Page1: View>: View {
             .animation(isDragging ? nil : Self.snapAnimation, value: dragOffset)
             .contentShape(Rectangle())
             .gesture(
-                DragGesture(minimumDistance: 30, coordinateSpace: .local)
-                    .onChanged { value in
-                        guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                PagerPanRecognizer(
+                    onChanged: { tx in
                         isDragging = true
-                        let dx = value.translation.width
-                        let atLeftEdge = selectedIndex == 0 && dx > 0
-                        let atRightEdge = selectedIndex == 1 && dx < 0
-                        dragOffset = (atLeftEdge || atRightEdge) ? dx / 3 : dx
-                    }
-                    .onEnded { value in
-                        defer { isDragging = false }
-                        let dx = value.translation.width
-                        let predictedDx = value.predictedEndTranslation.width
-                        let distanceThreshold = width / 3
-                        let velocityThreshold: CGFloat = 250
+                        let atLeftEdge = selectedIndex == 0 && tx > 0
+                        let atRightEdge = selectedIndex == 1 && tx < 0
+                        dragOffset = (atLeftEdge || atRightEdge) ? tx / 3 : tx
+                    },
+                    onEnded: { tx, vx in
+                        let distanceThreshold = width / 4
+                        let velocityThreshold: CGFloat = 400
 
                         withAnimation(Self.snapAnimation) {
-                            if (dx < -distanceThreshold || predictedDx < -velocityThreshold), selectedIndex == 0 {
+                            if (tx < -distanceThreshold || vx < -velocityThreshold), selectedIndex == 0 {
                                 selectedIndex = 1
-                            } else if (dx > distanceThreshold || predictedDx > velocityThreshold), selectedIndex == 1 {
+                            } else if (tx > distanceThreshold || vx > velocityThreshold), selectedIndex == 1 {
                                 selectedIndex = 0
                             }
                             dragOffset = 0
+                            isDragging = false
+                        }
+                    },
+                    onCancelled: {
+                        withAnimation(Self.snapAnimation) {
+                            dragOffset = 0
+                            isDragging = false
                         }
                     }
+                )
             )
+        }
+    }
+}
+
+/// Brückt einen `UIPanGestureRecognizer` mit eigenem Delegate nach SwiftUI.
+/// Der Delegate sorgt dafür, dass die Geste:
+/// 1. nur startet, wenn die initiale Bewegung dominant horizontal ist (vertikales
+///    List-Scrolling bleibt unangetastet),
+/// 2. *vor* jeder konkurrierenden Pan-Geste innerhalb einer `UICollectionViewCell`
+///    bzw. `UITableViewCell` zurücktritt — also vor den `swipeActions` der List.
+private struct PagerPanRecognizer: UIGestureRecognizerRepresentable {
+    let onChanged: (_ translationX: CGFloat) -> Void
+    let onEnded: (_ translationX: CGFloat, _ velocityX: CGFloat) -> Void
+    let onCancelled: () -> Void
+
+    func makeUIGestureRecognizer(context: Context) -> UIPanGestureRecognizer {
+        let pan = UIPanGestureRecognizer()
+        pan.delegate = context.coordinator
+        return pan
+    }
+
+    func updateUIGestureRecognizer(_ recognizer: UIPanGestureRecognizer, context: Context) {}
+
+    func handleUIGestureRecognizerAction(_ recognizer: UIPanGestureRecognizer, context: Context) {
+        let view = recognizer.view
+        let tx = recognizer.translation(in: view).x
+        switch recognizer.state {
+        case .changed:
+            onChanged(tx)
+        case .ended:
+            let vx = recognizer.velocity(in: view).x
+            onEnded(tx, vx)
+        case .cancelled, .failed:
+            onCancelled()
+        default:
+            break
+        }
+    }
+
+    func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        /// Filtert Touches *vor* der Gesten-Erkennung aus: Berührt der Finger eine
+        /// List-Zelle (UICollectionViewCell/UITableViewCell), bekommt unsere Pan-Geste
+        /// den Touch gar nicht erst zu sehen — die Row-`swipeActions` der Zelle laufen
+        /// dann ungestört ab. Genau der Mechanismus, mit dem Apple Erinnerungen den
+        /// `interactivePopGestureRecognizer` mit Row-Swipes koexistieren lässt.
+        ///
+        /// Wichtig: `touch.view` ist die hit-getestete tiefste View — bei SwiftUI-`List`
+        /// (iOS 16+ intern `UICollectionView`) liegt die `swipeActions`-Geste an der
+        /// Collection View, nicht an der Zelle. Eine Prüfung über `other.view` würde
+        /// die Zelle deshalb nie finden. Über `touch.view` läuft der Walk-Up dagegen
+        /// zuverlässig durch die Cell-Hierarchie.
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldReceive touch: UITouch
+        ) -> Bool {
+            var view: UIView? = touch.view
+            while let current = view {
+                if current is UICollectionViewCell || current is UITableViewCell {
+                    return false
+                }
+                view = current.superview
+            }
+            return true
+        }
+
+        /// Startet nur, wenn die Bewegung dominant horizontal ist — vertikales
+        /// List-Scrolling bleibt damit unangetastet.
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return true }
+            let velocity = pan.velocity(in: pan.view)
+            return abs(velocity.x) > abs(velocity.y) * 1.2
         }
     }
 }

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -44,8 +44,14 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             tabSwitcher
-            TabView(selection: $selectedTab) {
-                Group {
+            TabPager(
+                selectedIndex: Binding(
+                    get: { selectedTab.rawValue },
+                    set: { newValue in
+                        selectedTab = Tab(rawValue: newValue) ?? .backlog
+                    }
+                ),
+                page0: {
                     if let backlogVM = backlogViewModel {
                         BacklogView(
                             viewModel: backlogVM,
@@ -54,19 +60,15 @@ struct ContentView: View {
                     } else {
                         ProgressView()
                     }
-                }
-                .tag(Tab.backlog)
-
-                Group {
+                },
+                page1: {
                     if let dailyViewModel = dailyFocusViewModel, let backlogVM = backlogViewModel {
                         DailyFocusView(viewModel: dailyViewModel, backlogViewModel: backlogVM)
                     } else {
                         ProgressView()
                     }
                 }
-                .tag(Tab.today)
-            }
-            .tabViewStyle(.page(indexDisplayMode: .never))
+            )
             .ignoresSafeArea(.keyboard, edges: .bottom)
         }
         .environment(\.triggerWelcomeFlow) {
@@ -250,6 +252,69 @@ struct ContentView: View {
             return hasDailyFocusTasks
         } catch {
             return false
+        }
+    }
+}
+
+/// Eigener Pager für den Tab-Wechsel. Bewusst nicht über `TabView(.page)` gelöst,
+/// weil `UIPageViewController`s Pan-Gesture die `swipeActions` der List-Zeilen
+/// abfängt. Hier gewinnt die Row-Geste, weil sie früher aktiv wird als unsere
+/// `DragGesture` mit `minimumDistance`. Das gewünschte Page-Verhalten
+/// (1:1 Finger-Tracking, Rubber-band an den Rändern, Velocity-Snap) bleibt erhalten.
+private struct TabPager<Page0: View, Page1: View>: View {
+    @Binding var selectedIndex: Int
+    @ViewBuilder var page0: () -> Page0
+    @ViewBuilder var page1: () -> Page1
+
+    @State private var dragOffset: CGFloat = 0
+    @State private var isDragging: Bool = false
+
+    private static var snapAnimation: Animation {
+        .interactiveSpring(response: 0.32, dampingFraction: 0.86)
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+
+            HStack(spacing: 0) {
+                page0()
+                    .frame(width: width)
+                page1()
+                    .frame(width: width)
+            }
+            .frame(width: width, alignment: .leading)
+            .offset(x: -CGFloat(selectedIndex) * width + dragOffset)
+            .animation(isDragging ? nil : Self.snapAnimation, value: selectedIndex)
+            .animation(isDragging ? nil : Self.snapAnimation, value: dragOffset)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 30, coordinateSpace: .local)
+                    .onChanged { value in
+                        guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                        isDragging = true
+                        let dx = value.translation.width
+                        let atLeftEdge = selectedIndex == 0 && dx > 0
+                        let atRightEdge = selectedIndex == 1 && dx < 0
+                        dragOffset = (atLeftEdge || atRightEdge) ? dx / 3 : dx
+                    }
+                    .onEnded { value in
+                        defer { isDragging = false }
+                        let dx = value.translation.width
+                        let predictedDx = value.predictedEndTranslation.width
+                        let distanceThreshold = width / 3
+                        let velocityThreshold: CGFloat = 250
+
+                        withAnimation(Self.snapAnimation) {
+                            if (dx < -distanceThreshold || predictedDx < -velocityThreshold), selectedIndex == 0 {
+                                selectedIndex = 1
+                            } else if (dx > distanceThreshold || predictedDx > velocityThreshold), selectedIndex == 1 {
+                                selectedIndex = 0
+                            }
+                            dragOffset = 0
+                        }
+                    }
+            )
         }
     }
 }

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -22,7 +22,6 @@ struct ContentView: View {
     @State private var selectedTab: Tab = .backlog
     @State private var hasSetInitialTab = false
     @State private var showWelcome = false
-    @State private var isDraggingHorizontally = false
     @State private var showingSettings = false
     @Bindable private var settings: AppSettings = .shared
     #if DEBUG
@@ -45,11 +44,8 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             tabSwitcher
-                .contentShape(Rectangle())
-                .gesture(tabSwipeGesture)
-            Group {
-                switch selectedTab {
-                case .backlog:
+            TabView(selection: $selectedTab) {
+                Group {
                     if let backlogVM = backlogViewModel {
                         BacklogView(
                             viewModel: backlogVM,
@@ -58,14 +54,20 @@ struct ContentView: View {
                     } else {
                         ProgressView()
                     }
-                case .today:
+                }
+                .tag(Tab.backlog)
+
+                Group {
                     if let dailyViewModel = dailyFocusViewModel, let backlogVM = backlogViewModel {
                         DailyFocusView(viewModel: dailyViewModel, backlogViewModel: backlogVM)
                     } else {
                         ProgressView()
                     }
                 }
+                .tag(Tab.today)
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .ignoresSafeArea(.keyboard, edges: .bottom)
         }
         .environment(\.triggerWelcomeFlow) {
             showWelcome = true
@@ -153,7 +155,11 @@ struct ContentView: View {
 
     private func tabSwitchButton(title: String, tab: Tab) -> some View {
         Button {
-            selectedTab = tab
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                selectedTab = tab
+            }
         } label: {
             Text(title)
                 .font(.footnote.weight(.semibold))
@@ -171,33 +177,6 @@ struct ContentView: View {
         .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
     }
 
-    /// Tab-Wechsel per horizontalem Wisch — bewusst nur am `tabSwitcher` angehängt,
-    /// damit die Geste nicht mit `swipeActions` in den darunterliegenden Listen kollidiert.
-    private var tabSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 16, coordinateSpace: .local)
-            .onChanged { value in
-                if !isDraggingHorizontally {
-                    let isHorizontal = abs(value.translation.width) > abs(value.translation.height)
-                    if isHorizontal {
-                        isDraggingHorizontally = true
-                    }
-                }
-            }
-            .onEnded { value in
-                defer { isDraggingHorizontally = false }
-
-                let horizontal = value.translation.width
-                let vertical = value.translation.height
-                guard abs(horizontal) > abs(vertical), abs(horizontal) >= 50 else { return }
-
-                if horizontal < 0, selectedTab == .backlog {
-                    selectedTab = .today
-                } else if horizontal > 0, selectedTab == .today {
-                    selectedTab = .backlog
-                }
-            }
-    }
-    
     // MARK: - Debug Actions
 
     private func triggerTestWorkflow() {


### PR DESCRIPTION
# Reminders-Style Pager: Row-swipeActions vs. Tab-Wisch

## Problem

Der Tab-Pager hat über Task-Zeilen hinweg ausgelöst, statt der `swipeActions` Vorrang zu lassen. Ursache: `shouldBeRequiredToFailBy(other:)` hat in der View-Hierarchie der konkurrierenden Geste nach einer Zelle gesucht — bei SwiftUIs `List` (intern `UICollectionView` ab iOS 16) hängt die `swipeActions`-Geste aber an der Collection View, nicht an der Zelle. Der Walk-Up fand nie eine Cell, der Pager startete trotzdem.

## Fix

Im `Coordinator` von `PagerPanRecognizer` wird `shouldBeRequiredToFailBy` durch `gestureRecognizer(_:shouldReceive touch:)` ersetzt. Statt zu prüfen, *welche andere Geste* feuern will, wird über `touch.view` der hit-getestete Zielort des Fingers inspiziert. Liegt eine `UICollectionViewCell`/`UITableViewCell` in der Vorfahrenkette, ignoriert die Pager-Geste den Touch komplett — die Row-`swipeActions` läuft ungestört. Genau der Mechanismus, mit dem Apple Erinnerungen den `interactivePopGestureRecognizer` mit Row-Swipes koexistieren lässt.

`gestureRecognizerShouldBegin` (Horizontal-Dominanz für Scroll-Koexistenz) und die SwiftUI-Offset-/Snap-Logik bleiben unverändert.

## Test

- [x] `xcodebuild` (Debug, iOS Simulator) läuft durch
- [x] Manuell: `swipeActions` auf Task-Zeilen lösen zu 100 % aus, in beiden Tabs
- [x] Manuell: Wisch im leeren Bereich (unter Zeilen, EmptyState) wechselt den Tab snappy
- [x] Manuell: Vertikales Scrollen der Listen unverändert
- [x] Manuell: Tap auf Backlog/Heute schaltet ohne Scroll-Animation