### PR TITLE
Backlog: Erledigt-Kreis als Platzhalter anzeigen

### DIFF
--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -274,7 +274,8 @@ struct BacklogView: View {
                     await viewModel.deleteTask(task)
                 }
             },
-            showBacklogBadge: false
+            showBacklogBadge: false,
+            showsDisabledToggle: true
         )
         .swipeActions(edge: .leading) {
             Button {
@@ -299,7 +300,8 @@ struct BacklogView: View {
                     await viewModel.deleteTask(task)
                 }
             },
-            showBacklogBadge: false
+            showBacklogBadge: false,
+            showsDisabledToggle: true
         )
         .contextMenu {
             categoryContextMenu(for: task)

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -17,6 +17,7 @@ struct TaskRowView: View {
     let onDelete: (() -> Void)?
     let showDragHandle: Bool
     let showBacklogBadge: Bool
+    let showsDisabledToggle: Bool
     
     @State private var showingDetail = false
     
@@ -25,13 +26,15 @@ struct TaskRowView: View {
         onToggle: (() -> Void)? = nil,
         onDelete: (() -> Void)? = nil,
         showDragHandle: Bool = false,
-        showBacklogBadge: Bool = true
+        showBacklogBadge: Bool = true,
+        showsDisabledToggle: Bool = false
     ) {
         self.task = task
         self.onToggle = onToggle
         self.onDelete = onDelete
         self.showDragHandle = showDragHandle
         self.showBacklogBadge = showBacklogBadge
+        self.showsDisabledToggle = showsDisabledToggle
     }
     
     var body: some View {
@@ -55,6 +58,14 @@ struct TaskRowView: View {
                         .frame(minWidth: 32, minHeight: 32)
                 }
                 .buttonStyle(.plain)
+            } else if showsDisabledToggle {
+                Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle.dashed")
+                    .font(checkboxFont)
+                    .foregroundStyle(.gray)
+                    .frame(minWidth: 32, minHeight: 32)
+                    .opacity(0.5)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
             }
             
             titleAndMetaColumn


### PR DESCRIPTION
Im Backlog wird jetzt links neben jeder Task ein gestrichelter Kreis (circle.dashed, 50% Opacity) angezeigt, damit die Liste optisch konsistent zum "Heute"-Tab wirkt. Der Kreis ist bewusst nicht tappbar - Tasks lassen sich weiterhin nur im "Heute"-Tab als erledigt markieren.

## Was ändert sich?

Aufgaben im Backlog bekommen links denselben Kreis-Indikator wie im
„Heute"-Tab. Damit wirkt die Backlog-Liste nicht mehr „nackt" und ist
visuell konsistent mit dem Heute-Tab.

Wichtig: Der Kreis im Backlog ist **nur Anzeige** — er ist nicht klickbar.
Tasks können weiterhin ausschließlich im „Heute"-Tab als erledigt markiert
werden. Das ist gewollt, damit der Erledigt-Workflow bewusst über das
Heute-Board läuft.

## Wie ist das visuell gelöst?

- Im Backlog wird `circle.dashed` (gestrichelter Kreis) mit 50% Opacity
  gezeigt. Die gestrichelte Variante ist die übliche UX-Konvention
  (Things, Linear, Apple Reminders) für „Platzhalter, hier ist nichts
  zu tun".
- Im „Heute"-Tab bleibt alles wie bisher: durchgezogener Kreis,
  voll sichtbar, tappbar.

## Technische Umsetzung

- `TaskRowView` bekommt einen neuen Parameter `showsDisabledToggle`.
  Ist er `true` und es gibt kein `onToggle`, wird der Kreis als reines
  `Image` gerendert — ohne Button, mit `allowsHitTesting(false)` und
  `accessibilityHidden(true)`. Dadurch öffnet ein Tap auf die Zeile
  weiterhin das Task-Detail, und VoiceOver bietet den Kreis nicht
  als Bedienelement an.
- `BacklogView` setzt diesen Parameter in beiden Backlog-Zeilen
  (kategorisiert und unkategorisiert).
- `DailyFocusView` bleibt unverändert.