### PR TITLE
Info screen gone

### DIFF
--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -52,6 +52,7 @@ struct SettingsView: View {
                 makeItCountSection
                 synchronisationSection
                 appearanceSection
+                welcomeSection
             }
             .listSectionSpacing(.compact)
             .safeAreaInset(edge: .bottom, spacing: 0) {
@@ -209,35 +210,38 @@ struct SettingsView: View {
             }
         }
     }
-    
-    private var settingsBottomChrome: some View {
-        VStack(spacing: 10) {
-            if let onRequestShowWelcome {
+
+    @ViewBuilder
+    private var welcomeSection: some View {
+        if let showWelcomeAgain = onRequestShowWelcome {
+            Section {
                 Button {
                     dismiss()
-                    onRequestShowWelcome()
+                    showWelcomeAgain()
                 } label: {
                     Text(String(localized: "settings.welcome.showAgain", defaultValue: "Show welcome message again"))
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity)
+                        .foregroundStyle(.primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.borderless)
+                .tint(.primary)
                 .accessibilityIdentifier("SettingsShowWelcomeButton")
             }
-
-            Text(versionBuildFooterLine)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
-                .accessibilityLabel(versionBuildAccessibilityLabel)
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 12)
-        .padding(.bottom, 8)
-        .background(Color(uiColor: .systemGroupedBackground))
+    }
+    
+    private var settingsBottomChrome: some View {
+        Text(versionBuildFooterLine)
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 8)
+            .background(Color(uiColor: .systemGroupedBackground))
+            .accessibilityLabel(versionBuildAccessibilityLabel)
     }
 
     private var versionBuildFooterLine: String {

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -129,9 +129,12 @@ private struct TaskRowContent: View {
         return buildRowStack()
             .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
             .modifier(TrailingSwipeDeleteModifier(onDelete: onDelete))
+            // Task detail (info icon + sheet): set Swift flag ENABLE_TASK_DETAIL in the target’s Other Swift Flags to re-enable.
+            #if ENABLE_TASK_DETAIL
             .sheet(isPresented: $showingDetail) {
                 TaskDetailView(task: task)
             }
+            #endif
     }
 
     private func buildRowStack() -> some View {
@@ -167,9 +170,11 @@ private struct TaskRowContent: View {
             
             titleAndMetaColumn
 
+            #if ENABLE_TASK_DETAIL
             if isEditingTitle {
                 infoButton
             }
+            #endif
         }
         .padding(.vertical, verticalPadding)
         .contentShape(Rectangle())


### PR DESCRIPTION
## Was sich für Nutzer ändert
- **Einstellungen** wirken **ruhiger und übersichtlicher**: keine grauen Kapitel-Überschriften, **weniger Leerfläche** zwischen den Kacheln, und **Hinweistexte** sitzen **unter** der passenden Einstellung (nur noch beim **Kalender-Sync**), **nicht** als extra Zeile in der weißen Box.
- **Täglicher Reset:** kurzes Label **„Uhrzeit für täglichen Reset“**; der frühere lange Absatz darunter ist **weg** (steckt in der Welcome-Einführung).
- **Make it count:** Schwelle wird mit einem **Minus–Zahl–Plus**-Steuer eingestellt; Texte beschreiben **„so oft im Heute-Tab nicht erledigt“** statt „verpasste Tage“; überflüssige Buttons/Erklärungen sind bereinigt.
- **Anzeige & Kategorien** stehen **in einer** Gruppe; die kurzen Hilfetexte unter den Schaltern gibt es **nicht mehr**.
- **Version & Build** stehen **ganz unten**, klein und grau, im Format **`1.2.3 (456)`**, nicht mehr als eigene Listeinträge.
- **Welcome erneut:** nicht mehr über das **?** oben, sondern über eine **normale Zeile** in den Einstellungen (**„Willkommensnachricht erneut anzeigen“** / „Show welcome message again“).

## Hinweis
String-Katalog und `SettingsView` wurden entsprechend angepasst; Verhalten beim Tippen (Einstellungen schließen, Welcome öffnen) entspricht der bisherigen Logik.