### PR TITLE
In heute Tab gezogene Tasks werden auch ohne update der seite angezeigt

### DIFF
--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -282,6 +282,9 @@ struct BacklogView: View {
                 HapticFeedback.medium()
                 _Concurrency.Task {
                     await viewModel.moveTaskToDailyFocus(task)
+                    await MainActor.run {
+                        dailyFocusViewModel?.loadDailyTasks()
+                    }
                 }
             } label: {
                 Label(String(localized: "backlog.swipe.today", defaultValue: "Today"), systemImage: "sun.max.fill")
@@ -311,6 +314,9 @@ struct BacklogView: View {
                 HapticFeedback.medium()
                 _Concurrency.Task {
                     await viewModel.moveTaskToDailyFocus(task)
+                    await MainActor.run {
+                        dailyFocusViewModel?.loadDailyTasks()
+                    }
                 }
             } label: {
                 Label(String(localized: "backlog.swipe.today", defaultValue: "Today"), systemImage: "sun.max.fill")


### PR DESCRIPTION
Wenn ein Task per Swipe vom Backlog in den Heute-Tab verschoben wird, erscheint er ab sofort direkt in der Heute-Liste – ohne dass man die Ansicht erst durch Herunterziehen aktualisieren muss.