### PR TITLE
feat(settings): Kompakter iOS‑Stil, Make-it-count-Zähler, Welcome-Link

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -7810,66 +7810,6 @@
         }
       }
     },
-    "settings.category.description" : {
-      "comment" : "Settings · Footer text below category toggle · Plain sentence explaining the toggle.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Organisiere deine Backlog-Aufgaben in Kategorien."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Organize your backlog tasks into categories."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Organiza las tareas de tu Backlog por categorías."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Organisez les tâches de votre Backlog en catégories."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Organizza le attività del Backlog in categorie."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バックログのタスクをカテゴリで整理します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "백로그 작업을 카테고리로 정리합니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Organize as tarefas do seu Backlog em categorias."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将待办清单中的任务按分类整理。"
-          }
-        }
-      }
-    },
     "settings.category.section" : {
       "comment" : "Settings · Section header for category-related toggles · Plural noun phrase.",
       "extractionState" : "manual",
@@ -8046,66 +7986,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "调试"
-          }
-        }
-      }
-    },
-    "settings.display.description" : {
-      "comment" : "Settings · Footer text below display toggle · Plain sentence.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeigt erledigte Aufgaben im „Heute“-Tab."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shows completed tasks in the Today tab."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra las tareas completadas en la pestaña Hoy."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affiche les tâches terminées dans l’onglet Aujourd’hui."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra le attività completate nella scheda Oggi."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「今日」タブに完了済みのタスクを表示します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "‘오늘’ 탭에 완료된 작업을 표시합니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra as tarefas concluídas na aba Hoje."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在“今天”标签页显示已完成的任务。"
           }
         }
       }
@@ -8530,66 +8410,6 @@
         }
       }
     },
-    "settings.reset.description" : {
-      "comment" : "Settings · Footer text below reset-time picker · Plain sentence explaining the daily reset.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht erledigte Aufgaben werden täglich um diese Uhrzeit zurück ins Backlog verschoben."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uncompleted tasks will be moved back to the backlog daily at this time."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las tareas sin completar se devolverán al Backlog cada día a esta hora."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chaque jour à cette heure, les tâches non terminées sont renvoyées vers le Backlog."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le attività non completate vengono riportate nel Backlog ogni giorno a quest’ora."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未完了のタスクは毎日この時刻にバックログへ戻されます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "완료되지 않은 작업은 매일 이 시각에 백로그로 다시 이동합니다."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tarefas não concluídas voltam para o Backlog diariamente neste horário."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未完成的任务会在每天的这个时间移回待办清单。"
-          }
-        }
-      }
-    },
     "settings.reset.section" : {
       "comment" : "Settings · Section header for the daily reset configuration · Single noun.",
       "extractionState" : "manual",
@@ -8651,61 +8471,61 @@
       }
     },
     "settings.reset.time" : {
-      "comment" : "Settings · DatePicker label for the daily reset time · Noun phrase.",
+      "comment" : "Settings · DatePicker label · Daily reset clock time.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset-Zeit"
+            "value" : "Uhrzeit für täglichen Reset"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset Time"
+            "value" : "Time for daily reset"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hora de restablecimiento"
+            "value" : "Hora del reinicio diario"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Heure de réinitialisation"
+            "value" : "Heure du réinitialisation quotidienne"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ora di reimpostazione"
+            "value" : "Ora del ripristino giornaliero"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リセット時刻"
+            "value" : "日次リセットの時刻"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "초기화 시각"
+            "value" : "매일 초기화 시각"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Horário de redefinição"
+            "value" : "Horário da redefinição diária"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置时间"
+            "value" : "每日重置时间"
           }
         }
       }
@@ -9006,6 +8826,66 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示欢迎页面"
+          }
+        }
+      }
+    },
+    "settings.welcome.showAgain" : {
+      "comment" : "Settings · Footer button · Re-opens the welcome onboarding.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommensnachricht erneut anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show welcome message again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a mostrar el mensaje de bienvenida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher à nouveau le message de bienvenue"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra di nuovo il messaggio di benvenuto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェルカムメッセージをもう一度表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환영 메시지 다시 보기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar mensagem de boas-vindas novamente"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再次显示欢迎信息"
           }
         }
       }
@@ -11823,74 +11703,20 @@
         }
       }
     },
-    "settings.makeitcount.description" : {
-      "comment" : "Settings · Make it count section · Description text below the stepper.",
+    "settings.makeitcount.label" : {
+      "comment" : "Settings · Make it count · Explanation beside the numeric counter (no number in string).",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nicht-wiederkehrende Tasks, die nach dem Reset nicht erledigt wurden, werden archiviert. Wiederkehrende Tasks kehren immer ins Backlog zurück."
+            "value" : "Make it count. Task archivieren, wenn sie so häufig nicht erledigt wurde"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Non-recurring tasks that are not completed after the daily reset will be archived. Recurring tasks always return to the backlog."
-          }
-        }
-      }
-    },
-    "settings.makeitcount.disable" : {
-      "comment" : "Settings · Make it count section · Button label to attempt disabling (triggers locked alert).",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make it count deaktivieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Make it count"
-          }
-        }
-      }
-    },
-    "settings.makeitcount.section" : {
-      "comment" : "Settings · Section title for Make it count settings.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make it count"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make it count"
-          }
-        }
-      }
-    },
-    "settings.makeitcount.stepper" : {
-      "comment" : "Settings · Make it count stepper label. Uses interpolated threshold number.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archivieren nach \\(settings.makeItCountThreshold) verpasstem Tag(en)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archive after \\(settings.makeItCountThreshold) missed day(s)"
+            "value" : "Make it count. Archive a task if it was incomplete on Today."
           }
         }
       }

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -54,7 +54,7 @@ final class Task {
     /// erzeugten Backlog-Clone in Verbindung.
     var recurringCloneID: UUID? = nil
 
-    /// Zählt wie oft der Task beim automatischen Reset nicht erledigt war.
+    /// Zählt, wie oft der Task im Heute-Tab lag und beim täglichen Reset noch nicht erledigt war.
     /// Wird bei manuellem Zurücklegen und bei Unarchivierung auf 0 gesetzt.
     var resetCount: Int = 0
 

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -94,7 +94,7 @@ final class ResetEngine {
                 if task.resetCount >= threshold {
                     task.archive()
                     hasArchivedAnyTask = true
-                    print("📦 Archived task '\(task.title)' after \(task.resetCount) missed reset(s)")
+                    print("📦 Archived task '\(task.title)' after \(task.resetCount) incomplete day(s) on Today")
                 } else {
                     task.resetToBacklog()
                     let offset = TimeInterval(-index) * 0.001

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -10,8 +10,11 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct SettingsView: View {
+
+    private static let makeItCountThresholdRange = 1...7
     @Bindable var settings: AppSettings
     @Environment(\.dismiss) private var dismiss
     
@@ -41,8 +44,6 @@ struct SettingsView: View {
         self._resetTime = State(initialValue: calendar.date(from: components) ?? Date())
     }
     
-    @State private var showMakeItCountLockedAlert = false
-
     var body: some View {
         NavigationStack {
             Form {
@@ -50,38 +51,15 @@ struct SettingsView: View {
                 resetSection
                 makeItCountSection
                 synchronisationSection
-                displaySection
-                categorySection
-                infoSection
+                appearanceSection
             }
-            .alert(
-                String(localized: "makeitcount.alert.title", defaultValue: "Make it count is essential"),
-                isPresented: $showMakeItCountLockedAlert
-            ) {
-                Button(String(localized: "makeitcount.alert.confirm", defaultValue: "Sounds great"), role: .cancel) {}
-            } message: {
-                Text(
-                    String(
-                        localized: "makeitcount.alert.message",
-                        defaultValue: "This is one of Dawny's core features. Tasks that are not completed are archived so your backlog stays focused and meaningful.\n\nTherefore, Make it count cannot be disabled in Dawny."
-                    )
-                )
+            .listSectionSpacing(.compact)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                settingsBottomChrome
             }
             .navigationTitle(String(localized: "settings.title", defaultValue: "Settings"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if let onRequestShowWelcome {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button {
-                            dismiss()
-                            onRequestShowWelcome()
-                        } label: {
-                            Image(systemName: "questionmark.circle")
-                        }
-                        .accessibilityLabel(String(localized: "settings.welcome.help", defaultValue: "Show welcome screen"))
-                        .accessibilityIdentifier("SettingsShowWelcomeButton")
-                    }
-                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(String(localized: "settings.done", defaultValue: "Done")) {
                         dismiss()
@@ -96,7 +74,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var debugSection: some View {
         if onRequestAddTestItems != nil || onRequestDeleteAll != nil {
-            Section(String(localized: "settings.debug.section", defaultValue: "Debug")) {
+            Section {
                 if let onRequestAddTestItems {
                     Button {
                         onRequestAddTestItems()
@@ -125,51 +103,74 @@ struct SettingsView: View {
     }
     
     private var makeItCountSection: some View {
-        Section(String(localized: "settings.makeitcount.section", defaultValue: "Make it count")) {
-            Stepper(
-                value: $settings.makeItCountThreshold,
-                in: 1...7
-            ) {
-                HStack {
-                    Text(
-                        String(
-                            localized: "settings.makeitcount.stepper",
-                            defaultValue: "Archive after \(settings.makeItCountThreshold) missed day(s)"
-                        )
-                    )
-                    Spacer()
-                }
-            }
+        Section {
+            HStack(alignment: .center, spacing: 12) {
+                Text(String(localized: "settings.makeitcount.label", defaultValue: "Make it count. Archive a task if it was incomplete on Today."))
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(
-                String(
-                    localized: "settings.makeitcount.description",
-                    defaultValue: "Non-recurring tasks that are not completed after the daily reset will be archived. Recurring tasks always return to the backlog."
-                )
-            )
-            .font(.caption)
-            .foregroundColor(.secondary)
-
-            Button {
-                showMakeItCountLockedAlert = true
-            } label: {
-                HStack {
-                    Label(
-                        String(localized: "settings.makeitcount.disable", defaultValue: "Disable Make it count"),
-                        systemImage: "lock.fill"
-                    )
-                    .foregroundStyle(.secondary)
-                    Spacer()
-                }
+                makeItCountThresholdPill
             }
-            .buttonStyle(.plain)
         }
     }
 
+    private var makeItCountThresholdPill: some View {
+        let range = Self.makeItCountThresholdRange
+        return HStack(spacing: 0) {
+            Button {
+                if settings.makeItCountThreshold > range.lowerBound {
+                    settings.makeItCountThreshold -= 1
+                }
+            } label: {
+                Image(systemName: "minus")
+                    .font(.body.weight(.medium))
+                    .frame(width: 38, height: 34)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(settings.makeItCountThreshold <= range.lowerBound)
+
+            makeItCountPillDivider
+
+            Text("\(settings.makeItCountThreshold)")
+                .font(.body.weight(.medium))
+                .monospacedDigit()
+                .frame(minWidth: 26)
+
+            makeItCountPillDivider
+
+            Button {
+                if settings.makeItCountThreshold < range.upperBound {
+                    settings.makeItCountThreshold += 1
+                }
+            } label: {
+                Image(systemName: "plus")
+                    .font(.body.weight(.medium))
+                    .frame(width: 38, height: 34)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(settings.makeItCountThreshold >= range.upperBound)
+        }
+        .foregroundStyle(.primary)
+        .padding(.horizontal, 2)
+        .padding(.vertical, 4)
+        .background(Color(uiColor: .secondarySystemFill))
+        .clipShape(Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("SettingsMakeItCountThreshold")
+    }
+
+    private var makeItCountPillDivider: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.12))
+            .frame(width: 1, height: 22)
+    }
+
     private var resetSection: some View {
-        Section(String(localized: "settings.reset.section", defaultValue: "Reset")) {
+        Section {
             DatePicker(
-                String(localized: "settings.reset.time", defaultValue: "Reset Time"),
+                String(localized: "settings.reset.time", defaultValue: "Time for daily reset"),
                 selection: $resetTime,
                 displayedComponents: .hourAndMinute
             )
@@ -177,37 +178,24 @@ struct SettingsView: View {
                 let hour = Calendar.current.component(.hour, from: newValue)
                 settings.resetHour = hour
             }
-            
-            Text(String(localized: "settings.reset.description", defaultValue: "Uncompleted tasks will be moved back to the backlog daily at this time."))
-                .font(.caption)
-                .foregroundColor(.secondary)
         }
     }
     
     private var synchronisationSection: some View {
-        Section(String(localized: "settings.sync.section", defaultValue: "Synchronization")) {
+        Section {
             Toggle(String(localized: "settings.sync.toggle", defaultValue: "Calendar Sync"), isOn: $settings.calendarSyncEnabled)
-            
+        } footer: {
             Text(String(localized: "settings.sync.description", defaultValue: "Synchronizes Daily Focus tasks with iOS Reminders."))
-                .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
     
-    private var displaySection: some View {
-        Section(String(localized: "settings.display.section", defaultValue: "Display")) {
+    private var appearanceSection: some View {
+        Section {
             Toggle(String(localized: "settings.display.toggle", defaultValue: "Show Completed Tasks"), isOn: $settings.showCompletedTasksInToday)
-            
-            Text(String(localized: "settings.display.description", defaultValue: "Shows completed tasks in the Today tab."))
-                .font(.caption)
-                .foregroundColor(.secondary)
-        }
-    }
-    
-    private var categorySection: some View {
-        Section(String(localized: "settings.category.section", defaultValue: "Backlog Categories")) {
             Toggle(String(localized: "settings.category.toggle", defaultValue: "Show Categories"), isOn: $settings.showCategories)
-            
+
             if settings.showCategories {
                 Picker(String(localized: "settings.category.default", defaultValue: "Default Category for New Tasks"), selection: $settings.defaultCategoryType) {
                     ForEach(TaskCategory.allCases.filter { $0 != .uncategorized && $0 != .custom }, id: \.self) { category in
@@ -219,31 +207,49 @@ struct SettingsView: View {
                     }
                 }
             }
-            
-            Text(String(localized: "settings.category.description", defaultValue: "Organize your backlog tasks into categories."))
-                .font(.caption)
-                .foregroundColor(.secondary)
         }
     }
     
-    private var infoSection: some View {
-        Section(String(localized: "settings.info.section", defaultValue: "Info")) {
-            HStack {
-                Text(String(localized: "settings.info.version", defaultValue: "Version"))
-                Spacer()
-                Text(appVersion)
-                    .foregroundColor(.secondary)
+    private var settingsBottomChrome: some View {
+        VStack(spacing: 10) {
+            if let onRequestShowWelcome {
+                Button {
+                    dismiss()
+                    onRequestShowWelcome()
+                } label: {
+                    Text(String(localized: "settings.welcome.showAgain", defaultValue: "Show welcome message again"))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("SettingsShowWelcomeButton")
             }
-            
-            HStack {
-                Text(String(localized: "settings.info.build", defaultValue: "Build"))
-                Spacer()
-                Text(appBuild)
-                    .foregroundColor(.secondary)
-            }
+
+            Text(versionBuildFooterLine)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .accessibilityLabel(versionBuildAccessibilityLabel)
         }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+        .background(Color(uiColor: .systemGroupedBackground))
     }
-    
+
+    private var versionBuildFooterLine: String {
+        "\(appVersion) (\(appBuild))"
+    }
+
+    private var versionBuildAccessibilityLabel: String {
+        let versionLabel = String(localized: "settings.info.version", defaultValue: "Version")
+        let buildLabel = String(localized: "settings.info.build", defaultValue: "Build")
+        return "\(versionLabel) \(appVersion), \(buildLabel) \(appBuild)"
+    }
+
     // MARK: - Computed Properties
     
     private var appVersion: String {


### PR DESCRIPTION
## Kurzüberblick
Die **Einstellungen** wirken näher am üblichen **iOS‑Settings‑Look**: weniger Leerraum, **keine grauen Kapitel‑Überschriften**, und wo noch Hilfstext steht, sitzt er **unter** der weißen Karte statt als extra Zeile **in** der Karte.

## Inhaltliche Änderungen
- **Täglicher Reset:** Label **„Uhrzeit für täglichen Reset“**; der lange Erklärungstext unter der Uhrzeit ist **weg** (steckt in der Welcome‑Story).
- **Make it count:** Schwelle über einen **Minus‑Zahl‑Plus‑Balken** statt „… x Mal“ im Satz; Texte auf **„so oft im Heute‑Tab nicht erledigt“** ausgerichtet; **Deaktivieren‑Button** und die alte falsche Zahlen‑Anzeige im String‑Katalog sind bereinigt.
- **Anzeige / Kategorien:** Die kurzen Erklärungen unter den Schaltern sind **entfernt**; die beiden Bereiche sind zu **einer** Gruppe zusammengezogen.
- **Version & Build:** Stehen **unten außerhalb** der Liste, klein und grau, als **`Version (Build)`** (z. B. `1.2.3 (456)`).
- **Welcome:** Statt **Fragezeichen‑Button** in der Titelleiste gibt es unten den Button **„Willkommensnachricht erneut anzeigen“** / **„Show welcome message again“**, der wie zuvor die **Welcome‑Maske** öffnet und die **Einstellungen schließt**.

## Für dich als Orientierung
Als Nutzer siehst du vor allem: **aufgeräumtere Einstellungen**, **klarere Texte** rund um Reset und Archivieren, und **Welcome** erreichst du **unten** über den neuen Link statt über das **?** oben.