### PR TITLE
Make it count

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -11776,13 +11776,13 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Das ist eines der Kern-Features von Dawny. Tasks, die wiederholt nicht erledigt werden, werden archiviert, damit dein Backlog fokussiert und bedeutsam bleibt. Es kann nicht deaktiviert werden."
+            "value" : "Das ist eines der Kern-Features von Dawny. Tasks, die nicht erledigt werden, werden archiviert, damit dein Backlog fokussiert und bedeutsam bleibt.\n\nDaher kann Make it count in Dawny nicht deaktiviert werden."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This is one of Dawny's core features. Tasks that are repeatedly not completed are archived so your backlog stays focused and meaningful. It can't be turned off."
+            "value" : "This is one of Dawny's core features. Tasks that are not completed are archived so your backlog stays focused and meaningful.\n\nTherefore, Make it count cannot be disabled in Dawny."
           }
         }
       }
@@ -11801,6 +11801,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Make it count is essential"
+          }
+        }
+      }
+    },
+    "makeitcount.alert.confirm" : {
+      "comment" : "Make it count · Alert dismiss button — affirmative acknowledgment.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klingt super"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sounds great"
           }
         }
       }

--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -11624,6 +11624,366 @@
           }
         }
       }
+    },
+    "archive.empty.message" : {
+      "comment" : "Archive tab · Empty state body text · Motivational.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du bringst fertig, was du anfängst. Dein Archiv ist leer – weiter so!"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You're finishing what you start. Your archive is empty – keep it up!"
+          }
+        }
+      }
+    },
+    "archive.empty.title" : {
+      "comment" : "Archive tab · Empty state headline.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nichts hier!"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing here!"
+          }
+        }
+      }
+    },
+    "archive.section.header" : {
+      "comment" : "Archive tab · Section header below the tab title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivierte Tasks können reaktiviert oder gelöscht werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archived tasks can be reactivated or deleted."
+          }
+        }
+      }
+    },
+    "archive.swipe.backlog" : {
+      "comment" : "Archive tab · Leading swipe action label · Moves task back to Backlog.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backlog"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backlog"
+          }
+        }
+      }
+    },
+    "archive.swipe.delete" : {
+      "comment" : "Archive tab · Trailing swipe action label · Permanently deletes the task.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "archive.swipe.today" : {
+      "comment" : "Archive tab · Leading swipe action label · Moves task directly to Today.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heute"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today"
+          }
+        }
+      }
+    },
+    "error.archive.load" : {
+      "comment" : "Error message when archive tasks can't be loaded.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiv konnte nicht geladen werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to load archived tasks."
+          }
+        }
+      }
+    },
+    "error.archive.save" : {
+      "comment" : "Error message when an archive operation fails to save.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern fehlgeschlagen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to save."
+          }
+        }
+      }
+    },
+    "makeitcount.alert.message" : {
+      "comment" : "Make it count · Alert body text explaining why the feature can't be disabled.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das ist eines der Kern-Features von Dawny. Tasks, die wiederholt nicht erledigt werden, werden archiviert, damit dein Backlog fokussiert und bedeutsam bleibt. Es kann nicht deaktiviert werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is one of Dawny's core features. Tasks that are repeatedly not completed are archived so your backlog stays focused and meaningful. It can't be turned off."
+          }
+        }
+      }
+    },
+    "makeitcount.alert.title" : {
+      "comment" : "Make it count · Alert title when user tries to disable the feature.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count ist unverzichtbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count is essential"
+          }
+        }
+      }
+    },
+    "settings.makeitcount.description" : {
+      "comment" : "Settings · Make it count section · Description text below the stepper.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht-wiederkehrende Tasks, die nach dem Reset nicht erledigt wurden, werden archiviert. Wiederkehrende Tasks kehren immer ins Backlog zurück."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non-recurring tasks that are not completed after the daily reset will be archived. Recurring tasks always return to the backlog."
+          }
+        }
+      }
+    },
+    "settings.makeitcount.disable" : {
+      "comment" : "Settings · Make it count section · Button label to attempt disabling (triggers locked alert).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count deaktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Make it count"
+          }
+        }
+      }
+    },
+    "settings.makeitcount.section" : {
+      "comment" : "Settings · Section title for Make it count settings.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count"
+          }
+        }
+      }
+    },
+    "settings.makeitcount.stepper" : {
+      "comment" : "Settings · Make it count stepper label. Uses interpolated threshold number.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivieren nach \\(settings.makeItCountThreshold) verpasstem Tag(en)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archive after \\(settings.makeItCountThreshold) missed day(s)"
+          }
+        }
+      }
+    },
+    "tabs.archive" : {
+      "comment" : "Top tabs · Archive tab button accessibility label.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiv"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archive"
+          }
+        }
+      }
+    },
+    "task.status.archived" : {
+      "comment" : "Task status display name for archived tasks.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiviert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archived"
+          }
+        }
+      }
+    },
+    "welcome.makeitcount.body" : {
+      "comment" : "Welcome screen · Make it count page · Body text.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasks, die du nicht erledigst, werden archiviert statt sich still anzuhäufen. Dein Backlog bleibt schlank, ehrlich und bedeutsam."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tasks you don't complete get archived instead of silently piling up. Your backlog stays lean, honest, and meaningful."
+          }
+        }
+      }
+    },
+    "welcome.makeitcount.checkbox" : {
+      "comment" : "Welcome screen · Make it count checkbox label.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count"
+          }
+        }
+      }
+    },
+    "welcome.makeitcount.checkbox.hint" : {
+      "comment" : "Welcome screen · Make it count checkbox · Accessibility hint.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Feature ist immer aktiv"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This feature is always enabled"
+          }
+        }
+      }
+    },
+    "welcome.makeitcount.title" : {
+      "comment" : "Welcome screen · Make it count page · Title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make it count"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/App/Sources/Models/AppSettings.swift
+++ b/App/Sources/Models/AppSettings.swift
@@ -24,6 +24,8 @@ final class AppSettings {
         static let showCategories = "DawnyShowCategories"
         static let defaultCategoryType = "DawnyDefaultCategoryType"
         static let hasSeenWelcome = "DawnyHasSeenWelcome"
+        static let makeItCountThreshold = "DawnyMakeItCountThreshold"
+        static let hasNewArchivedTasks = "DawnyHasNewArchivedTasks"
     }
     
     // MARK: - Properties
@@ -62,6 +64,20 @@ final class AppSettings {
             UserDefaults.standard.set(hasSeenWelcome, forKey: Keys.hasSeenWelcome)
         }
     }
+
+    /// Anzahl der fehlgeschlagenen Resets, bevor ein Task archiviert wird (1–7, Standard: 1)
+    var makeItCountThreshold: Int {
+        didSet {
+            UserDefaults.standard.set(makeItCountThreshold, forKey: Keys.makeItCountThreshold)
+        }
+    }
+
+    /// Zeigt an ob beim letzten Reset neue Tasks ins Archiv verschoben wurden (Dot-Badge)
+    var hasNewArchivedTasks: Bool {
+        didSet {
+            UserDefaults.standard.set(hasNewArchivedTasks, forKey: Keys.hasNewArchivedTasks)
+        }
+    }
     
     /// Standard-Kategorie für neue Tasks (wenn Kategorien aktiviert)
     var defaultCategoryType: TaskCategory {
@@ -84,6 +100,8 @@ final class AppSettings {
         self.showCompletedTasksInToday = UserDefaults.standard.object(forKey: Keys.showCompletedTasksInToday) as? Bool ?? true
         self.showCategories = UserDefaults.standard.object(forKey: Keys.showCategories) as? Bool ?? true
         self.hasSeenWelcome = UserDefaults.standard.bool(forKey: Keys.hasSeenWelcome)
+        self.makeItCountThreshold = UserDefaults.standard.object(forKey: Keys.makeItCountThreshold) as? Int ?? 1
+        self.hasNewArchivedTasks = UserDefaults.standard.bool(forKey: Keys.hasNewArchivedTasks)
         
         // Lade defaultCategoryType
         if let data = UserDefaults.standard.data(forKey: Keys.defaultCategoryType),

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -54,6 +54,13 @@ final class Task {
     /// erzeugten Backlog-Clone in Verbindung.
     var recurringCloneID: UUID? = nil
 
+    /// Zählt wie oft der Task beim automatischen Reset nicht erledigt war.
+    /// Wird bei manuellem Zurücklegen und bei Unarchivierung auf 0 gesetzt.
+    var resetCount: Int = 0
+
+    /// Zeitpunkt der Archivierung (nil wenn nicht archiviert)
+    var archivedAt: Date? = nil
+
     // MARK: - Relationships
     
     /// Referenz zum Parent-Backlog
@@ -131,11 +138,39 @@ final class Task {
         modifiedAt = Date()
     }
     
-    /// Setzt den Task zurück ins Backlog (für 3-AM-Reset)
+    /// Setzt den Task zurück ins Backlog (für 3-AM-Reset oder manuell).
+    /// `resetCount` wird hier NICHT zurückgesetzt – das macht der ResetEngine-Aufrufer
+    /// nur beim manuellen Zurücklegen, nicht beim automatischen Reset.
     func resetToBacklog() {
         status = .inBacklog
         scheduledDate = nil
         sortPriority = Date() // Move to top
+        modifiedAt = Date()
+    }
+
+    /// Archiviert den Task nach wiederholtem Nicht-Erledigen (Make it count).
+    func archive() {
+        status = .archived
+        archivedAt = Date()
+        scheduledDate = nil
+        modifiedAt = Date()
+    }
+
+    /// Unarchiviert den Task zurück ins Backlog. Setzt resetCount auf 0.
+    func unarchiveToBacklog() {
+        status = .inBacklog
+        archivedAt = nil
+        resetCount = 0
+        sortPriority = Date()
+        modifiedAt = Date()
+    }
+
+    /// Unarchiviert den Task direkt in den Daily Focus. Setzt resetCount auf 0.
+    func unarchiveToDailyFocus(date: Date) {
+        status = .dailyFocus
+        scheduledDate = date
+        archivedAt = nil
+        resetCount = 0
         modifiedAt = Date()
     }
     

--- a/App/Sources/Models/TaskStatus.swift
+++ b/App/Sources/Models/TaskStatus.swift
@@ -24,6 +24,9 @@ enum TaskStatus: String, Codable, CaseIterable {
     
     /// Task wurde abgeschlossen
     case completed
+
+    /// Task wurde nach wiederholtem Nicht-Erledigen archiviert (Make it count)
+    case archived
     
     var displayName: String {
         switch self {
@@ -35,6 +38,8 @@ enum TaskStatus: String, Codable, CaseIterable {
             return String(localized: "task.status.today", defaultValue: "Today")
         case .completed:
             return String(localized: "task.status.completed", defaultValue: "Completed")
+        case .archived:
+            return String(localized: "task.status.archived", defaultValue: "Archived")
         }
     }
     

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -72,6 +72,9 @@ final class ResetEngine {
         }
         
         print("📋 Resetting \(tasksToReset.count) task(s)")
+
+        let threshold = AppSettings.shared.makeItCountThreshold
+        var hasArchivedAnyTask = false
         
         // Reset jeden Task
         for (index, task) in tasksToReset.enumerated() {
@@ -79,15 +82,29 @@ final class ResetEngine {
             if task.isSyncedToCalendar {
                 await syncEngine?.removeTaskFromCalendar(task)
             }
-            
-            // Reset Task Status
-            task.resetToBacklog()
-            
-            // Setze sortPriority mit kleinem Offset für Ordnung
-            // Neuere Resets kommen weiter oben, aber innerhalb eines Resets
-            // wird die relative Ordnung beibehalten
-            let offset = TimeInterval(-index) * 0.001 // Millisekunden-Offset
-            task.sortPriority = referenceDate.addingTimeInterval(offset)
+
+            if task.isRecurring {
+                // Wiederkehrende Tasks gehen immer zurück ins Backlog, nie ins Archiv
+                task.resetToBacklog()
+                let offset = TimeInterval(-index) * 0.001
+                task.sortPriority = referenceDate.addingTimeInterval(offset)
+            } else {
+                // Nicht-wiederkehrend: Zähler erhöhen, ggf. archivieren
+                task.resetCount += 1
+                if task.resetCount >= threshold {
+                    task.archive()
+                    hasArchivedAnyTask = true
+                    print("📦 Archived task '\(task.title)' after \(task.resetCount) missed reset(s)")
+                } else {
+                    task.resetToBacklog()
+                    let offset = TimeInterval(-index) * 0.001
+                    task.sortPriority = referenceDate.addingTimeInterval(offset)
+                }
+            }
+        }
+
+        if hasArchivedAnyTask {
+            AppSettings.shared.hasNewArchivedTasks = true
         }
         
         // Save Context

--- a/App/Sources/ViewModels/ArchiveViewModel.swift
+++ b/App/Sources/ViewModels/ArchiveViewModel.swift
@@ -1,0 +1,108 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  ArchiveViewModel.swift
+//  Dawny
+//
+//  ViewModel für das Archiv (Make it count)
+//
+
+import Foundation
+import SwiftData
+import Observation
+
+@Observable
+final class ArchiveViewModel {
+    // MARK: - Properties
+
+    private let modelContext: ModelContext
+
+    var archivedTasks: [Task] = []
+    var errorMessage: String?
+
+    var isEmpty: Bool { archivedTasks.isEmpty }
+
+    // MARK: - Initializer
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+        loadArchivedTasks()
+    }
+
+    // MARK: - Loading
+
+    func loadArchivedTasks() {
+        let descriptor = FetchDescriptor<Task>(
+            sortBy: [SortDescriptor(\.archivedAt, order: .reverse)]
+        )
+        do {
+            let all = try modelContext.fetch(descriptor)
+            archivedTasks = all.filter { $0.status == .archived && !$0.isDeleted }
+        } catch {
+            errorMessage = String(
+                localized: "error.archive.load",
+                defaultValue: "Failed to load archived tasks: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: - Task Actions
+
+    /// Unarchiviert einen Task zurück ins Backlog (in seine letzte Kategorie).
+    /// Falls die Kategorie zwischenzeitlich gelöscht wurde, wird „Unkategorisiert" verwendet.
+    func unarchiveToBacklog(taskID: UUID) {
+        guard let task = task(withID: taskID) else { return }
+        ensureCategoryExists(for: task)
+        task.unarchiveToBacklog()
+        saveAndReload()
+    }
+
+    /// Unarchiviert einen Task direkt in den Daily Focus.
+    /// Falls die Kategorie zwischenzeitlich gelöscht wurde, wird „Unkategorisiert" verwendet.
+    func unarchiveToDailyFocus(taskID: UUID) {
+        guard let task = task(withID: taskID) else { return }
+        ensureCategoryExists(for: task)
+        task.unarchiveToDailyFocus(date: Date())
+        saveAndReload()
+    }
+
+    /// Löscht einen archivierten Task permanent.
+    func deleteTask(taskID: UUID) {
+        guard let task = task(withID: taskID) else { return }
+        modelContext.delete(task)
+        saveAndReload()
+    }
+
+    // MARK: - Private Helpers
+
+    private func task(withID id: UUID) -> Task? {
+        var descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    /// Stellt sicher, dass der Task eine gültige Kategorie hat.
+    /// Wenn die Kategorie gelöscht wurde (nil oder isDeleted), wird „Unkategorisiert" zugewiesen.
+    private func ensureCategoryExists(for task: Task) {
+        guard task.category == nil || task.category?.isDeleted == true else { return }
+        let descriptor = FetchDescriptor<Category>()
+        guard let categories = try? modelContext.fetch(descriptor) else { return }
+        if let uncategorized = categories.first(where: { $0.isUncategorized && !$0.isDeleted }) {
+            task.category = uncategorized
+        }
+    }
+
+    private func saveAndReload() {
+        do {
+            try modelContext.save()
+            loadArchivedTasks()
+        } catch {
+            errorMessage = String(
+                localized: "error.archive.save",
+                defaultValue: "Failed to save: \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -196,6 +196,7 @@ final class DailyFocusViewModel {
         let needsCalendarRemove = task.isSyncedToCalendar
         let taskID = task.id
 
+        task.resetCount = 0
         task.resetToBacklog()
         
         do {

--- a/App/Sources/Views/ArchiveView.swift
+++ b/App/Sources/Views/ArchiveView.swift
@@ -1,0 +1,191 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  ArchiveView.swift
+//  Dawny
+//
+//  Archiv-Tab – zeigt nicht erledigte Tasks, die nach wiederholtem Nicht-Erledigen archiviert wurden.
+//
+
+import SwiftUI
+import SwiftData
+
+struct ArchiveView: View {
+    @Bindable var viewModel: ArchiveViewModel
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isEmpty {
+                    emptyStateView
+                } else {
+                    taskList
+                }
+            }
+            .toolbar(.hidden, for: .navigationBar)
+            .onAppear {
+                viewModel.loadArchivedTasks()
+            }
+            .overlay(alignment: .top) {
+                if let error = viewModel.errorMessage {
+                    ErrorBannerView(message: error) {
+                        viewModel.errorMessage = nil
+                    }
+                    .padding(.top, 8)
+                }
+            }
+        }
+    }
+
+    // MARK: - Task List
+
+    private var taskList: some View {
+        List {
+            Section {
+                ForEach(viewModel.archivedTasks, id: \.id) { task in
+                    archivedTaskRow(task: task)
+                }
+            } header: {
+                Text(
+                    String(
+                        localized: "archive.section.header",
+                        defaultValue: "Archived tasks can be reactivated or deleted."
+                    )
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .textCase(nil)
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    // MARK: - Row
+
+    private func archivedTaskRow(task: Task) -> some View {
+        ArchivedTaskRowView(
+            task: task,
+            onUnarchiveToBacklog: {
+                viewModel.unarchiveToBacklog(taskID: task.id)
+            },
+            onUnarchiveToDailyFocus: {
+                viewModel.unarchiveToDailyFocus(taskID: task.id)
+            },
+            onDelete: {
+                viewModel.deleteTask(taskID: task.id)
+            }
+        )
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            Button {
+                viewModel.unarchiveToDailyFocus(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.today", defaultValue: "Today"),
+                    systemImage: "sun.max.fill"
+                )
+            }
+            .tint(.orange)
+
+            Button {
+                viewModel.unarchiveToBacklog(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.backlog", defaultValue: "Backlog"),
+                    systemImage: "tray.fill"
+                )
+            }
+            .tint(.blue)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                viewModel.deleteTask(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.delete", defaultValue: "Delete"),
+                    systemImage: "trash"
+                )
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        EmptyStateView(
+            icon: "checkmark.seal.fill",
+            title: String(localized: "archive.empty.title", defaultValue: "Nothing here!"),
+            message: String(
+                localized: "archive.empty.message",
+                defaultValue: "You're finishing what you start. Your archive is empty – keep it up!"
+            )
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Archived Task Row
+
+/// Zeigt einen archivierten Task ausgegraut an (keine Checkbox, kein Drag-Handle).
+private struct ArchivedTaskRowView: View {
+    let task: Task
+    let onUnarchiveToBacklog: () -> Void
+    let onUnarchiveToDailyFocus: () -> Void
+    let onDelete: () -> Void
+
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        if let resolved: Task = modelContext.registeredModel(for: task.persistentModelID),
+           resolved.modelContext != nil,
+           !resolved.isDeleted {
+            rowContent(task: resolved)
+        } else {
+            EmptyView()
+        }
+    }
+
+    private func rowContent(task: Task) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "archivebox")
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(task.title)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                if let notes = task.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+
+                if let category = task.category {
+                    HStack(spacing: 4) {
+                        Image(systemName: category.displayIconName)
+                            .font(.caption2)
+                        Text(category.displayName)
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer()
+
+            if let archivedAt = task.archivedAt {
+                Text(archivedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.quaternary)
+            }
+        }
+        .padding(.vertical, 4)
+        .opacity(0.75)
+    }
+}

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     
     @State private var backlogViewModel: BacklogViewModel?
     @State private var dailyFocusViewModel: DailyFocusViewModel?
+    @State private var archiveViewModel: ArchiveViewModel?
     @State private var selectedTab: Tab = .backlog
     @State private var hasSetInitialTab = false
     @State private var showWelcome = false
@@ -40,6 +41,7 @@ struct ContentView: View {
     enum Tab: Int {
         case backlog = 0
         case today = 1
+        case archive = 2
     }
     
     var body: some View {
@@ -52,6 +54,7 @@ struct ContentView: View {
                         selectedTab = Tab(rawValue: newValue) ?? .backlog
                     }
                 ),
+                pageCount: 3,
                 page0: {
                     if let backlogVM = backlogViewModel {
                         BacklogView(
@@ -65,6 +68,13 @@ struct ContentView: View {
                 page1: {
                     if let dailyViewModel = dailyFocusViewModel, let backlogVM = backlogViewModel {
                         DailyFocusView(viewModel: dailyViewModel, backlogViewModel: backlogVM)
+                    } else {
+                        ProgressView()
+                    }
+                },
+                page2: {
+                    if let archiveVM = archiveViewModel {
+                        ArchiveView(viewModel: archiveVM)
                     } else {
                         ProgressView()
                     }
@@ -138,8 +148,8 @@ struct ContentView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 32, height: 32)
                     .contentShape(Rectangle())
-                    // Ohne das meldet XCTest oft einen separaten „gearshape.fill“-Button mit ungültigem Aktivierungspunkt,
-                    // während das Label „Einstellungen“/„Settings“ auf dem Eltern-Button liegt.
+                    // Ohne das meldet XCTest oft einen separaten „gearshape.fill"-Button mit ungültigem Aktivierungspunkt,
+                    // während das Label „Einstellungen"/„Settings" auf dem Eltern-Button liegt.
                     .accessibilityHidden(true)
             }
             .buttonStyle(.plain)
@@ -158,11 +168,46 @@ struct ContentView: View {
             }
             .padding(2)
             .background(Color(UIColor.secondarySystemFill), in: Capsule())
+
+            archiveTabButton
         }
         .padding(.horizontal, 12)
         .padding(.top, 4)
         .padding(.bottom, 2)
         .background(.thinMaterial)
+    }
+
+    /// Archiv-Tab-Button mit optionalem Dot-Badge (erscheint nach einem Reset, der neue Tasks archiviert hat).
+    private var archiveTabButton: some View {
+        Button {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                selectedTab = .archive
+                settings.hasNewArchivedTasks = false
+                archiveViewModel?.loadArchivedTasks()
+            }
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: selectedTab == .archive ? "archivebox.fill" : "archivebox")
+                    .font(.body)
+                    .foregroundStyle(selectedTab == .archive ? Color.primary : Color.secondary)
+                    .frame(width: 36, height: 32)
+                    .contentShape(Rectangle())
+                    .accessibilityHidden(true)
+
+                if settings.hasNewArchivedTasks {
+                    Circle()
+                        .fill(Color.orange)
+                        .frame(width: 8, height: 8)
+                        .offset(x: -4, y: 4)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(localized: "tabs.archive", defaultValue: "Archive"))
+        .accessibilityAddTraits(selectedTab == .archive ? .isSelected : [])
+        .accessibilityIdentifier("ToolbarArchiveButton")
     }
 
     private func tabSwitchButton(title: String, tab: Tab) -> some View {
@@ -217,6 +262,7 @@ struct ContentView: View {
         backlogVM.loadBacklogs()
         backlogVM.loadCategories()
         dailyFocusViewModel?.loadDailyTasks()
+        archiveViewModel?.loadArchivedTasks()
         #endif
     }
 
@@ -236,6 +282,8 @@ struct ContentView: View {
             syncEngine: syncEngine,
             resetEngine: resetEngine
         )
+
+        archiveViewModel = ArchiveViewModel(modelContext: modelContext)
     }
     
     // MARK: - Tab Selection Logic
@@ -269,10 +317,12 @@ struct ContentView: View {
 /// `UIGestureRecognizerRepresentable` (iOS 18+). Der Delegate stellt sicher, dass
 /// der Pager *immer* hinter Row-Swipe-Gesten zurücktritt — exakt das Pattern,
 /// das Apple Erinnerungen für die Back-Geste verwendet.
-private struct TabPager<Page0: View, Page1: View>: View {
+private struct TabPager<Page0: View, Page1: View, Page2: View>: View {
     @Binding var selectedIndex: Int
+    let pageCount: Int
     @ViewBuilder var page0: () -> Page0
     @ViewBuilder var page1: () -> Page1
+    @ViewBuilder var page2: () -> Page2
 
     @State private var dragOffset: CGFloat = 0
     @State private var isDragging: Bool = false
@@ -290,6 +340,8 @@ private struct TabPager<Page0: View, Page1: View>: View {
                     .frame(width: width)
                 page1()
                     .frame(width: width)
+                page2()
+                    .frame(width: width)
             }
             .frame(width: width, alignment: .leading)
             .offset(x: -CGFloat(selectedIndex) * width + dragOffset)
@@ -301,7 +353,7 @@ private struct TabPager<Page0: View, Page1: View>: View {
                     onChanged: { tx in
                         isDragging = true
                         let atLeftEdge = selectedIndex == 0 && tx > 0
-                        let atRightEdge = selectedIndex == 1 && tx < 0
+                        let atRightEdge = selectedIndex == pageCount - 1 && tx < 0
                         dragOffset = (atLeftEdge || atRightEdge) ? tx / 3 : tx
                     },
                     onEnded: { tx, vx in
@@ -309,10 +361,10 @@ private struct TabPager<Page0: View, Page1: View>: View {
                         let velocityThreshold: CGFloat = 400
 
                         withAnimation(Self.snapAnimation) {
-                            if (tx < -distanceThreshold || vx < -velocityThreshold), selectedIndex == 0 {
-                                selectedIndex = 1
-                            } else if (tx > distanceThreshold || vx > velocityThreshold), selectedIndex == 1 {
-                                selectedIndex = 0
+                            if (tx < -distanceThreshold || vx < -velocityThreshold), selectedIndex < pageCount - 1 {
+                                selectedIndex += 1
+                            } else if (tx > distanceThreshold || vx > velocityThreshold), selectedIndex > 0 {
+                                selectedIndex -= 1
                             }
                             dragOffset = 0
                             isDragging = false

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -58,12 +58,12 @@ struct SettingsView: View {
                 String(localized: "makeitcount.alert.title", defaultValue: "Make it count is essential"),
                 isPresented: $showMakeItCountLockedAlert
             ) {
-                Button(String(localized: "settings.done", defaultValue: "Done"), role: .cancel) {}
+                Button(String(localized: "makeitcount.alert.confirm", defaultValue: "Sounds great"), role: .cancel) {}
             } message: {
                 Text(
                     String(
                         localized: "makeitcount.alert.message",
-                        defaultValue: "This is one of Dawny's core features. Tasks that are repeatedly not completed are archived so your backlog stays focused and meaningful. It can't be turned off."
+                        defaultValue: "This is one of Dawny's core features. Tasks that are not completed are archived so your backlog stays focused and meaningful.\n\nTherefore, Make it count cannot be disabled in Dawny."
                     )
                 )
             }

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -41,15 +41,31 @@ struct SettingsView: View {
         self._resetTime = State(initialValue: calendar.date(from: components) ?? Date())
     }
     
+    @State private var showMakeItCountLockedAlert = false
+
     var body: some View {
         NavigationStack {
             Form {
                 debugSection
                 resetSection
+                makeItCountSection
                 synchronisationSection
                 displaySection
                 categorySection
                 infoSection
+            }
+            .alert(
+                String(localized: "makeitcount.alert.title", defaultValue: "Make it count is essential"),
+                isPresented: $showMakeItCountLockedAlert
+            ) {
+                Button(String(localized: "settings.done", defaultValue: "Done"), role: .cancel) {}
+            } message: {
+                Text(
+                    String(
+                        localized: "makeitcount.alert.message",
+                        defaultValue: "This is one of Dawny's core features. Tasks that are repeatedly not completed are archived so your backlog stays focused and meaningful. It can't be turned off."
+                    )
+                )
             }
             .navigationTitle(String(localized: "settings.title", defaultValue: "Settings"))
             .navigationBarTitleDisplayMode(.inline)
@@ -108,6 +124,48 @@ struct SettingsView: View {
         }
     }
     
+    private var makeItCountSection: some View {
+        Section(String(localized: "settings.makeitcount.section", defaultValue: "Make it count")) {
+            Stepper(
+                value: $settings.makeItCountThreshold,
+                in: 1...7
+            ) {
+                HStack {
+                    Text(
+                        String(
+                            localized: "settings.makeitcount.stepper",
+                            defaultValue: "Archive after \(settings.makeItCountThreshold) missed day(s)"
+                        )
+                    )
+                    Spacer()
+                }
+            }
+
+            Text(
+                String(
+                    localized: "settings.makeitcount.description",
+                    defaultValue: "Non-recurring tasks that are not completed after the daily reset will be archived. Recurring tasks always return to the backlog."
+                )
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+
+            Button {
+                showMakeItCountLockedAlert = true
+            } label: {
+                HStack {
+                    Label(
+                        String(localized: "settings.makeitcount.disable", defaultValue: "Disable Make it count"),
+                        systemImage: "lock.fill"
+                    )
+                    .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
     private var resetSection: some View {
         Section(String(localized: "settings.reset.section", defaultValue: "Reset")) {
             DatePicker(

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -323,6 +323,8 @@ private struct TaskRowContent: View {
             return .orange
         case .completed:
             return .green
+        case .archived:
+            return .secondary
         }
     }
     

--- a/App/Sources/Views/WelcomeView.swift
+++ b/App/Sources/Views/WelcomeView.swift
@@ -83,7 +83,7 @@ struct WelcomeView: View {
         VStack(spacing: 0) {
             TabView(selection: $currentPage) {
                 ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
-                    pageView(page)
+                    pageView(page, pageIndex: index)
                         .tag(index)
                 }
             }
@@ -100,8 +100,9 @@ struct WelcomeView: View {
 
     // MARK: - Page Content
 
-    private func pageView(_ page: WelcomePage) -> some View {
-        VStack(spacing: 28) {
+    private func pageView(_ page: WelcomePage, pageIndex: Int) -> some View {
+        let isMakeItCountPage = pageIndex == pages.count - 1
+        return VStack(spacing: 28) {
             Spacer()
 
             Image(systemName: page.icon)
@@ -125,6 +126,12 @@ struct WelcomeView: View {
             .padding(.horizontal, 36)
 
             Spacer()
+
+            if isMakeItCountPage {
+                makeItCountCheckbox
+                    .padding(.horizontal, 32)
+            }
+
             Spacer()
         }
     }
@@ -136,8 +143,6 @@ struct WelcomeView: View {
             pageIndicator
 
             if currentPage == pages.count - 1 {
-                makeItCountCheckbox
-
                 Button(action: onDismiss) {
                     Text(String(localized: "welcome.cta.start", defaultValue: "Get started"))
                         .font(.headline)
@@ -167,12 +172,12 @@ struct WelcomeView: View {
             String(localized: "makeitcount.alert.title", defaultValue: "Make it count is essential"),
             isPresented: $showMakeItCountLockedAlert
         ) {
-            Button(String(localized: "settings.done", defaultValue: "Done"), role: .cancel) {}
+            Button(String(localized: "makeitcount.alert.confirm", defaultValue: "Sounds great"), role: .cancel) {}
         } message: {
             Text(
                 String(
                     localized: "makeitcount.alert.message",
-                    defaultValue: "This is one of Dawny's core features. Tasks that are repeatedly not completed are archived so your backlog stays focused and meaningful. It can't be turned off."
+                    defaultValue: "This is one of Dawny's core features. Tasks that are not completed are archived so your backlog stays focused and meaningful.\n\nTherefore, Make it count cannot be disabled in Dawny."
                 )
             )
         }
@@ -184,16 +189,17 @@ struct WelcomeView: View {
         Button {
             showMakeItCountLockedAlert = true
         } label: {
-            HStack(spacing: 10) {
+            HStack(spacing: 12) {
                 Image(systemName: "checkmark.square.fill")
-                    .font(.title3)
+                    .font(.system(size: 30, weight: .medium))
                     .foregroundStyle(.indigo)
                 Text(String(localized: "welcome.makeitcount.checkbox", defaultValue: "Make it count"))
-                    .font(.subheadline.weight(.medium))
+                    .font(.title3.weight(.semibold))
                     .foregroundStyle(.primary)
-                Spacer()
+                    .multilineTextAlignment(.center)
             }
             .padding(.horizontal, 4)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(String(localized: "welcome.makeitcount.checkbox", defaultValue: "Make it count"))

--- a/App/Sources/Views/WelcomeView.swift
+++ b/App/Sources/Views/WelcomeView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 
 struct WelcomeView: View {
     @State private var currentPage = 0
+    @State private var showMakeItCountLockedAlert = false
     var onDismiss: () -> Void
 
     private let pages: [WelcomePage] = [
@@ -62,6 +63,18 @@ struct WelcomeView: View {
             body: LocalizedStringResource(
                 "welcome.page4.body",
                 defaultValue: "Anything left undone slides back to the backlog overnight. Tomorrow is a clean slate."
+            )
+        ),
+        WelcomePage(
+            icon: "archivebox.fill",
+            iconColor: .indigo,
+            title: LocalizedStringResource(
+                "welcome.makeitcount.title",
+                defaultValue: "Make it count"
+            ),
+            body: LocalizedStringResource(
+                "welcome.makeitcount.body",
+                defaultValue: "Tasks you don't complete get archived instead of silently piling up. Your backlog stays lean, honest, and meaningful."
             )
         )
     ]
@@ -123,6 +136,8 @@ struct WelcomeView: View {
             pageIndicator
 
             if currentPage == pages.count - 1 {
+                makeItCountCheckbox
+
                 Button(action: onDismiss) {
                     Text(String(localized: "welcome.cta.start", defaultValue: "Get started"))
                         .font(.headline)
@@ -148,6 +163,47 @@ struct WelcomeView: View {
                 .accessibilityIdentifier("WelcomeNextButton")
             }
         }
+        .alert(
+            String(localized: "makeitcount.alert.title", defaultValue: "Make it count is essential"),
+            isPresented: $showMakeItCountLockedAlert
+        ) {
+            Button(String(localized: "settings.done", defaultValue: "Done"), role: .cancel) {}
+        } message: {
+            Text(
+                String(
+                    localized: "makeitcount.alert.message",
+                    defaultValue: "This is one of Dawny's core features. Tasks that are repeatedly not completed are archived so your backlog stays focused and meaningful. It can't be turned off."
+                )
+            )
+        }
+    }
+
+    /// Checkbox für Make it count – standardmäßig aktiv, nicht deaktivierbar.
+    /// Bei Versuch zu deaktivieren erscheint ein erklärender Alert.
+    private var makeItCountCheckbox: some View {
+        Button {
+            showMakeItCountLockedAlert = true
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "checkmark.square.fill")
+                    .font(.title3)
+                    .foregroundStyle(.indigo)
+                Text(String(localized: "welcome.makeitcount.checkbox", defaultValue: "Make it count"))
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.primary)
+                Spacer()
+            }
+            .padding(.horizontal, 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(localized: "welcome.makeitcount.checkbox", defaultValue: "Make it count"))
+        .accessibilityHint(
+            String(
+                localized: "welcome.makeitcount.checkbox.hint",
+                defaultValue: "This feature is always enabled"
+            )
+        )
+        .accessibilityIdentifier("WelcomeMakeItCountCheckbox")
     }
 
     private var pageIndicator: some View {

--- a/DawnyTests/Services/MakeItCountResetTests.swift
+++ b/DawnyTests/Services/MakeItCountResetTests.swift
@@ -1,0 +1,229 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  MakeItCountResetTests.swift
+//  DawnyTests
+//
+//  Tests für das Make it count Feature: ResetEngine archiviert non-recurring Tasks
+//  nach Erreichen des Schwellwerts, recurring Tasks gehen immer zurück ins Backlog.
+//
+
+import XCTest
+import SwiftData
+@testable import Dawny
+
+@MainActor
+final class MakeItCountResetTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var timeProvider: MockTimeProvider!
+    var calendarService: MockCalendarService!
+    var syncEngine: SyncEngine!
+    var resetEngine: ResetEngine!
+
+    private var originalThreshold: Int!
+    private var originalHasNewArchived: Bool!
+    private var originalResetHour: Int!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try TestModelContainer.create()
+        context = container.mainContext
+        timeProvider = MockTimeProvider()
+        calendarService = MockCalendarService()
+        syncEngine = SyncEngine(calendarService: calendarService, modelContext: context)
+        resetEngine = ResetEngine(timeProvider: timeProvider, modelContext: context)
+        resetEngine.syncEngine = syncEngine
+        resetEngine.clearLastResetDate()
+
+        originalThreshold = AppSettings.shared.makeItCountThreshold
+        originalHasNewArchived = AppSettings.shared.hasNewArchivedTasks
+        originalResetHour = AppSettings.shared.resetHour
+
+        AppSettings.shared.resetHour = 3
+        AppSettings.shared.makeItCountThreshold = 1
+        AppSettings.shared.hasNewArchivedTasks = false
+    }
+
+    override func tearDown() async throws {
+        AppSettings.shared.makeItCountThreshold = originalThreshold
+        AppSettings.shared.hasNewArchivedTasks = originalHasNewArchived
+        AppSettings.shared.resetHour = originalResetHour
+        container = nil
+        context = nil
+        syncEngine = nil
+        resetEngine = nil
+        timeProvider = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func referenceDate() -> Date {
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 1
+        components.day = 15
+        components.hour = 10
+        return Calendar.current.date(from: components)!
+    }
+
+    private func makeRecurringCategory() -> Dawny.Category {
+        let service = CategoryService(modelContext: context)
+        service.initializeDefaultCategories()
+        if let cat = service.getCategoriesSorted().first(where: { $0.isRecurring }) {
+            return cat
+        }
+        let cat = Dawny.Category(categoryType: .quick, isRecurring: true)
+        context.insert(cat)
+        try? context.save()
+        return cat
+    }
+
+    private func makeNonRecurringCategory() -> Dawny.Category {
+        let service = CategoryService(modelContext: context)
+        service.initializeDefaultCategories()
+        if let cat = service.getCategoriesSorted().first(where: { !$0.isRecurring && !$0.isUncategorized }) {
+            return cat
+        }
+        let cat = Dawny.Category(categoryType: .someday, isRecurring: false)
+        context.insert(cat)
+        try? context.save()
+        return cat
+    }
+
+    // MARK: - Tests: Threshold = 1 (Standard)
+
+    func testNonRecurringTaskArchivedAfterOneReset() async throws {
+        AppSettings.shared.makeItCountThreshold = 1
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertEqual(task.status, .archived, "Task sollte nach einem Reset archiviert sein (threshold=1)")
+        XCTAssertNotNil(task.archivedAt)
+        XCTAssertEqual(task.resetCount, 1)
+        XCTAssertTrue(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    func testNonRecurringTaskGoesBackToBacklogBelowThreshold() async throws {
+        AppSettings.shared.makeItCountThreshold = 2
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertEqual(task.status, .inBacklog, "Task sollte bei threshold=2 nach erstem Reset ins Backlog gehen")
+        XCTAssertEqual(task.resetCount, 1)
+        XCTAssertFalse(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    func testNonRecurringTaskArchivedAfterReachingThreshold() async throws {
+        AppSettings.shared.makeItCountThreshold = 2
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+
+        // Erster Reset: ins Backlog (resetCount = 1)
+        await resetEngine.performReset(referenceDate: referenceDate())
+        XCTAssertEqual(task.status, .inBacklog)
+        XCTAssertEqual(task.resetCount, 1)
+
+        // Zweiter Reset: Task muss wieder in dailyFocus sein
+        task.moveToDailyFocus(date: Date())
+        try context.save()
+
+        await resetEngine.performReset(referenceDate: referenceDate().addingTimeInterval(86400))
+        XCTAssertEqual(task.status, .archived, "Task sollte nach threshold=2 Resets archiviert sein")
+        XCTAssertEqual(task.resetCount, 2)
+        XCTAssertTrue(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    // MARK: - Tests: Recurring Tasks
+
+    func testRecurringTaskAlwaysGoesBackToBacklog() async throws {
+        AppSettings.shared.makeItCountThreshold = 1
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Recurring", status: .dailyFocus, backlog: backlog)
+        task.category = makeRecurringCategory()
+        try context.save()
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertEqual(task.status, .inBacklog, "Wiederkehrender Task soll immer ins Backlog zurück")
+        XCTAssertNil(task.archivedAt)
+        XCTAssertFalse(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    func testRecurringTaskResetCountNotIncremented() async throws {
+        AppSettings.shared.makeItCountThreshold = 1
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Recurring", status: .dailyFocus, backlog: backlog)
+        task.category = makeRecurringCategory()
+        try context.save()
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertEqual(task.resetCount, 0, "Wiederkehrender Task: resetCount darf nicht erhöht werden")
+    }
+
+    // MARK: - Tests: Mixed Tasks
+
+    func testMixedRecurringAndNonRecurringReset() async throws {
+        AppSettings.shared.makeItCountThreshold = 1
+        let backlog = TestModelContainer.createBacklog(in: context)
+
+        let recurring = TestModelContainer.createTask(in: context, title: "Recurring", status: .dailyFocus, backlog: backlog)
+        recurring.category = makeRecurringCategory()
+
+        let nonRecurring = TestModelContainer.createTask(in: context, title: "Normal", status: .dailyFocus, backlog: backlog)
+        try context.save()
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertEqual(recurring.status, .inBacklog)
+        XCTAssertEqual(nonRecurring.status, .archived)
+        XCTAssertTrue(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    // MARK: - Tests: Dot Badge
+
+    func testDotBadgeSetWhenTasksAreArchived() async throws {
+        AppSettings.shared.makeItCountThreshold = 1
+        AppSettings.shared.hasNewArchivedTasks = false
+        let backlog = TestModelContainer.createBacklog(in: context)
+        _ = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertTrue(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    func testDotBadgeNotSetWhenNoTasksArchived() async throws {
+        AppSettings.shared.makeItCountThreshold = 2
+        AppSettings.shared.hasNewArchivedTasks = false
+        let backlog = TestModelContainer.createBacklog(in: context)
+        _ = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertFalse(AppSettings.shared.hasNewArchivedTasks)
+    }
+
+    // MARK: - Tests: Missed Days count as single +1
+
+    func testMissedDaysCountAsSingleReset() async throws {
+        AppSettings.shared.makeItCountThreshold = 3
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+
+        // Simuliere einen einzelnen Reset (auch wenn mehrere Tage verpasst wurden)
+        await resetEngine.performReset(referenceDate: referenceDate())
+
+        XCTAssertEqual(task.resetCount, 1, "Auch bei mehreren verpassten Tagen: nur +1 beim Reset")
+        XCTAssertEqual(task.status, .inBacklog)
+    }
+}

--- a/DawnyTests/ViewModels/ArchiveViewModelTests.swift
+++ b/DawnyTests/ViewModels/ArchiveViewModelTests.swift
@@ -1,0 +1,214 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  ArchiveViewModelTests.swift
+//  DawnyTests
+//
+//  Tests für ArchiveViewModel: Unarchivierung, Kategorie-Edge-Case, Löschen.
+//
+
+import XCTest
+import SwiftData
+@testable import Dawny
+
+@MainActor
+final class ArchiveViewModelTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var viewModel: ArchiveViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try TestModelContainer.create()
+        context = container.mainContext
+        viewModel = ArchiveViewModel(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        context = nil
+        viewModel = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeArchivedTask(title: String = "Archived", category: Dawny.Category? = nil) -> Task {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: title, backlog: backlog)
+        task.category = category
+        task.archive()
+        try? context.save()
+        return task
+    }
+
+    private func makeCategory(type: TaskCategory = .someday) -> Dawny.Category {
+        let service = CategoryService(modelContext: context)
+        service.initializeDefaultCategories()
+        if let cat = service.getCategoriesSorted().first(where: { $0.categoryType == type }) {
+            return cat
+        }
+        let cat = Dawny.Category(categoryType: type)
+        context.insert(cat)
+        try? context.save()
+        return cat
+    }
+
+    private func makeUncategorized() -> Dawny.Category {
+        let service = CategoryService(modelContext: context)
+        service.initializeDefaultCategories()
+        return service.getCategoriesSorted().first(where: { $0.isUncategorized })!
+    }
+
+    // MARK: - Load Tests
+
+    func testLoadArchivedTasksReturnsOnlyArchivedTasks() throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let archived = TestModelContainer.createTask(in: context, title: "Archived", backlog: backlog)
+        archived.archive()
+        _ = TestModelContainer.createTask(in: context, title: "Normal", status: .inBacklog, backlog: backlog)
+        try context.save()
+
+        viewModel.loadArchivedTasks()
+
+        XCTAssertEqual(viewModel.archivedTasks.count, 1)
+        XCTAssertEqual(viewModel.archivedTasks.first?.title, "Archived")
+    }
+
+    func testEmptyWhenNoArchivedTasks() throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        _ = TestModelContainer.createTask(in: context, title: "Normal", status: .inBacklog, backlog: backlog)
+        try context.save()
+
+        viewModel.loadArchivedTasks()
+
+        XCTAssertTrue(viewModel.isEmpty)
+    }
+
+    // MARK: - Unarchive to Backlog
+
+    func testUnarchiveToBacklogSetsStatusInBacklog() throws {
+        let task = makeArchivedTask()
+
+        viewModel.unarchiveToBacklog(taskID: task.id)
+
+        XCTAssertEqual(task.status, .inBacklog)
+    }
+
+    func testUnarchiveToBacklogResetsResetCount() throws {
+        let task = makeArchivedTask()
+        task.resetCount = 5
+        try context.save()
+
+        viewModel.unarchiveToBacklog(taskID: task.id)
+
+        XCTAssertEqual(task.resetCount, 0, "resetCount muss bei Unarchivierung auf 0 gesetzt werden")
+    }
+
+    func testUnarchiveToBacklogClearsArchivedAt() throws {
+        let task = makeArchivedTask()
+
+        viewModel.unarchiveToBacklog(taskID: task.id)
+
+        XCTAssertNil(task.archivedAt)
+    }
+
+    func testUnarchiveToBacklogPreservesCategory() throws {
+        let category = makeCategory()
+        let task = makeArchivedTask(category: category)
+
+        viewModel.unarchiveToBacklog(taskID: task.id)
+
+        XCTAssertEqual(task.category?.id, category.id, "Kategorie muss nach Unarchivierung erhalten bleiben")
+    }
+
+    func testUnarchiveToBacklogRemovesFromArchivedList() throws {
+        let task = makeArchivedTask()
+        viewModel.loadArchivedTasks()
+        XCTAssertEqual(viewModel.archivedTasks.count, 1)
+
+        viewModel.unarchiveToBacklog(taskID: task.id)
+
+        XCTAssertEqual(viewModel.archivedTasks.count, 0)
+    }
+
+    // MARK: - Unarchive to Daily Focus
+
+    func testUnarchiveToDailyFocusSetsStatusDailyFocus() throws {
+        let task = makeArchivedTask()
+
+        viewModel.unarchiveToDailyFocus(taskID: task.id)
+
+        XCTAssertEqual(task.status, .dailyFocus)
+    }
+
+    func testUnarchiveToDailyFocusResetsResetCount() throws {
+        let task = makeArchivedTask()
+        task.resetCount = 3
+        try context.save()
+
+        viewModel.unarchiveToDailyFocus(taskID: task.id)
+
+        XCTAssertEqual(task.resetCount, 0)
+    }
+
+    func testUnarchiveToDailyFocusSetsScheduledDate() throws {
+        let task = makeArchivedTask()
+
+        viewModel.unarchiveToDailyFocus(taskID: task.id)
+
+        XCTAssertNotNil(task.scheduledDate, "scheduledDate muss gesetzt sein wenn Task in DailyFocus")
+    }
+
+    // MARK: - Category Edge Case: Category deleted
+
+    func testUnarchiveToBacklogAssignsUncategorizedWhenCategoryDeleted() throws {
+        let category = makeCategory()
+        let uncategorized = makeUncategorized()
+        let task = makeArchivedTask(category: category)
+
+        // Kategorie löschen
+        context.delete(category)
+        try context.save()
+
+        viewModel.unarchiveToBacklog(taskID: task.id)
+
+        XCTAssertEqual(
+            task.category?.id,
+            uncategorized.id,
+            "Gelöschte Kategorie: Task soll in 'Unkategorisiert' landen"
+        )
+    }
+
+    func testUnarchiveToDailyFocusAssignsUncategorizedWhenCategoryDeleted() throws {
+        let category = makeCategory()
+        let uncategorized = makeUncategorized()
+        let task = makeArchivedTask(category: category)
+
+        context.delete(category)
+        try context.save()
+
+        viewModel.unarchiveToDailyFocus(taskID: task.id)
+
+        XCTAssertEqual(task.category?.id, uncategorized.id)
+    }
+
+    // MARK: - Delete
+
+    func testDeleteTaskPermanentlyDeletesTask() throws {
+        let task = makeArchivedTask()
+        viewModel.loadArchivedTasks()
+        XCTAssertEqual(viewModel.archivedTasks.count, 1)
+
+        viewModel.deleteTask(taskID: task.id)
+
+        viewModel.loadArchivedTasks()
+        XCTAssertEqual(viewModel.archivedTasks.count, 0)
+
+        let all = try context.fetch(FetchDescriptor<Task>())
+        XCTAssertTrue(all.isEmpty, "Task muss permanent gelöscht worden sein")
+    }
+}

--- a/DawnyTests/ViewModels/MakeItCountDailyFocusTests.swift
+++ b/DawnyTests/ViewModels/MakeItCountDailyFocusTests.swift
@@ -1,0 +1,83 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  MakeItCountDailyFocusTests.swift
+//  DawnyTests
+//
+//  Tests dass manuelles Zurücklegen von Heute → Backlog den resetCount auf 0 setzt.
+//
+
+import XCTest
+import SwiftData
+@testable import Dawny
+
+@MainActor
+final class MakeItCountDailyFocusTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var syncEngine: SyncEngine!
+    var resetEngine: ResetEngine!
+    var timeProvider: MockTimeProvider!
+    var originalCalendarEnabled: Bool!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        originalCalendarEnabled = AppSettings.shared.calendarSyncEnabled
+        AppSettings.shared.calendarSyncEnabled = false
+        timeProvider = MockTimeProvider()
+        container = try TestModelContainer.create()
+        context = container.mainContext
+        let calendarService = MockCalendarService()
+        syncEngine = SyncEngine(calendarService: calendarService, modelContext: context)
+        resetEngine = ResetEngine(timeProvider: timeProvider, modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        AppSettings.shared.calendarSyncEnabled = originalCalendarEnabled
+        container = nil
+        context = nil
+        syncEngine = nil
+        resetEngine = nil
+        timeProvider = nil
+        try await super.tearDown()
+    }
+
+    func testManualRemoveFromDailyFocusResetsCounter() async throws {
+        let vm = DailyFocusViewModel(
+            modelContext: context,
+            syncEngine: syncEngine,
+            resetEngine: resetEngine
+        )
+        let backlog = TestModelContainer.createBacklog(in: context, title: "B")
+        let task = TestModelContainer.createTask(in: context, title: "Task", status: .dailyFocus, backlog: backlog)
+
+        // Simuliere dass der Task bereits 2 Mal nicht erledigt wurde
+        task.resetCount = 2
+        try context.save()
+
+        await vm.removeFromDailyFocus(task)
+
+        XCTAssertEqual(task.resetCount, 0, "Manuelles Zurücklegen soll resetCount auf 0 setzen")
+        XCTAssertEqual(task.status, .inBacklog)
+    }
+
+    func testManualRemoveDoesNotArchiveTask() async throws {
+        let vm = DailyFocusViewModel(
+            modelContext: context,
+            syncEngine: syncEngine,
+            resetEngine: resetEngine
+        )
+        let backlog = TestModelContainer.createBacklog(in: context, title: "B")
+        let task = TestModelContainer.createTask(in: context, title: "Task", status: .dailyFocus, backlog: backlog)
+        task.resetCount = 99
+        try context.save()
+
+        await vm.removeFromDailyFocus(task)
+
+        XCTAssertNotEqual(task.status, .archived, "Manuelles Zurücklegen darf nicht archivieren")
+        XCTAssertEqual(task.status, .inBacklog)
+    }
+}


### PR DESCRIPTION
## Kurz überblick

Diese Änderung führt das **„Make it count“**-Prinzip ein: Wer seine Aufgaben in „Heute“ immer wieder nicht erledigt, soll sie nicht endlos im normalen Backlog vor sich herschieben – sondern sie landen nach einer **einstellbaren Anzahl verpasster Tage** (Standard: sofort nach dem ersten solchen Reset) im **Archiv**.

## Was Nutzer sehen

- **Neuer Archiv-Tab** (Symbol mit Kiste) neben Backlog/Heute; auch per Wischen zwischen den drei Bereichen erreichbar.
- **Archivierte Aufgaben** erscheinen **gedämpft/ausgegraut**, mit **Wischen**: zurück ins Backlog, direkt nach „Heute“, oder **löschen**.
- **Oranger Punkt** am Archiv-Symbol, wenn beim letzten Reset **neue** Einträge ins Archiv gekommen sind (verschwindet beim Öffnen des Archiv-Tabs).
- **Einstellungen:** Schieberegler (Stepper) **1–7 Tage**, ab wann archiviert wird; Button „Make it count deaktivieren“ erklärt per Dialog, warum das nicht geht (Kernfeature).
- **Welcome:** zusätzliche Seite zu „Make it count“ und eine **immer aktive** Checkbox mit gleicher Erklärung beim Antippen.

## Technisch (kurz)

- Neuer Status **archiviert**, Zähler und Zeitstempel für Archivierung; **Reset-Logik** unterscheidet wiederkehrende vs. normale Aufgaben; manuelles Zurücklegen von „Heute“ setzt den Zähler zurück.
- Tests für Reset, Archiv-ViewModel und Daily-Focus-Verhalten ergänzt.

## Hinweis zum Review

Bitte einmal **Archiv-Flow** (Reset simulieren oder warten), **Schwellwert** in den Einstellungen und **Welcome** auf einem Gerät durchklicken.