### PR TITLE
Wiederkehrende tasks

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -862,6 +862,81 @@
         }
       }
     },
+    "category.action.makeRecurring" : {
+      "comment" : "Backlog · Confirmation dialog button · Marks a category as recurring.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Als wiederkehrend markieren" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mark as recurring" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Marcar como recurrente" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Marquer comme récurrent" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Segna come ricorrente" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返しに設定" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "반복으로 표시" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Marcar como recorrente" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "标记为重复" } }
+      }
+    },
+    "category.action.unmakeRecurring" : {
+      "comment" : "Backlog · Confirmation dialog button · Clears recurring flag from a category.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wiederkehrend aufheben" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove recurring" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Quitar recurrencia" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Retirer le récurrent" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Rimuovi ricorrenza" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返しを解除" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "반복 해제" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Remover recorrente" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "取消重复" } }
+      }
+    },
+    "category.add.recurringToggle" : {
+      "comment" : "Backlog · VoiceOver for recurring toggle in add-category row.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wiederkehrend" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Recurring" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Recurrente" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Récurrent" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Ricorrente" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返し" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "반복" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Recorrente" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重复" } }
+      }
+    },
+    "category.recurring.default.name" : {
+      "comment" : "Default name for the built-in recurring category.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wiederkehrende Aufgaben" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Recurring Tasks" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Tareas recurrentes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tâches récurrentes" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Attività ricorrenti" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返しタスク" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "반복 작업" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Tarefas recorrentes" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重复任务" } }
+      }
+    },
+    "task.recurring.badge" : {
+      "comment" : "Accessibility label for the recurring task/category badge icon.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Wiederkehrend" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Recurring" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Recurrente" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Récurrent" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Ricorrente" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返し" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "반복" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Recorrente" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重复" } }
+      }
+    },
     "category.add.accessibility" : {
       "comment" : "Backlog · VoiceOver label of the “add category” row button · Imperative.",
       "extractionState" : "manual",

--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -3397,6 +3397,51 @@
         }
       }
     },
+    "debug.testtask.recurring.1" : {
+      "comment" : "Debug-only · Sample test task in a recurring category · 'Add Test Items' settings.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Zähne putzen" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Brush teeth" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Lavarse los dientes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Se brosser les dents" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Lavare i denti" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "歯を磨く" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "양치하기" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Escovar os dentes" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "刷牙" } }
+      }
+    },
+    "debug.testtask.recurring.2" : {
+      "comment" : "Debug-only · Sample recurring test task · 'Add Test Items' settings.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Ein Glas Wasser trinken" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Drink a glass of water" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Beber un vaso de agua" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Boire un verre d’eau" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Bere un bicchiere d’acqua" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "水を一杯飲む" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "물 한 잔 마시기" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Beber um copo de água" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "喝一杯水" } }
+      }
+    },
+    "debug.testtask.recurring.3" : {
+      "comment" : "Debug-only · Sample recurring test task · 'Add Test Items' settings.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "5 Min. Dehnen" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "5 min stretch break" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "5 min de estiramiento" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "5 min d’étirements" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "5 min di stiramento" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "5分ストレッチ" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "5분 스트레칭" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "5 min de alongamento" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "5分钟拉伸" } }
+      }
+    },
     "debug.testtask.someday.1" : {
       "comment" : "Debug-only · Sample test task title (Someday category) · Used by 'Add Test Items' settings action.",
       "extractionState" : "manual",

--- a/App/Sources/Models/Backlog.swift
+++ b/App/Sources/Models/Backlog.swift
@@ -54,21 +54,28 @@ final class Backlog {
     
     /// Anzahl der Tasks im Backlog
     var taskCount: Int {
-        tasks.filter { $0.status == .inBacklog }.count
+        liveTasks.filter { $0.status == .inBacklog }.count
     }
     
     /// Tasks die im Backlog sind (nicht completed/scheduled)
     var backlogTasks: [Task] {
-        tasks
+        liveTasks
             .filter { $0.status == .inBacklog }
             .sorted()
     }
     
     /// Tasks die completed sind
     var completedTasks: [Task] {
-        tasks
+        liveTasks
             .filter { $0.status == .completed }
             .sorted { $0.modifiedAt > $1.modifiedAt }
+    }
+
+    /// Filtert bereits als gelöscht markierte (tombstoned) Tasks aus der
+    /// Relationship. SwiftData hält solche Referenzen teils noch bis zum
+    /// nächsten Save – Zugriffe auf `status` o.ä. crashen sonst.
+    private var liveTasks: [Task] {
+        tasks.filter { !$0.isDeleted }
     }
     
     // MARK: - Methods

--- a/App/Sources/Models/Category.swift
+++ b/App/Sources/Models/Category.swift
@@ -42,6 +42,10 @@ final class Category {
     /// Solange `false`, wird `categoryType.iconName` als Default verwendet.
     var isIconCustomized: Bool = false
 
+    /// Wenn true, verhalten sich Tasks in dieser Kategorie „wiederkehrend“
+    /// (siehe Heute-Backlog-Clone-Logik).
+    var isRecurring: Bool = false
+
     /// Erstellungsdatum
     var createdAt: Date
     
@@ -62,6 +66,7 @@ final class Category {
         isUncategorized: Bool = false,
         isNameCustomized: Bool = false,
         isIconCustomized: Bool = false,
+        isRecurring: Bool = false,
         createdAt: Date = Date(),
         tasks: [Task] = []
     ) {
@@ -73,6 +78,7 @@ final class Category {
         self.isUncategorized = isUncategorized || (categoryType == .uncategorized)
         self.isNameCustomized = isNameCustomized
         self.isIconCustomized = isIconCustomized
+        self.isRecurring = isRecurring
         self.createdAt = createdAt
         self.tasks = tasks
     }
@@ -125,9 +131,14 @@ final class Category {
         !isUncategorized && categoryType != .quick
     }
 
+    /// Darf der Nutzer die wiederkehrende Markierung umschalten?
+    var canToggleRecurring: Bool {
+        !isUncategorized
+    }
+
     /// True, wenn überhaupt irgendeine Edit-Aktion verfügbar ist.
     var hasAnyEditCapability: Bool {
-        canRename || canChangeIcon || canDelete
+        canRename || canChangeIcon || canDelete || canToggleRecurring
     }
 }
 

--- a/App/Sources/Models/Category.swift
+++ b/App/Sources/Models/Category.swift
@@ -87,14 +87,20 @@ final class Category {
     
     /// Anzahl der Tasks in dieser Kategorie (nur Backlog-Tasks)
     var taskCount: Int {
-        tasks.filter { $0.status == .inBacklog }.count
+        liveTasks.filter { $0.status == .inBacklog }.count
     }
     
     /// Tasks die im Backlog sind (nicht completed/scheduled)
     var backlogTasks: [Task] {
-        tasks
+        liveTasks
             .filter { $0.status == .inBacklog }
             .sorted()
+    }
+
+    /// Filtert bereits als gelöscht markierte Tasks aus der Relationship.
+    /// Siehe Hinweis in `Backlog.liveTasks`.
+    private var liveTasks: [Task] {
+        tasks.filter { !$0.isDeleted }
     }
 
     // MARK: - Display

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -49,7 +49,11 @@ final class Task {
     
     /// Flag ob Task abgeschlossen ist
     var isCompleted: Bool
-    
+
+    /// Setzt `complete`/`uncomplete` für wiederkehrende Aufgaben mit dem
+    /// erzeugten Backlog-Clone in Verbindung.
+    var recurringCloneID: UUID? = nil
+
     // MARK: - Relationships
     
     /// Referenz zum Parent-Backlog
@@ -72,6 +76,7 @@ final class Task {
         createdAt: Date = Date(),
         modifiedAt: Date = Date(),
         isCompleted: Bool = false,
+        recurringCloneID: UUID? = nil,
         category: Category? = nil
     ) {
         self.id = id
@@ -85,6 +90,7 @@ final class Task {
         self.createdAt = createdAt
         self.modifiedAt = modifiedAt
         self.isCompleted = isCompleted
+        self.recurringCloneID = recurringCloneID
         self.category = category
     }
     
@@ -110,7 +116,12 @@ final class Task {
         guard isCompleted, let scheduledDate = scheduledDate else { return false }
         return Calendar.current.isDateInToday(scheduledDate)
     }
-    
+
+    /// True, wenn der Task in einer als wiederkehrend markierten Kategorie liegt.
+    var isRecurring: Bool {
+        category?.isRecurring == true
+    }
+
     // MARK: - Methods
     
     /// Markiert den Task als abgeschlossen

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -27,6 +27,7 @@ enum CategoryEditError: LocalizedError {
     case protectedFromRename
     case protectedFromIconChange
     case protectedFromDelete
+    case protectedFromRecurring
     case uncategorizedMissing
     case persistence(underlying: Error)
 
@@ -43,7 +44,7 @@ enum CategoryEditError: LocalizedError {
                 defaultValue: "The name may be at most %lld characters."
             )
             return String(format: format, locale: .current, maxLength)
-        case .protectedFromRename, .protectedFromIconChange, .protectedFromDelete:
+        case .protectedFromRename, .protectedFromIconChange, .protectedFromDelete, .protectedFromRecurring:
             return String(
                 localized: "category.edit.errorProtected",
                 defaultValue: "This category can't be modified."
@@ -70,39 +71,48 @@ final class CategoryService {
         self.modelContext = modelContext
     }
     
-    /// Initialisiert die Standard-Kategorien beim ersten App-Start
+    /// Initialisiert die Standard-Kategorien beim ersten App-Start und
+    /// legt bei Bedarf die Standard-„Wiederkehrende Aufgaben“-Kategorie an (Idempotent / Migration).
     func initializeDefaultCategories() {
-        // Prüfe ob bereits Kategorien existieren
         let descriptor = FetchDescriptor<Category>()
         do {
-            let existingCategories = try modelContext.fetch(descriptor)
-            
-            if !existingCategories.isEmpty {
-                // Kategorien existieren bereits
-                return
+            var allCategories = try modelContext.fetch(descriptor)
+
+            if allCategories.isEmpty {
+                let types: [TaskCategory] = [.quick, .thisWeek, .thisMonth, .thisYear, .someday, .uncategorized]
+                for categoryType in types {
+                    let category = Category(
+                        categoryType: categoryType,
+                        orderIndex: categoryType.defaultOrderIndex,
+                        isUncategorized: categoryType == .uncategorized
+                    )
+                    modelContext.insert(category)
+                }
+                try modelContext.save()
+                allCategories = try modelContext.fetch(descriptor)
+            }
+
+            if !allCategories.contains(where: { $0.isRecurring }) {
+                let nextOrderIndex = (allCategories.map(\.orderIndex).max() ?? -1) + 1
+                let defaultName = String(
+                    localized: "category.recurring.default.name",
+                    defaultValue: "Recurring Tasks"
+                )
+                let recurring = Category(
+                    categoryType: .custom,
+                    name: defaultName,
+                    iconName: "arrow.triangle.2.circlepath",
+                    orderIndex: nextOrderIndex,
+                    isUncategorized: false,
+                    isNameCustomized: true,
+                    isIconCustomized: true,
+                    isRecurring: true
+                )
+                modelContext.insert(recurring)
+                try modelContext.save()
             }
         } catch {
-            // Fehler beim Laden - versuche trotzdem zu erstellen
-            print("Fehler beim Laden der Kategorien: \(error)")
-        }
-        
-        // Erstelle alle Standard-Kategorien
-        let categories: [TaskCategory] = [.quick, .thisWeek, .thisMonth, .thisYear, .someday, .uncategorized]
-        
-        for categoryType in categories {
-            let category = Category(
-                categoryType: categoryType,
-                orderIndex: categoryType.defaultOrderIndex,
-                isUncategorized: categoryType == .uncategorized
-            )
-            modelContext.insert(category)
-        }
-        
-        // Speichere die Kategorien
-        do {
-            try modelContext.save()
-        } catch {
-            print("Fehler beim Speichern der Standard-Kategorien: \(error)")
+            print("Fehler bei Standard-Kategorien / wiederkehrender Default: \(error)")
         }
     }
     
@@ -138,7 +148,8 @@ final class CategoryService {
     }
     
     /// Legt eine neue benutzerdefinierte Kategorie an (erscheint nach bestehenden Einträgen, typisch unter „Unkategorisiert“).
-    func createCustom(name: String) throws -> Category {
+    /// - Parameter isRecurring: Wenn `true`, passendes Default-Symbol und `isRecurring` auf dem Modell.
+    func createCustom(name: String, isRecurring: Bool = false) throws -> Category {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw CategoryEditError.nameEmpty
@@ -151,18 +162,30 @@ final class CategoryService {
         let existing = try modelContext.fetch(descriptor)
         let nextOrderIndex = (existing.map(\.orderIndex).max() ?? -1) + 1
 
+        let icon = isRecurring ? "arrow.triangle.2.circlepath" : TaskCategory.custom.iconName
         let category = Category(
             categoryType: .custom,
             name: trimmed,
-            iconName: TaskCategory.custom.iconName,
+            iconName: icon,
             orderIndex: nextOrderIndex,
             isUncategorized: false,
             isNameCustomized: true,
-            isIconCustomized: true
+            isIconCustomized: true,
+            isRecurring: isRecurring
         )
         modelContext.insert(category)
         try save()
         return category
+    }
+
+    /// Setzt die Eigenschaft „wiederkehrend“ auf einer Kategorie.
+    func setRecurring(_ category: Category, to newValue: Bool) throws {
+        guard category.canToggleRecurring else {
+            throw CategoryEditError.protectedFromRecurring
+        }
+        if category.isRecurring == newValue { return }
+        category.isRecurring = newValue
+        try save()
     }
 
     /// Gibt eine Kategorie nach Typ zurück

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -93,27 +93,110 @@ final class CategoryService {
             }
 
             if !allCategories.contains(where: { $0.isRecurring }) {
-                let nextOrderIndex = (allCategories.map(\.orderIndex).max() ?? -1) + 1
                 let defaultName = String(
                     localized: "category.recurring.default.name",
                     defaultValue: "Recurring Tasks"
                 )
-                let recurring = Category(
-                    categoryType: .custom,
-                    name: defaultName,
-                    iconName: "arrow.triangle.2.circlepath",
-                    orderIndex: nextOrderIndex,
-                    isUncategorized: false,
-                    isNameCustomized: true,
-                    isIconCustomized: true,
-                    isRecurring: true
+                let recurring = try makeRecurringDefaultCategory(
+                    allCategories: &allCategories,
+                    defaultName: defaultName
                 )
                 modelContext.insert(recurring)
+                try modelContext.save()
+            } else {
+                try repositionDefaultRecurringBeforeUncategorizedIfNeeded()
                 try modelContext.save()
             }
         } catch {
             print("Fehler bei Standard-Kategorien / wiederkehrender Default: \(error)")
         }
+    }
+
+    // MARK: - Recurring default placement (direkt vor „Unkategorisiert“)
+
+    private static let fallbackDefaultRecurringNames: Set<String> = [
+        "Recurring Tasks",
+        "Wiederkehrende Aufgaben"
+    ]
+
+    private func isLikelyDefaultRecurringCategory(_ category: Category) -> Bool {
+        guard category.isRecurring, category.categoryType == .custom else { return false }
+        let loc = String(
+            localized: "category.recurring.default.name",
+            defaultValue: "Recurring Tasks"
+        )
+        if category.name == loc { return true }
+        if Self.fallbackDefaultRecurringNames.contains(category.name) { return true }
+        return false
+    }
+
+    /// Jede Kategorie mit `orderIndex >= target` rückt um eins hoch, danach entsteht freier Slot ``target`` (Einfügen der wiederkehrenden Default-Kategorie).
+    private func shiftOrderIndicesUp(from target: Int, excluding: Category? = nil) {
+        let descriptor = FetchDescriptor<Category>()
+        guard let all = try? modelContext.fetch(descriptor) else { return }
+        for c in all where c.id != excluding?.id && c.orderIndex >= target {
+            c.orderIndex += 1
+        }
+    }
+
+    private func makeRecurringDefaultCategory(
+        allCategories: inout [Category],
+        defaultName: String
+    ) throws -> Category {
+        guard let uncat = getUncategorizedCategory() else {
+            let next = (allCategories.map(\.orderIndex).max() ?? -1) + 1
+            return Category(
+                categoryType: .custom,
+                name: defaultName,
+                iconName: "arrow.triangle.2.circlepath",
+                orderIndex: next,
+                isUncategorized: false,
+                isNameCustomized: true,
+                isIconCustomized: true,
+                isRecurring: true
+            )
+        }
+        let target = uncat.orderIndex
+        shiftOrderIndicesUp(from: target, excluding: nil)
+        return Category(
+            categoryType: .custom,
+            name: defaultName,
+            iconName: "arrow.triangle.2.circlepath",
+            orderIndex: target,
+            isUncategorized: false,
+            isNameCustomized: true,
+            isIconCustomized: true,
+            isRecurring: true
+        )
+    }
+
+    private static let recurringOrderMigratedKey = "DawnyMigratedRecurringDefaultBeforeUncategorizedV1"
+
+    /// Einmal: Standard-„Wiederkehrende Aufgaben“ (falls noch unter Unkategorisiert) vorschieben. Danach bleibt die manuelle Sortierung.
+    private func repositionDefaultRecurringBeforeUncategorizedIfNeeded() throws {
+        guard !UserDefaults.standard.bool(forKey: Self.recurringOrderMigratedKey) else { return }
+        defer { UserDefaults.standard.set(true, forKey: Self.recurringOrderMigratedKey) }
+
+        let descriptor = FetchDescriptor<Category>()
+        let all = try modelContext.fetch(descriptor)
+        guard let uncat = all.first(where: { $0.isUncategorized }) else { return }
+        let candidates = all.filter { isLikelyDefaultRecurringCategory($0) }
+        guard let rec = candidates.sorted(by: { $0.createdAt < $1.createdAt }).first else { return }
+
+        let sorted = all.sorted()
+        guard
+            let uncatIndex = sorted.firstIndex(where: { $0.id == uncat.id }),
+            let recIndex = sorted.firstIndex(where: { $0.id == rec.id })
+        else { return }
+
+        if recIndex < uncatIndex { return }
+
+        rec.orderIndex = 999_999
+        let target = uncat.orderIndex
+        for c in all where c.id != rec.id && c.orderIndex >= target {
+            c.orderIndex += 1
+        }
+        rec.orderIndex = target
     }
     
     /// Gibt die "Unkategorisiert"-Kategorie zurück

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -245,6 +245,47 @@ final class BacklogViewModel {
             errorMessage = String(format: format, error.localizedDescription)
         }
     }
+
+    /// Leert die angezeigte Backlog-Liste sofort, ohne Daten zu löschen.
+    /// Wichtig vor Debug-Massenlöschen, damit keine `TaskRowView` mehr auf
+    /// SwiftData-Tasks zeigt, die gleich getombstoned werden – sonst crasht
+    /// ein SwiftUI-Zwischenrender in `Task.status.getter`.
+    func clearTasksFromDisplayOnly() {
+        currentBacklog = nil
+        backlogs = []
+    }
+
+    /// Löscht *alle* Tasks aus sämtlichen Backlogs.
+    ///
+    /// Ablauf: Calendar-Sync **zuerst** (darf yielden), danach
+    /// `clearTasksFromDisplayOnly()` + Delete + `save()` in einem
+    /// **synchronen** Block (kein `await` dazwischen, damit SwiftUI nicht
+    /// mit tombstoned Task-Objekten rendert).
+    func deleteAllTasks() async {
+        do {
+            let descriptor = FetchDescriptor<Task>()
+            let allTasks = try modelContext.fetch(descriptor)
+
+            for task in allTasks where task.isSyncedToCalendar {
+                await syncEngine.removeTaskFromCalendar(task)
+            }
+
+            // --- Ab hier synchron: kein await, damit SwiftUI nicht dazwischenrendert ---
+            clearTasksFromDisplayOnly()
+
+            for task in allTasks {
+                modelContext.delete(task)
+            }
+
+            try modelContext.save()
+        } catch {
+            let format = String(
+                localized: "error.backlog.delete_task",
+                defaultValue: "Failed to delete task: %@"
+            )
+            errorMessage = String(format: format, error.localizedDescription)
+        }
+    }
     
     /// Markiert einen Task als abgeschlossen
     func completeTask(_ task: Task) async {
@@ -601,8 +642,9 @@ final class BacklogViewModel {
 
     /// Legt realistische Beispiel-Tasks im Backlog an (für manuelles UI-Testing).
     ///
-    /// Pro Kategorie werden 5 Beispiel-Tasks angelegt. Vier davon (die ersten beiden
-    /// aus *Quick* und *This Week*) werden zusätzlich direkt in den Heute-Tab gelegt,
+    /// Pro Kategorie werden 5 Beispiel-Tasks angelegt (bei wiederkehrenden Kategorien 3).
+    /// Vier davon (die ersten beiden aus *Quick* und *This Week*) werden zusätzlich direkt
+    /// in den Heute-Tab gelegt; bei wiederkehrenden Aufgaben eine Beispielaufgabe in *Heute*,
     /// damit der Heute-View ebenfalls vorgefüllt ist.
     func addDebugTestItems(settings: AppSettings) {
         loadCategories()
@@ -613,7 +655,12 @@ final class BacklogViewModel {
         let todayDate = Calendar.current.startOfDay(for: Date())
 
         for category in assignableCategories {
-            let items = Self.debugTestItems(for: category.categoryType)
+            let items: [DebugTestItem] = {
+                if category.isRecurring {
+                    return Self.recurringDebugTestItems()
+                }
+                return Self.debugTestItems(for: category.categoryType)
+            }()
             for item in items {
                 guard let task = addTask(title: item.title, category: category) else { continue }
                 if item.placeInToday {
@@ -762,5 +809,22 @@ final class BacklogViewModel {
         case .uncategorized, .custom:
             return []
         }
+    }
+
+    private static func recurringDebugTestItems() -> [DebugTestItem] {
+        [
+            DebugTestItem(
+                title: String(localized: "debug.testtask.recurring.1", defaultValue: "Brush teeth"),
+                placeInToday: true
+            ),
+            DebugTestItem(
+                title: String(localized: "debug.testtask.recurring.2", defaultValue: "Drink a glass of water"),
+                placeInToday: false
+            ),
+            DebugTestItem(
+                title: String(localized: "debug.testtask.recurring.3", defaultValue: "5 min stretch break"),
+                placeInToday: false
+            )
+        ]
     }
 }

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -485,11 +485,28 @@ final class BacklogViewModel {
         }
     }
 
+    /// Schaltet die Eigenschaft „wiederkehrend“ für eine Kategorie um.
+    @discardableResult
+    func toggleRecurring(_ category: Category) -> Bool {
+        do {
+            try categoryService.setRecurring(category, to: !category.isRecurring)
+            loadCategories()
+            HapticFeedback.success()
+            return true
+        } catch let error as CategoryEditError {
+            errorMessage = error.errorDescription
+            return false
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
     /// Legt eine neue benutzerdefinierte Kategorie an.
     @discardableResult
-    func createCategory(name: String) -> Category? {
+    func createCategory(name: String, isRecurring: Bool = false) -> Category? {
         do {
-            let category = try categoryService.createCustom(name: name)
+            let category = try categoryService.createCustom(name: name, isRecurring: isRecurring)
             loadCategories()
             HapticFeedback.success()
             return category

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -39,11 +39,19 @@ final class DailyFocusViewModel {
     
     // MARK: - Task Loading
     
-    /// Leert die angezeigte Liste sofort (z. B. vor Debug-Massenlöschen), damit kein `TaskRowView` noch auf Task-Objekte zeigt.
+    /// Leert die angezeigte Liste sofort (z. B. vor Debug-Massenlöschen), damit kein `TaskRowView` noch auf Task-Objekte zeigt.
     func clearTasksFromDisplayOnly() {
         dailyTasks = []
     }
     
+    /// Liefert einen frischen `Task` aus dem aktuellen Kontext (wichtig nach
+    /// Löschungen / Saves, damit kein abgelöstes `PersistentModel` verwendet wird).
+    private func task(withID id: UUID) -> Task? {
+        var descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+
     /// Lädt alle Daily Focus Tasks für heute
     func loadDailyTasks() {
         let descriptor = FetchDescriptor<Task>(
@@ -54,10 +62,8 @@ final class DailyFocusViewModel {
             let allTasks = try modelContext.fetch(descriptor)
             let settings = AppSettings.shared
             
-            // Filter: Aktive Daily Focus Tasks
             var tasks = allTasks.filter { $0.status == .dailyFocus }
             
-            // Füge erledigte Tasks hinzu, wenn Einstellung aktiviert ist
             if settings.showCompletedTasksInToday {
                 let completedToday = allTasks.filter { $0.isCompletedToday }
                 tasks.append(contentsOf: completedToday)
@@ -78,13 +84,8 @@ final class DailyFocusViewModel {
         isLoading = true
         defer { isLoading = false }
         
-        // Prüfe ob Reset nötig
         await resetEngine.checkAndPerformResetIfNeeded()
-        
-        // Sync mit Kalender
         await syncWithCalendar()
-        
-        // Reload Tasks
         loadDailyTasks()
     }
     
@@ -92,22 +93,32 @@ final class DailyFocusViewModel {
     
     /// Markiert einen Task als abgeschlossen
     func completeTask(_ task: Task) async {
-        let wasRecurring = task.isRecurring
+        await completeTask(taskID: task.id)
+    }
 
-        task.complete()
+    /// Wie `completeTask(_:)`, aber nur mit UUID – holt den Task immer frisch aus dem
+    /// `ModelContext` (vermeidet abgelöste Referenzen aus `ForEach`-Closures).
+    ///
+    /// Calendar-Sync erst **nach** `save()` + `loadDailyTasks()`, damit kein
+    /// `await`-Yield SwiftUI die Chance gibt, mit veralteten Referenzen zu rendern.
+    func completeTask(taskID: UUID) async {
+        guard let t = self.task(withID: taskID) else { return }
+        let wasRecurring = t.isRecurring
+
+        t.complete()
 
         if wasRecurring {
             let clone = Task(
-                title: task.title,
-                notes: task.notes,
+                title: t.title,
+                notes: t.notes,
                 status: .inBacklog,
-                parentBacklogID: task.parentBacklogID,
+                parentBacklogID: t.parentBacklogID,
                 sortPriority: Date(),
-                category: task.category
+                category: t.category
             )
-            clone.backlog = task.backlog
+            clone.backlog = t.backlog
             if clone.backlog == nil {
-                let parentID = task.parentBacklogID
+                let parentID = t.parentBacklogID
                 var backlogDescriptor = FetchDescriptor<Backlog>(predicate: #Predicate<Backlog> { $0.id == parentID })
                 backlogDescriptor.fetchLimit = 1
                 if let backlog = try? modelContext.fetch(backlogDescriptor).first {
@@ -115,13 +126,11 @@ final class DailyFocusViewModel {
                 }
             }
             modelContext.insert(clone)
-            task.recurringCloneID = clone.id
+            t.recurringCloneID = clone.id
         }
 
-        // Sync zu Kalender (Original; Clone ohne `externalReminderID`)
-        if task.isSyncedToCalendar {
-            await syncEngine.syncTaskToCalendar(task)
-        }
+        let needsCalendarSync = t.isSyncedToCalendar
+        let taskID = t.id
 
         do {
             try modelContext.save()
@@ -132,29 +141,38 @@ final class DailyFocusViewModel {
                 defaultValue: "Failed to complete task: %@"
             )
             errorMessage = String(format: format, error.localizedDescription)
-        }
-    }
-    
-    /// Markiert einen erledigten Task wieder als offen
-    func uncompleteTask(_ task: Task) async {
-        if let cloneID = task.recurringCloneID {
-            var cloneDescriptor = FetchDescriptor<Task>(predicate: #Predicate<Task> { $0.id == cloneID })
-            cloneDescriptor.fetchLimit = 1
-            if let clone = try? modelContext.fetch(cloneDescriptor).first {
-                modelContext.delete(clone)
-            }
-            task.recurringCloneID = nil
+            return
         }
 
+        if needsCalendarSync, let fresh = self.task(withID: taskID) {
+            await syncEngine.syncTaskToCalendar(fresh)
+        }
+    }
+
+    /// Markiert einen erledigten Task wieder als offen
+    func uncompleteTask(_ task: Task) async {
+        await uncompleteTask(taskID: task.id)
+    }
+
+    /// Erledigten Task wieder öffnen.
+    ///
+    /// Clone-Delete + Parent-Änderung in **einem** `save()`,
+    /// `loadDailyTasks()` **sofort** danach (kein `await` dazwischen).
+    /// Calendar-Sync erst NACH dem UI-Refresh.
+    func uncompleteTask(taskID: UUID) async {
+        guard let task = self.task(withID: taskID) else { return }
+
+        if let cloneID = task.recurringCloneID, let clone = self.task(withID: cloneID) {
+            modelContext.delete(clone)
+        }
+
+        task.recurringCloneID = nil
         task.isCompleted = false
         task.status = .dailyFocus
         task.modifiedAt = Date()
-        
-        // Sync zu Kalender falls vorher synchronisiert
-        if task.isSyncedToCalendar {
-            await syncEngine.syncTaskToCalendar(task)
-        }
-        
+
+        let needsCalendarSync = task.isSyncedToCalendar
+
         do {
             try modelContext.save()
             loadDailyTasks()
@@ -165,16 +183,19 @@ final class DailyFocusViewModel {
                 defaultValue: "Failed to reopen task: %@"
             )
             errorMessage = String(format: format, error.localizedDescription)
+            return
+        }
+
+        if needsCalendarSync, let fresh = self.task(withID: taskID) {
+            await syncEngine.syncTaskToCalendar(fresh)
         }
     }
     
     /// Entfernt einen Task aus Daily Focus zurück ins Backlog
     func removeFromDailyFocus(_ task: Task) async {
-        // Entferne aus Kalender
-        if task.isSyncedToCalendar {
-            await syncEngine.removeTaskFromCalendar(task)
-        }
-        
+        let needsCalendarRemove = task.isSyncedToCalendar
+        let taskID = task.id
+
         task.resetToBacklog()
         
         do {
@@ -186,6 +207,11 @@ final class DailyFocusViewModel {
                 defaultValue: "Failed to remove task from today: %@"
             )
             errorMessage = String(format: format, error.localizedDescription)
+            return
+        }
+
+        if needsCalendarRemove, let fresh = self.task(withID: taskID) {
+            await syncEngine.removeTaskFromCalendar(fresh)
         }
     }
     
@@ -281,28 +307,23 @@ final class DailyFocusViewModel {
     
     // MARK: - Computed Properties
     
-    /// Anzahl der noch offenen Tasks
     var openTaskCount: Int {
         dailyTasks.filter { !$0.isCompleted }.count
     }
     
-    /// Anzahl der abgeschlossenen Tasks
     var completedTaskCount: Int {
         dailyTasks.filter { $0.isCompleted }.count
     }
     
-    /// Fortschritt in Prozent
     var progressPercentage: Double {
         guard !dailyTasks.isEmpty else { return 0 }
         return Double(completedTaskCount) / Double(dailyTasks.count)
     }
     
-    /// Offene Tasks
     var openTasks: [Task] {
         dailyTasks.filter { !$0.isCompleted }
     }
     
-    /// Abgeschlossene Tasks
     var completedTasks: [Task] {
         dailyTasks.filter { $0.isCompleted }
     }

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -92,13 +92,37 @@ final class DailyFocusViewModel {
     
     /// Markiert einen Task als abgeschlossen
     func completeTask(_ task: Task) async {
+        let wasRecurring = task.isRecurring
+
         task.complete()
-        
-        // Sync zu Kalender
+
+        if wasRecurring {
+            let clone = Task(
+                title: task.title,
+                notes: task.notes,
+                status: .inBacklog,
+                parentBacklogID: task.parentBacklogID,
+                sortPriority: Date(),
+                category: task.category
+            )
+            clone.backlog = task.backlog
+            if clone.backlog == nil {
+                let parentID = task.parentBacklogID
+                var backlogDescriptor = FetchDescriptor<Backlog>(predicate: #Predicate<Backlog> { $0.id == parentID })
+                backlogDescriptor.fetchLimit = 1
+                if let backlog = try? modelContext.fetch(backlogDescriptor).first {
+                    clone.backlog = backlog
+                }
+            }
+            modelContext.insert(clone)
+            task.recurringCloneID = clone.id
+        }
+
+        // Sync zu Kalender (Original; Clone ohne `externalReminderID`)
         if task.isSyncedToCalendar {
             await syncEngine.syncTaskToCalendar(task)
         }
-        
+
         do {
             try modelContext.save()
             loadDailyTasks()
@@ -113,6 +137,15 @@ final class DailyFocusViewModel {
     
     /// Markiert einen erledigten Task wieder als offen
     func uncompleteTask(_ task: Task) async {
+        if let cloneID = task.recurringCloneID {
+            var cloneDescriptor = FetchDescriptor<Task>(predicate: #Predicate<Task> { $0.id == cloneID })
+            cloneDescriptor.fetchLimit = 1
+            if let clone = try? modelContext.fetch(cloneDescriptor).first {
+                modelContext.delete(clone)
+            }
+            task.recurringCloneID = nil
+        }
+
         task.isCompleted = false
         task.status = .dailyFocus
         task.modifiedAt = Date()

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -58,7 +58,10 @@ struct BacklogView: View {
                 CategoryActionMenu(
                     actionsCategory: $actionsCategory,
                     onEdit: { category in beginRenaming(category) },
-                    onDelete: { category in requestDelete(category) }
+                    onDelete: { category in requestDelete(category) },
+                    onToggleRecurring: { category in
+                        _ = viewModel.toggleRecurring(category)
+                    }
                 )
             )
             .modifier(
@@ -154,8 +157,8 @@ struct BacklogView: View {
             }
 
             Section {
-                AddCategoryRow { name in
-                    if let created = viewModel.createCategory(name: name) {
+                AddCategoryRow { name, isRecurring in
+                    if let created = viewModel.createCategory(name: name, isRecurring: isRecurring) {
                         expandedCategories.insert(created.id)
                     }
                 }
@@ -276,6 +279,7 @@ struct BacklogView: View {
                 }
             },
             showBacklogBadge: false,
+            showRecurringTaskBadge: false,
             showsDisabledToggle: true,
             focusedTaskID: $focusedTaskID,
             onSaveTitle: { newTitle in
@@ -311,6 +315,7 @@ struct BacklogView: View {
                 }
             },
             showBacklogBadge: false,
+            showRecurringTaskBadge: false,
             showsDisabledToggle: true,
             focusedTaskID: $focusedTaskID,
             onSaveTitle: { newTitle in
@@ -477,6 +482,7 @@ private struct CategoryActionMenu: ViewModifier {
     @Binding var actionsCategory: Category?
     let onEdit: (Category) -> Void
     let onDelete: (Category) -> Void
+    let onToggleRecurring: (Category) -> Void
 
     func body(content: Content) -> some View {
         content.confirmationDialog(
@@ -493,6 +499,27 @@ private struct CategoryActionMenu: ViewModifier {
                     )
                 ) {
                     onEdit(category)
+                }
+            }
+            if category.canToggleRecurring {
+                Button {
+                    onToggleRecurring(category)
+                } label: {
+                    if category.isRecurring {
+                        Text(
+                            String(
+                                localized: "category.action.unmakeRecurring",
+                                defaultValue: "Remove recurring"
+                            )
+                        )
+                    } else {
+                        Text(
+                            String(
+                                localized: "category.action.makeRecurring",
+                                defaultValue: "Mark as recurring"
+                            )
+                        )
+                    }
                 }
             }
             if category.canDelete {

--- a/App/Sources/Views/Components/AddCategoryRow.swift
+++ b/App/Sources/Views/Components/AddCategoryRow.swift
@@ -12,10 +12,11 @@
 import SwiftUI
 
 struct AddCategoryRow: View {
-    let onCreate: (String) -> Void
+    let onCreate: (String, Bool) -> Void
 
     @State private var isEditing = false
     @State private var draft = ""
+    @State private var isRecurring = false
     @FocusState private var isFocused: Bool
 
     private let maxLength = CategoryService.maxNameLength
@@ -60,6 +61,7 @@ struct AddCategoryRow: View {
         .onTapGesture {
             isEditing = true
             draft = ""
+            isRecurring = false
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
@@ -70,14 +72,24 @@ struct AddCategoryRow: View {
 
     private var activeRow: some View {
         HStack(spacing: 8) {
-            Image(systemName: "tag")
-                .font(.subheadline)
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 28, height: 28)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color.accentColor.opacity(0.15))
-                )
+            Button {
+                isRecurring.toggle()
+                HapticFeedback.light()
+            } label: {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.subheadline)
+                    .foregroundStyle(isRecurring ? Color.accentColor : Color.secondary)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(isRecurring ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.1))
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+                String(localized: "category.add.recurringToggle", defaultValue: "Recurring")
+            )
+            .accessibilityAddTraits(isRecurring ? .isSelected : [])
 
             TextField(placeholder, text: $draft)
                 .font(.headline)
@@ -120,18 +132,20 @@ struct AddCategoryRow: View {
             HapticFeedback.error()
             return
         }
-        onCreate(trimmed)
+        onCreate(trimmed, isRecurring)
         resetAfterCreate()
     }
 
     private func cancel() {
         draft = ""
+        isRecurring = false
         isEditing = false
     }
 
     /// Zuerst `draft` leeren, dann Fokus entfernen – sonst feuert `onChange` noch mit altem Text und legt doppelt an.
     private func resetAfterCreate() {
         draft = ""
+        isRecurring = false
         isFocused = false
         isEditing = false
     }

--- a/App/Sources/Views/Components/CategoryHeaderView.swift
+++ b/App/Sources/Views/Components/CategoryHeaderView.swift
@@ -45,9 +45,22 @@ struct CategoryHeaderView: View {
                     onCancel: onCancelRename
                 )
             } else {
-                Text(category.displayName)
-                    .font(.headline)
-                    .foregroundColor(.primary)
+                HStack(spacing: 6) {
+                    Text(category.displayName)
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                    if category.isRecurring {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .accessibilityLabel(
+                                String(
+                                    localized: "task.recurring.badge",
+                                    defaultValue: "Recurring"
+                                )
+                            )
+                    }
+                }
             }
 
             Spacer()

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
     @Bindable private var settings: AppSettings = .shared
     #if DEBUG
     @State private var showingClearAllConfirm = false
+    @State private var listContentRemount = 0
     #endif
 
     private var clearAllAction: (() -> Void)? {
@@ -69,6 +70,11 @@ struct ContentView: View {
                     }
                 }
             )
+            // DEBUG: Wird mit `listContentRemount` erhöht, damit Listen/Zellen nach
+            // Massenlöschung wirklich neu entstehen (keine hängenden SwiftData-Referenzen).
+            #if DEBUG
+            .id(listContentRemount)
+            #endif
             .ignoresSafeArea(.keyboard, edges: .bottom)
         }
         .environment(\.triggerWelcomeFlow) {
@@ -197,23 +203,20 @@ struct ContentView: View {
     private func clearAllBacklogTasks() async {
         #if DEBUG
         guard let backlogVM = backlogViewModel else { return }
-        let backlogTasks = backlogVM.backlogTasks
-        let todayTasks = dailyFocusViewModel?.dailyTasks ?? []
 
+        // DailyFocus-Display SOFORT leeren – innerhalb deleteAllTasks()
+        // wird auch clearTasksFromDisplayOnly() für den BacklogVM aufgerufen,
+        // beides SYNCHRON VOR dem save(), damit kein SwiftUI-Render mit
+        // tombstoned Tasks passiert.
         dailyFocusViewModel?.clearTasksFromDisplayOnly()
 
-        for task in backlogTasks {
-            await backlogVM.deleteTask(task)
-        }
+        // Calendar-Sync (darf yielden) + synchroner Delete-Block.
+        await backlogVM.deleteAllTasks()
 
-        if let dfvm = dailyFocusViewModel {
-            for task in todayTasks {
-                await dfvm.deleteTask(task)
-            }
-        }
-
+        listContentRemount += 1
         backlogVM.loadBacklogs()
         backlogVM.loadCategories()
+        dailyFocusViewModel?.loadDailyTasks()
         #endif
     }
 

--- a/App/Sources/Views/DailyFocusView.swift
+++ b/App/Sources/Views/DailyFocusView.swift
@@ -92,8 +92,9 @@ struct DailyFocusView: View {
                         TaskRowView(
                             task: task,
                             onToggle: {
+                                let taskID = task.id
                                 _Concurrency.Task {
-                                    await viewModel.uncompleteTask(task)
+                                    await viewModel.uncompleteTask(taskID: taskID)
                                 }
                             },
                             onDelete: nil,
@@ -118,8 +119,9 @@ struct DailyFocusView: View {
         TaskRowView(
             task: task,
             onToggle: {
+                let taskID = task.id
                 _Concurrency.Task {
-                    await viewModel.completeTask(task)
+                    await viewModel.completeTask(taskID: taskID)
                 }
             },
             onDelete: nil,

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -17,6 +17,8 @@ struct TaskRowView: View {
     let onDelete: (() -> Void)?
     let showDragHandle: Bool
     let showBacklogBadge: Bool
+    /// Wenn `false`, kein „wiederkehrend“-Symbol in der Zeile (z. B. Backlog – Kategorie zeigt es im Header).
+    let showRecurringTaskBadge: Bool
     let showsDisabledToggle: Bool
     @Binding var focusedTaskID: UUID?
     let onSaveTitle: ((String) -> Void)?
@@ -31,6 +33,7 @@ struct TaskRowView: View {
         onDelete: (() -> Void)? = nil,
         showDragHandle: Bool = false,
         showBacklogBadge: Bool = true,
+        showRecurringTaskBadge: Bool = true,
         showsDisabledToggle: Bool = false,
         focusedTaskID: Binding<UUID?> = .constant(nil),
         onSaveTitle: ((String) -> Void)? = nil
@@ -40,6 +43,7 @@ struct TaskRowView: View {
         self.onDelete = onDelete
         self.showDragHandle = showDragHandle
         self.showBacklogBadge = showBacklogBadge
+        self.showRecurringTaskBadge = showRecurringTaskBadge
         self.showsDisabledToggle = showsDisabledToggle
         _focusedTaskID = focusedTaskID
         self.onSaveTitle = onSaveTitle
@@ -152,6 +156,18 @@ struct TaskRowView: View {
                         Label(String(localized: "task.calendar.badge", defaultValue: "Calendar"), systemImage: "calendar")
                             .font(.caption2)
                             .foregroundStyle(.blue)
+                    }
+
+                    if task.isRecurring, showRecurringTaskBadge {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel(
+                                String(
+                                    localized: "task.recurring.badge",
+                                    defaultValue: "Recurring"
+                                )
+                            )
                     }
                     
                     if shouldShowStatusBadge {
@@ -275,7 +291,9 @@ struct TaskRowView: View {
     
     /// Sollten Badges angezeigt werden?
     private var shouldShowBadges: Bool {
-        !task.isCompleted || task.isSyncedToCalendar
+        !task.isCompleted
+            || task.isSyncedToCalendar
+            || (task.isRecurring && showRecurringTaskBadge)
     }
 }
 

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -10,7 +10,11 @@
 //
 
 import SwiftUI
+import SwiftData
 
+/// Zeilen-Wrapper: löst `Task` über `ModelContext.registeredModel` auf. So wird nie auf ein
+/// SwiftData-Objekt gelesen, das bereits aus dem Kontext getrennt ist (Fatal:
+/// "backing data was detached …" / `Task.status`-Getter).
 struct TaskRowView: View {
     let task: Task
     let onToggle: (() -> Void)?
@@ -22,11 +26,9 @@ struct TaskRowView: View {
     let showsDisabledToggle: Bool
     @Binding var focusedTaskID: UUID?
     let onSaveTitle: ((String) -> Void)?
-    
-    @State private var showingDetail = false
-    @State private var titleDraft: String = ""
-    @FocusState private var isTitleFieldFocused: Bool
-    
+
+    @Environment(\.modelContext) private var modelContext
+
     init(
         task: Task,
         onToggle: (() -> Void)? = nil,
@@ -48,9 +50,92 @@ struct TaskRowView: View {
         _focusedTaskID = focusedTaskID
         self.onSaveTitle = onSaveTitle
     }
-    
+
     var body: some View {
-        let rowStack = HStack(spacing: horizontalSpacing) {
+        if let resolved: Task = modelContext.registeredModel(for: task.persistentModelID),
+           resolved.modelContext != nil,
+           !resolved.isDeleted {
+            TaskRowContent(
+                task: resolved,
+                onToggle: onToggle,
+                onDelete: onDelete,
+                showDragHandle: showDragHandle,
+                showBacklogBadge: showBacklogBadge,
+                showRecurringTaskBadge: showRecurringTaskBadge,
+                showsDisabledToggle: showsDisabledToggle,
+                focusedTaskID: $focusedTaskID,
+                onSaveTitle: onSaveTitle
+            )
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Row content (gültiger SwiftData-`Task`)
+
+private struct TaskRowContent: View {
+    let task: Task
+    let onToggle: (() -> Void)?
+    let onDelete: (() -> Void)?
+    let showDragHandle: Bool
+    let showBacklogBadge: Bool
+    let showRecurringTaskBadge: Bool
+    let showsDisabledToggle: Bool
+    @Binding var focusedTaskID: UUID?
+    let onSaveTitle: ((String) -> Void)?
+
+    @State private var showingDetail = false
+    @State private var titleDraft: String = ""
+    @FocusState private var isTitleFieldFocused: Bool
+
+    init(
+        task: Task,
+        onToggle: (() -> Void)? = nil,
+        onDelete: (() -> Void)? = nil,
+        showDragHandle: Bool = false,
+        showBacklogBadge: Bool = true,
+        showRecurringTaskBadge: Bool = true,
+        showsDisabledToggle: Bool = false,
+        focusedTaskID: Binding<UUID?> = .constant(nil),
+        onSaveTitle: ((String) -> Void)? = nil
+    ) {
+        self.task = task
+        self.onToggle = onToggle
+        self.onDelete = onDelete
+        self.showDragHandle = showDragHandle
+        self.showBacklogBadge = showBacklogBadge
+        self.showRecurringTaskBadge = showRecurringTaskBadge
+        self.showsDisabledToggle = showsDisabledToggle
+        _focusedTaskID = focusedTaskID
+        self.onSaveTitle = onSaveTitle
+    }
+
+    var body: some View {
+        // Defensive Guard: SwiftUI kann `TaskRowContent.body` direkt erneut auslösen
+        // (Observation-Event auf `task`), ohne dass `TaskRowView.body` erneut läuft.
+        // Der hier gehaltene `let task: Task` kann dann auf ein Objekt zeigen, dessen
+        // SwiftData-Backing bereits detached ist → Zugriff auf `task.status` etc.
+        // crasht („backing data was detached"). `modelContext` / `isDeleted` zu lesen
+        // ist dagegen safe und liefert `nil`/`false` bei detachedem Backing.
+        if task.modelContext != nil, !task.isDeleted {
+            return AnyView(liveRow)
+        } else {
+            return AnyView(EmptyView())
+        }
+    }
+
+    private var liveRow: some View {
+        return buildRowStack()
+            .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
+            .modifier(TrailingSwipeDeleteModifier(onDelete: onDelete))
+            .sheet(isPresented: $showingDetail) {
+                TaskDetailView(task: task)
+            }
+    }
+
+    private func buildRowStack() -> some View {
+        HStack(spacing: horizontalSpacing) {
             // Drag Handle
             if showDragHandle {
                 Image(systemName: "line.3.horizontal")
@@ -106,15 +191,8 @@ struct TaskRowView: View {
                 }
             }
         }
-        
-        rowStack
-            .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
-            .modifier(TrailingSwipeDeleteModifier(onDelete: onDelete))
-        .sheet(isPresented: $showingDetail) {
-            TaskDetailView(task: task)
-        }
     }
-    
+
     @ViewBuilder
     private var titleAndMetaColumn: some View {
         let column = VStack(alignment: .leading, spacing: contentSpacing) {
@@ -323,28 +401,39 @@ private struct TrailingSwipeDeleteModifier: ViewModifier {
 
 struct TaskDetailView: View {
     let task: Task
+    @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
-    
+
     var body: some View {
+        if let resolved: Task = modelContext.registeredModel(for: task.persistentModelID) {
+            detailList(for: resolved)
+        } else {
+            Color.clear
+                .onAppear { dismiss() }
+        }
+    }
+
+    @ViewBuilder
+    private func detailList(for task: Task) -> some View {
         NavigationStack {
             List {
                 Section(String(localized: "task.detail.section", defaultValue: "Details")) {
                     LabeledContent(String(localized: "task.detail.title.label", defaultValue: "Title"), value: task.title)
-                    
+
                     if let notes = task.notes {
                         LabeledContent(String(localized: "task.detail.notes.label", defaultValue: "Notes")) {
                             Text(notes)
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    
+
                     LabeledContent(String(localized: "task.detail.status.label", defaultValue: "Status"), value: task.status.displayName)
-                    
+
                     if task.isSyncedToCalendar {
                         LabeledContent(String(localized: "task.detail.calendar.label", defaultValue: "Calendar"), value: String(localized: "task.detail.calendar.synced", defaultValue: "Synced"))
                     }
                 }
-                
+
                 Section(String(localized: "task.detail.timestamps.section", defaultValue: "Timestamps")) {
                     LabeledContent(String(localized: "task.detail.created.label", defaultValue: "Created"), value: task.createdAt.formatted(date: .abbreviated, time: .shortened))
                     LabeledContent(String(localized: "task.detail.modified.label", defaultValue: "Modified"), value: task.modifiedAt.formatted(date: .abbreviated, time: .shortened))
@@ -364,18 +453,27 @@ struct TaskDetailView: View {
 }
 
 #Preview {
+    let schema = Schema([Task.self, Backlog.self, Category.self])
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    let container = try! ModelContainer(for: schema, configurations: [configuration])
+    let backlog = Backlog(title: "Preview", orderIndex: 0)
     let task = Task(
         title: "Sample Task",
         notes: "This is a sample task with some notes",
         status: .dailyFocus,
-        parentBacklogID: UUID()
+        parentBacklogID: backlog.id
     )
-    
-    TaskRowView(
+    task.backlog = backlog
+    container.mainContext.insert(backlog)
+    container.mainContext.insert(task)
+    try? container.mainContext.save()
+
+    return TaskRowView(
         task: task,
         onToggle: {},
         onDelete: {},
         showDragHandle: true
     )
+    .modelContainer(container)
     .padding()
 }

--- a/Dawny.xcodeproj/project.pbxproj
+++ b/Dawny.xcodeproj/project.pbxproj
@@ -414,9 +414,9 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_SECURITY_COMPILER_WARNINGS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = Flo.Dawny.reset;
 				INFOPLIST_KEY_CFBundleDisplayName = Dawny;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "Dawny syncs your daily focus tasks with Apple Reminders.";
 				INFOPLIST_KEY_NSSiriUsageDescription = "Dawny lets you add tasks hands-free with Siri.";
@@ -457,9 +457,9 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_SECURITY_COMPILER_WARNINGS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = Flo.Dawny.reset;
 				INFOPLIST_KEY_CFBundleDisplayName = Dawny;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "Dawny syncs your daily focus tasks with Apple Reminders.";
 				INFOPLIST_KEY_NSSiriUsageDescription = "Dawny lets you add tasks hands-free with Siri.";

--- a/DawnyTests/Models/TaskModelTests.swift
+++ b/DawnyTests/Models/TaskModelTests.swift
@@ -170,4 +170,5 @@ final class TaskModelTests: XCTestCase {
         XCTAssertEqual(task.status, .scheduled)
         XCTAssertEqual(task.scheduledDate, futureDate)
     }
+
 }

--- a/DawnyTests/Services/CategoryServiceTests.swift
+++ b/DawnyTests/Services/CategoryServiceTests.swift
@@ -250,18 +250,62 @@ final class CategoryServiceTests: XCTestCase {
         XCTAssertFalse(uncat.canRename)
         XCTAssertFalse(uncat.canChangeIcon)
         XCTAssertFalse(uncat.canDelete)
+        XCTAssertFalse(uncat.canToggleRecurring)
         XCTAssertFalse(uncat.hasAnyEditCapability)
 
         let quick = try category(.quick)
         XCTAssertTrue(quick.canRename)
         XCTAssertTrue(quick.canChangeIcon)
         XCTAssertFalse(quick.canDelete)
+        XCTAssertTrue(quick.canToggleRecurring)
         XCTAssertTrue(quick.hasAnyEditCapability)
 
         let week = try category(.thisWeek)
         XCTAssertTrue(week.canRename)
         XCTAssertTrue(week.canChangeIcon)
         XCTAssertTrue(week.canDelete)
+        XCTAssertTrue(week.canToggleRecurring)
         XCTAssertTrue(week.hasAnyEditCapability)
+    }
+
+    // MARK: - Recurring
+
+    func testDefaultRecurringCategoryIsCreated() throws {
+        let recurring = service.getCategoriesSorted().filter(\.isRecurring)
+        XCTAssertEqual(recurring.count, 1, "Eine vorgebaute wiederkehrende Kategorie")
+        XCTAssertEqual(recurring[0].categoryType, .custom)
+    }
+
+    func testCreateCustomRecurringSetsIconAndFlag() throws {
+        let _ = try service.createCustom(name: "Habit", isRecurring: true)
+        let all = try context.fetch(FetchDescriptor<Dawny.Category>())
+        let habit = try XCTUnwrap(all.first { $0.name == "Habit" })
+        XCTAssertTrue(habit.isRecurring)
+        XCTAssertEqual(habit.displayIconName, "arrow.triangle.2.circlepath")
+    }
+
+    func testSetRecurringToggle() throws {
+        let cat = try category(.thisMonth)
+        XCTAssertFalse(cat.isRecurring)
+        try service.setRecurring(cat, to: true)
+        XCTAssertTrue(cat.isRecurring)
+        try service.setRecurring(cat, to: false)
+        XCTAssertFalse(cat.isRecurring)
+    }
+
+    func testSetRecurringUncategorizedThrows() throws {
+        let cat = try category(.uncategorized)
+        XCTAssertThrowsError(try service.setRecurring(cat, to: true)) { err in
+            guard case CategoryEditError.protectedFromRecurring = err else {
+                return XCTFail("Erwartet .protectedFromRecurring, war \(err)")
+            }
+        }
+    }
+
+    func testInitializeDefaultCategoriesRecurringIdempotent() throws {
+        let before = try context.fetch(FetchDescriptor<Dawny.Category>()).count
+        service.initializeDefaultCategories()
+        let after = try context.fetch(FetchDescriptor<Dawny.Category>()).count
+        XCTAssertEqual(before, after, "Zweiter Aufruf legt keine Duplikate an")
     }
 }

--- a/DawnyTests/Services/CategoryServiceTests.swift
+++ b/DawnyTests/Services/CategoryServiceTests.swift
@@ -24,6 +24,9 @@ final class CategoryServiceTests: XCTestCase {
     private var originalDefaultCategoryType: TaskCategory!
 
     override func setUp() async throws {
+        UserDefaults.standard.removeObject(
+            forKey: "DawnyMigratedRecurringDefaultBeforeUncategorizedV1"
+        )
         container = try TestModelContainer.create()
         context = container.mainContext
         service = CategoryService(modelContext: context)
@@ -274,6 +277,19 @@ final class CategoryServiceTests: XCTestCase {
         let recurring = service.getCategoriesSorted().filter(\.isRecurring)
         XCTAssertEqual(recurring.count, 1, "Eine vorgebaute wiederkehrende Kategorie")
         XCTAssertEqual(recurring[0].categoryType, .custom)
+    }
+
+    func testRecurringDefaultPlacedBeforeUncategorized() throws {
+        let uncat = try category(.uncategorized)
+        let rec = try XCTUnwrap(
+            service.getCategoriesSorted().first(where: { $0.isRecurring })
+        )
+        XCTAssertLessThan(rec.orderIndex, uncat.orderIndex, "Wiederkehrende Aufgaben unmittelbar vor Unkategorisiert (orderIndex)")
+
+        let order = service.getCategoriesSorted()
+        let rIdx = try XCTUnwrap(order.firstIndex(where: { $0.id == rec.id }))
+        let uIdx = try XCTUnwrap(order.firstIndex(where: { $0.id == uncat.id }))
+        XCTAssertLessThan(rIdx, uIdx, "Kategorie-Liste: wiederkehrend vor Unkategorisiert")
     }
 
     func testCreateCustomRecurringSetsIconAndFlag() throws {

--- a/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
+++ b/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
@@ -1,0 +1,153 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  DailyFocusRecurringTests.swift
+//  DawnyTests
+//
+//  Wiederkehrend: Complete erzeugt Backlog-Clone, Uncomplete entfernt ihn.
+//
+
+import XCTest
+import SwiftData
+@testable import Dawny
+
+@MainActor
+final class DailyFocusRecurringTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var syncEngine: SyncEngine!
+    var resetEngine: ResetEngine!
+    var timeProvider: MockTimeProvider!
+    var originalCalendarEnabled: Bool!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalCalendarEnabled = AppSettings.shared.calendarSyncEnabled
+        AppSettings.shared.calendarSyncEnabled = false
+        timeProvider = MockTimeProvider()
+        container = try TestModelContainer.create()
+        context = container.mainContext
+        let calendarService = MockCalendarService()
+        syncEngine = SyncEngine(calendarService: calendarService, modelContext: context)
+        resetEngine = ResetEngine(timeProvider: timeProvider, modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        AppSettings.shared.calendarSyncEnabled = originalCalendarEnabled
+        container = nil
+        context = nil
+        syncEngine = nil
+        resetEngine = nil
+        timeProvider = nil
+        try await super.tearDown()
+    }
+
+    private func recurringCategory() throws -> Dawny.Category {
+        let service = CategoryService(modelContext: context)
+        service.initializeDefaultCategories()
+        let rec = try XCTUnwrap(
+            service.getCategoriesSorted().first(where: { $0.isRecurring }),
+            "Wiederkehrend-Default Kategorie"
+        )
+        return rec
+    }
+
+    func testCompleteRecurringCreatesBacklogClone() async throws {
+        let vm = DailyFocusViewModel(
+            modelContext: context,
+            syncEngine: syncEngine,
+            resetEngine: resetEngine
+        )
+        let recurring = try recurringCategory()
+        let backlog = TestModelContainer.createBacklog(in: context, title: "B")
+        let task = backlog.addTask(title: "R1")
+        task.category = recurring
+        let today = Calendar.current.startOfDay(for: Date())
+        task.moveToDailyFocus(date: today)
+        try context.save()
+
+        await vm.completeTask(task)
+
+        let all = try context.fetch(FetchDescriptor<Task>())
+        XCTAssertEqual(all.count, 2)
+        let completed = all.filter { $0.status == .completed }
+        let backlogs = all.filter { $0.status == .inBacklog }
+        XCTAssertEqual(completed.count, 1)
+        XCTAssertEqual(completed[0].id, task.id)
+        XCTAssertEqual(backlogs.count, 1)
+        XCTAssertEqual(backlogs[0].title, "R1")
+        XCTAssertNil(backlogs[0].externalReminderID, "Clone ohne Kalender-Reminder")
+        XCTAssertEqual(task.recurringCloneID, backlogs[0].id)
+    }
+
+    func testUncompleteRecurringRemovesClone() async throws {
+        let vm = DailyFocusViewModel(
+            modelContext: context,
+            syncEngine: syncEngine,
+            resetEngine: resetEngine
+        )
+        let recurring = try recurringCategory()
+        let backlog = TestModelContainer.createBacklog(in: context, title: "B2")
+        let task = backlog.addTask(title: "R2")
+        task.category = recurring
+        task.moveToDailyFocus(date: Calendar.current.startOfDay(for: Date()))
+        try context.save()
+
+        await vm.completeTask(task)
+        XCTAssertNotNil(task.recurringCloneID)
+
+        await vm.uncompleteTask(task)
+
+        let all = try context.fetch(FetchDescriptor<Task>())
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all[0].id, task.id)
+        XCTAssertEqual(task.status, .dailyFocus)
+        XCTAssertFalse(task.isCompleted)
+        XCTAssertNil(task.recurringCloneID)
+    }
+
+    func testDoubleCompleteRecurringYieldsTwoCompletedEntries() async throws {
+        let vm = DailyFocusViewModel(
+            modelContext: context,
+            syncEngine: syncEngine,
+            resetEngine: resetEngine
+        )
+        let recurring = try recurringCategory()
+        let backlog = TestModelContainer.createBacklog(in: context, title: "B3")
+        let t1 = backlog.addTask(title: "Doppelt")
+        t1.category = recurring
+        t1.moveToDailyFocus(date: Calendar.current.startOfDay(for: Date()))
+        try context.save()
+
+        await vm.completeTask(t1)
+        var clone1 = try XCTUnwrap(try findTask(id: t1.recurringCloneID!))
+        clone1.moveToDailyFocus(date: Calendar.current.startOfDay(for: Date()))
+        try context.save()
+
+        await vm.completeTask(clone1)
+
+        let all = try context.fetch(FetchDescriptor<Task>())
+        XCTAssertEqual(all.filter { $0.status == .completed }.count, 2)
+        XCTAssertEqual(all.filter { $0.status == .inBacklog }.count, 1)
+    }
+
+    private func findTask(id: UUID) throws -> Task? {
+        var d = FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })
+        d.fetchLimit = 1
+        return try context.fetch(d).first
+    }
+
+    /// `Task.isRecurring` leitet von `Category.isRecurring` ab
+    func testTaskIsRecurringInheritsFromCategory() throws {
+        let rec = try recurringCategory()
+        let backlog = TestModelContainer.createBacklog(in: context, title: "B-inherit")
+        let task = backlog.addTask(title: "T")
+        task.category = rec
+        XCTAssertTrue(task.isRecurring)
+        task.category = nil
+        XCTAssertFalse(task.isRecurring)
+    }
+}

--- a/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
+++ b/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
@@ -25,6 +25,9 @@ final class DailyFocusRecurringTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        UserDefaults.standard.removeObject(
+            forKey: "DawnyMigratedRecurringDefaultBeforeUncategorizedV1"
+        )
         originalCalendarEnabled = AppSettings.shared.calendarSyncEnabled
         AppSettings.shared.calendarSyncEnabled = false
         timeProvider = MockTimeProvider()

--- a/DawnyUITests/DawnyUITests.swift
+++ b/DawnyUITests/DawnyUITests.swift
@@ -187,6 +187,20 @@ final class DawnyUITests: XCTestCase {
         // Quick-Entry: nicht `firstMatch` — kann off-screen sein; erst sichtbaren Eintrag wählen / scrollen.
         tapVisibleQuickAddInBacklog()
     }
+
+    /// Standard-Kategorie „Recurring Tasks“ (EN) erscheint im Backlog (laut Default-`initializeDefaultCategories`)
+    func testRecurringDefaultCategoryVisibleInBacklog() throws {
+        dismissWelcomeIfShown()
+        XCTAssertTrue(app.buttons["Backlog"].waitForExistence(timeout: 5))
+        app.buttons["Backlog"].tap()
+        for _ in 0..<12 {
+            if app.staticTexts["Recurring Tasks"].firstMatch.exists {
+                return
+            }
+            scrollHostForBacklog().swipeUp()
+        }
+        XCTFail("Kategorie 'Recurring Tasks' nicht sichtbar")
+    }
     
     func testShowWelcomeFromSettingsHelpButton() throws {
         throw XCTSkip("Temporär deaktiviert wegen instabilem Simulator-/UI-Test-Verhalten in CI.")


### PR DESCRIPTION
## Was war kaputt?

- **Heute:** Erledigte **wiederkehrende** Aufgabe wieder **offen** machen → Absturz.
- **Debug:** **Alle Aufgaben löschen** → Absturz.

## Warum?

SwiftData und SwiftUI aktualisieren sich nicht immer im gleichen Schritt.
Manchmal zeigte die UI noch eine **alte Referenz** auf eine Aufgabe, deren
technische Verbindung zur Datenbank schon weg war – ein Zugriff auf
Eigenschaften der Aufgabe führte dann zum Crash.

## Was haben wir geändert?

- **Aufgabenzeile & Detail:** Vor dem Rendern prüfen wir, ob die Aufgabe im
  aktuellen **ModelContext** noch valide ist (`modelContext` / gelöscht);
  sonst wird die Zeile bzw. die Detailansicht leer bzw. geschlossen.
- **Heute (ViewModel):** Speichern, Liste neu laden und Kalender-Sync (falls
  nötig) sind so **geordnet**, dass kein langes `await` die UI mitten in
  einer Zustandsänderung „hängen“ lässt; wiederkehrender Clone und Parent
  werden in **einem** Speichervorgang bearbeitet.
- **Alles löschen (Debug):** Zuerst Kalendereinträge, dann Anzeigen leeren,
  **ein** Löschvorgang mit **einem** `save()`.
- **Backlog & Kategorien:** In Zählungen/Listen tauchen **nur** Aufgaben auf,
  die nicht als gelöscht markiert sind, damit keine toten Beziehungen
  Probleme machen.