### PR TITLE
Realistische Test-Tasks statt generischer Testtask 1, 2, 3...

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -3022,6 +3022,1506 @@
         }
       }
     },
+    "debug.testtask.quick.1" : {
+      "comment" : "Debug-only · Sample test task title (Quick category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit dem Hund rausgehen 🐕"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Walk the dog 🐕"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasear al perro 🐕"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Promener le chien 🐕"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portare a spasso il cane 🐕"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "犬の散歩 🐕"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강아지 산책시키기 🐕"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passear com o cachorro 🐕"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遛狗 🐕"
+          }
+        }
+      }
+    },
+    "debug.testtask.quick.2" : {
+      "comment" : "Debug-only · Sample test task title (Quick category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arzttermin vereinbaren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make doctor’s appointment"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pedir cita con el médico"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prendre rendez-vous chez le médecin"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fissare un appuntamento dal medico"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "病院の予約をする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "병원 예약하기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar consulta médica"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预约看医生"
+          }
+        }
+      }
+    },
+    "debug.testtask.quick.3" : {
+      "comment" : "Debug-only · Sample test task title (Quick category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konzerttickets kaufen 🎟️"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get concert tickets 🎟️"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar entradas para el concierto 🎟️"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acheter des billets de concert 🎟️"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprare i biglietti del concerto 🎟️"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンサートのチケットを取る 🎟️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "콘서트 티켓 사기 🎟️"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar ingressos para o show 🎟️"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "买演唱会门票 🎟️"
+          }
+        }
+      }
+    },
+    "debug.testtask.quick.4" : {
+      "comment" : "Debug-only · Sample test task title (Quick category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paket abholen 📦"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick up package 📦"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recoger paquete 📦"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récupérer le colis 📦"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritirare il pacco 📦"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "荷物を受け取る 📦"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "택배 찾으러 가기 📦"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar encomenda 📦"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取快递 📦"
+          }
+        }
+      }
+    },
+    "debug.testtask.quick.5" : {
+      "comment" : "Debug-only · Sample test task title (Quick category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strafzettel bezahlen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay parking ticket"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar la multa de aparcamiento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payer l’amende de stationnement"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagare la multa per la sosta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "駐車違反の罰金を払う"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주차 위반 과태료 납부"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagar multa de estacionamento"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缴停车罚单"
+          }
+        }
+      }
+    },
+    "debug.testtask.someday.1" : {
+      "comment" : "Debug-only · Sample test task title (Someday category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haare blau färben"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dye hair blue"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teñirme el pelo de azul"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Me teindre les cheveux en bleu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tingermi i capelli di blu"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "髪を青く染める"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "머리 파랗게 염색하기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pintar o cabelo de azul"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "把头发染成蓝色"
+          }
+        }
+      }
+    },
+    "debug.testtask.someday.2" : {
+      "comment" : "Debug-only · Sample test task title (Someday category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reise nach Tokio buchen ✈️"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Book trip to Tokyo ✈️"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservar un viaje a Tokio ✈️"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réserver un voyage à Tokyo ✈️"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prenotare un viaggio a Tokyo ✈️"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "東京旅行を予約する ✈️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도쿄 여행 예약하기 ✈️"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservar uma viagem a Tóquio ✈️"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "订一趟东京之旅 ✈️"
+          }
+        }
+      }
+    },
+    "debug.testtask.someday.3" : {
+      "comment" : "Debug-only · Sample test task title (Someday category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gitarre spielen lernen 🎸"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Learn to play guitar 🎸"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aprender a tocar la guitarra 🎸"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apprendre à jouer de la guitare 🎸"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imparare a suonare la chitarra 🎸"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ギターを弾けるようになる 🎸"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타 배우기 🎸"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aprender a tocar violão 🎸"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学吉他 🎸"
+          }
+        }
+      }
+    },
+    "debug.testtask.someday.4" : {
+      "comment" : "Debug-only · Sample test task title (Someday category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einen Marathon laufen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run a marathon"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correr un maratón"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Courir un marathon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correre una maratona"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フルマラソンを走る"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마라톤 완주하기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correr uma maratona"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑一次马拉松"
+          }
+        }
+      }
+    },
+    "debug.testtask.someday.5" : {
+      "comment" : "Debug-only · Sample test task title (Someday category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einen Roman schreiben"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write a novel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribir una novela"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrire un roman"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrivere un romanzo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小説を書く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소설 쓰기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escrever um romance"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写一本小说"
+          }
+        }
+      }
+    },
+    "debug.testtask.thismonth.1" : {
+      "comment" : "Debug-only · Sample test task title (This Month category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Druckerpatrone wechseln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Replace printer cartridge"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar el cartucho de la impresora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacer la cartouche d’imprimante"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sostituire la cartuccia della stampante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プリンターのインクを交換する"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프린터 잉크 교체하기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trocar o cartucho da impressora"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更换打印机墨盒"
+          }
+        }
+      }
+    },
+    "debug.testtask.thismonth.2" : {
+      "comment" : "Debug-only · Sample test task title (This Month category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Bilder rahmen und aufhängen 🖼️"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frame and hang new pictures 🖼️"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enmarcar y colgar las fotos nuevas 🖼️"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encadrer et accrocher les nouvelles photos 🖼️"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incorniciare e appendere le nuove foto 🖼️"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しい写真を額装して飾る 🖼️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 사진 액자 만들고 걸기 🖼️"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoldurar e pendurar as fotos novas 🖼️"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "把新照片装框挂起来 🖼️"
+          }
+        }
+      }
+    },
+    "debug.testtask.thismonth.3" : {
+      "comment" : "Debug-only · Sample test task title (This Month category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster putzen ✨"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clean the windows ✨"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar las ventanas ✨"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nettoyer les vitres ✨"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulire le finestre ✨"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窓を掃除する ✨"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "창문 청소하기 ✨"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpar as janelas ✨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "擦窗户 ✨"
+          }
+        }
+      }
+    },
+    "debug.testtask.thismonth.4" : {
+      "comment" : "Debug-only · Sample test task title (This Month category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto zur Inspektion bringen 🚗"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Take car in for inspection 🚗"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Llevar el coche a la revisión 🚗"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amener la voiture au contrôle technique 🚗"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portare l’auto al tagliando 🚗"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "車を点検に出す 🚗"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "차량 점검 맡기기 🚗"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Levar o carro para revisão 🚗"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "把车送去保养 🚗"
+          }
+        }
+      }
+    },
+    "debug.testtask.thismonth.5" : {
+      "comment" : "Debug-only · Sample test task title (This Month category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geburtstagsessen reservieren 🎂"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Book birthday dinner 🎂"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservar la cena de cumpleaños 🎂"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réserver le dîner d’anniversaire 🎂"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prenotare la cena di compleanno 🎂"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "誕生日ディナーを予約する 🎂"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생일 저녁 식사 예약 🎂"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservar o jantar de aniversário 🎂"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预订生日晚餐 🎂"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisweek.1" : {
+      "comment" : "Debug-only · Sample test task title (This Week category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carlas Hochzeit zu-/absagen 💌"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RSVP to Carla’s wedding 💌"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar asistencia a la boda de Carla 💌"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répondre à l’invitation au mariage de Carla 💌"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confermare la presenza al matrimonio di Carla 💌"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カルラの結婚式に出欠の返事をする 💌"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "칼라 결혼식 참석 여부 답하기 💌"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar presença no casamento da Carla 💌"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回复 Carla 婚礼邀请 💌"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisweek.2" : {
+      "comment" : "Debug-only · Sample test task title (This Week category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einkaufen gehen 🛒"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get groceries 🛒"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacer la compra 🛒"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faire les courses 🛒"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fare la spesa 🛒"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "食料品の買い出し 🛒"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "장보기 🛒"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fazer compras do mercado 🛒"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "买菜 🛒"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisweek.3" : {
+      "comment" : "Debug-only · Sample test task title (This Week category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezept aus Apotheke holen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick up prescription"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recoger la receta en la farmacia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récupérer l’ordonnance à la pharmacie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritirare la ricetta in farmacia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "処方薬を受け取りに行く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "처방약 받아오기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar receita na farmácia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去药店取处方药"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisweek.4" : {
+      "comment" : "Debug-only · Sample test task title (This Week category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tom auf Nachricht antworten 💬"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reply to Tom’s message 💬"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responder al mensaje de Tom 💬"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répondre au message de Tom 💬"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rispondere al messaggio di Tom 💬"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トムのメッセージに返信する 💬"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "톰 메시지에 답장하기 💬"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responder à mensagem do Tom 💬"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回复 Tom 的消息 💬"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisweek.5" : {
+      "comment" : "Debug-only · Sample test task title (This Week category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reisekostenabrechnung einreichen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Submit expense report"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar informe de gastos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer la note de frais"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inviare la nota spese"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "経費精算を提出する"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경비 보고서 제출"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar relatório de despesas"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交报销单"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisyear.1" : {
+      "comment" : "Debug-only · Sample test task title (This Year category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neuen Kühlschrank kaufen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy a new fridge"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar una nevera nueva"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acheter un nouveau frigo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprare un frigorifero nuovo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しい冷蔵庫を買う"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 냉장고 사기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar uma geladeira nova"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "买新冰箱"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisyear.2" : {
+      "comment" : "Debug-only · Sample test task title (This Year category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschenkeliste für Geburtstage machen 🎁"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make list of birthday gifts 🎁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacer lista de regalos de cumpleaños 🎁"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faire la liste des cadeaux d’anniversaire 🎁"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fare la lista dei regali di compleanno 🎁"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "誕生日プレゼントのリストを作る 🎁"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생일 선물 목록 만들기 🎁"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fazer lista de presentes de aniversário 🎁"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列生日礼物清单 🎁"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisyear.3" : {
+      "comment" : "Debug-only · Sample test task title (This Year category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reisepass verlängern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renew passport"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renovar el pasaporte"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renouveler le passeport"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rinnovare il passaporto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスポートを更新する"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여권 갱신하기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renovar o passaporte"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "续办护照"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisyear.4" : {
+      "comment" : "Debug-only · Sample test task title (This Year category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sommerurlaub planen ☀️"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plan summer vacation ☀️"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planear las vacaciones de verano ☀️"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planifier les vacances d’été ☀️"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pianificare le vacanze estive ☀️"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "夏休みの計画を立てる ☀️"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여름 휴가 계획 세우기 ☀️"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planejar as férias de verão ☀️"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "计划暑假旅行 ☀️"
+          }
+        }
+      }
+    },
+    "debug.testtask.thisyear.5" : {
+      "comment" : "Debug-only · Sample test task title (This Year category) · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wieder mit Joggen anfangen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start running again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a salir a correr"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommencer à courir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricominciare a correre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランニングを再開する"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 달리기 시작하기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voltar a correr"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新开始跑步"
+          }
+        }
+      }
+    },
     "error.backlog.complete_task" : {
       "comment" : "Error banner · BacklogViewModel · Single sentence. %@ is the localized system error.",
       "extractionState" : "manual",

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -582,50 +582,168 @@ final class BacklogViewModel {
         }
     }
 
-    /// Legt Testelemente im Backlog an (für manuelles UI-Testing).
+    /// Legt realistische Beispiel-Tasks im Backlog an (für manuelles UI-Testing).
+    ///
+    /// Pro Kategorie werden 5 Beispiel-Tasks angelegt. Vier davon (die ersten beiden
+    /// aus *Quick* und *This Week*) werden zusätzlich direkt in den Heute-Tab gelegt,
+    /// damit der Heute-View ebenfalls vorgefüllt ist.
     func addDebugTestItems(settings: AppSettings) {
         loadCategories()
         let assignableCategories = categories
             .sorted()
             .filter { $0.categoryType != .uncategorized }
 
-        var counter = 1
+        let todayDate = Calendar.current.startOfDay(for: Date())
 
-        // In jeder Kategorie 3-4 Backlog-Tasks erzeugen.
         for category in assignableCategories {
-            let countPerCategory = Int.random(in: 3...4)
-            for index in 1...countPerCategory {
-                addTask(
-                    title: "Testtask \(counter) \(category.displayName) #\(index)",
-                    category: category
-                )
-                counter += 1
+            let items = Self.debugTestItems(for: category.categoryType)
+            for item in items {
+                guard let task = addTask(title: item.title, category: category) else { continue }
+                if item.placeInToday {
+                    task.moveToDailyFocus(date: todayDate)
+                }
             }
         }
 
-        // Zusätzlich 2-3 Tasks direkt in den Heute-Tab legen.
-        let todayCount = Int.random(in: 2...3)
-        let todayDate = Calendar.current.startOfDay(for: Date())
-        let todayCategory = assignableCategories.first(where: { $0.categoryType == .quick }) ?? assignableCategories.first
+        do {
+            try modelContext.save()
+        } catch {
+            let format = String(
+                localized: "error.backlog.debug_today_test_tasks",
+                defaultValue: "Failed to create test tasks: %@"
+            )
+            errorMessage = String(format: format, error.localizedDescription)
+        }
+    }
 
-        for index in 1...todayCount {
-            if let task = addTask(
-                title: "Testtask Heute \(counter) #\(index)",
-                category: todayCategory
-            ) {
-                task.moveToDailyFocus(date: todayDate)
-                do {
-                    try modelContext.save()
-                } catch {
-                    let format = String(
-                        localized: "error.backlog.debug_today_test_tasks",
-                        defaultValue: "Failed to create test tasks: %@"
-                    )
-                    errorMessage = String(format: format, error.localizedDescription)
-                    return
-                }
-            }
-            counter += 1
+    /// Beschreibt einen Debug-Test-Task: lokalisierter Titel + Flag, ob er
+    /// initial zusätzlich im Heute-Tab landen soll.
+    private struct DebugTestItem {
+        let title: String
+        let placeInToday: Bool
+    }
+
+    /// Liefert die fünf Beispiel-Tasks für die gegebene Kategorie. Für unbekannte
+    /// (z. B. `.custom`, `.uncategorized`) werden keine Items zurückgegeben.
+    private static func debugTestItems(for type: TaskCategory) -> [DebugTestItem] {
+        switch type {
+        case .quick:
+            return [
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.quick.1", defaultValue: "Walk the dog 🐕"),
+                    placeInToday: true
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.quick.2", defaultValue: "Make doctor’s appointment"),
+                    placeInToday: true
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.quick.3", defaultValue: "Get concert tickets 🎟️"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.quick.4", defaultValue: "Pick up package 📦"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.quick.5", defaultValue: "Pay parking ticket"),
+                    placeInToday: false
+                )
+            ]
+        case .thisWeek:
+            return [
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisweek.1", defaultValue: "RSVP to Carla’s wedding 💌"),
+                    placeInToday: true
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisweek.2", defaultValue: "Get groceries 🛒"),
+                    placeInToday: true
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisweek.3", defaultValue: "Pick up prescription"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisweek.4", defaultValue: "Reply to Tom’s message 💬"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisweek.5", defaultValue: "Submit expense report"),
+                    placeInToday: false
+                )
+            ]
+        case .thisMonth:
+            return [
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thismonth.1", defaultValue: "Replace printer cartridge"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thismonth.2", defaultValue: "Frame and hang new pictures 🖼️"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thismonth.3", defaultValue: "Clean the windows ✨"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thismonth.4", defaultValue: "Take car in for inspection 🚗"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thismonth.5", defaultValue: "Book birthday dinner 🎂"),
+                    placeInToday: false
+                )
+            ]
+        case .thisYear:
+            return [
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisyear.1", defaultValue: "Buy a new fridge"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisyear.2", defaultValue: "Make list of birthday gifts 🎁"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisyear.3", defaultValue: "Renew passport"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisyear.4", defaultValue: "Plan summer vacation ☀️"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.thisyear.5", defaultValue: "Start running again"),
+                    placeInToday: false
+                )
+            ]
+        case .someday:
+            return [
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.someday.1", defaultValue: "Dye hair blue"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.someday.2", defaultValue: "Book trip to Tokyo ✈️"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.someday.3", defaultValue: "Learn to play guitar 🎸"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.someday.4", defaultValue: "Run a marathon"),
+                    placeInToday: false
+                ),
+                DebugTestItem(
+                    title: String(localized: "debug.testtask.someday.5", defaultValue: "Write a novel"),
+                    placeInToday: false
+                )
+            ]
+        case .uncategorized, .custom:
+            return []
         }
     }
 }


### PR DESCRIPTION
### Was sich ändert

Der **„Test Items hinzufügen"**-Button in den Debug-Settings legt jetzt **realistische, alltagsnahe Beispiel-Tasks** an statt der bisherigen generischen `"Testtask 1 Quick #1"`-Strings. Pro Kategorie werden 5 passende Tasks erzeugt – z. B. *Walk the dog* in **Quick**, *RSVP to Carla's wedding* in **This Week**, *Buy a new fridge* in **This Year** oder *Book trip to Tokyo* in **Someday**.

Vier davon (die ersten beiden aus *Quick* und *This Week*) landen zusätzlich direkt im **Heute-Tab**, damit auch dieser View beim Testen sofort vorgefüllt ist.

### Warum

Mit den realistischen Titeln lassen sich Layout, Truncation, Emoji-Rendering und das Gefühl des UIs deutlich besser beurteilen als mit nichtssagenden Platzhaltern. Außerdem wird so im Testbetrieb sichtbar, ob ein Task in seiner Kategorie inhaltlich Sinn ergibt (kein „Walk the dog" in *This Year* mehr).

### Sprachen & Emojis

- Alle 25 Tasks in **9 Sprachen** übersetzt: de, en, es, fr, it, ja, ko, pt-BR, zh-Hans
- Emojis nur sparsam und ausschließlich bei positiven Tasks (Konzert 🎟️, Geburtstag 🎂, Tokio ✈️ …) – nicht bei Pflichtkram wie Strafzettel oder Reisekostenabrechnung

### Geänderte Dateien

- `App/Sources/Localizable.xcstrings` – 25 neue Schlüssel `debug.testtask.<kategorie>.<n>`
- `App/Sources/ViewModels/BacklogViewModel.swift` – `addDebugTestItems` neu, plus neue private Hilfsstruktur `DebugTestItem` und Lookup `debugTestItems(for:)`

Reines Debug-Feature – keine Änderungen am Produktverhalten für Endnutzer.