### PR TITLE
Rename categories

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -1493,6 +1493,390 @@
         }
       }
     },
+    "debug.testtask.archived.1" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Finally unsubscribe from that annoying newsletter"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den nervigen Newsletter endlich abbestellen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finally unsubscribe from that annoying newsletter"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.10" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Find fresh batteries for the remote"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Batterien für die Fernbedienung suchen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find fresh batteries for the remote"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.11" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Find the partner for the lonely blue sock"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den Partner für die einsame blaue Socke finden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find the partner for the lonely blue sock"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.12" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sort the top layer of the chaos drawer"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die oberste Schicht der Chaos-Schublade sortieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort the top layer of the chaos drawer"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.13" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Try the tea that's been in cabinet since 2023"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den Tee probieren, der seit 2023 im Schrank steht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try the tea that's been in cabinet since 2023"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.14" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pick a new desktop wallpaper"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein neues Desktop-Hintergrundbild aussuchen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick a new desktop wallpaper"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.15" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Throw all coin change into piggy bank"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das ganze Kleingeld aus dem Portemonnaie ins Sparschwein werfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Throw all coin change into piggy bank"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.16" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Figure out that one fridge noise"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herausfinden, was dieses eine Geräusch im Kühlschrank ist"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Figure out that one fridge noise"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.2" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Clean up the YouTube 'Watch later' list"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die „Später ansehen“-Liste auf YouTube aussortieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clean up the YouTube 'Watch later' list"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.3" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make an iPhone backup (for real!)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein iPhone Backup machen (wirklich!)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make an iPhone backup (for real!)"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.4" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Delete nearly identical selfies from gallery"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fast identische Selfies aus der Galerie löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete nearly identical selfies from gallery"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.5" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Clean the window that gets full sun"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Fenster putzen, auf das die Sonne direkt scheint"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clean the window that gets full sun"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.6" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tame the cable mess behind the TV"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den Kabelsalat hinter dem Fernseher bändigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tame the cable mess behind the TV"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.7" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Take out the waste paper"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altpapier weg bringen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Take out the waste paper"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.8" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Repot flowers that are outgrowing the pot"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Blumen umtopfen, die schon fast aus dem Topf fallen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repot flowers that are outgrowing the pot"
+          }
+        }
+      }
+    },
+    "debug.testtask.archived.9" : {
+      "comment" : "Debug-only · Archived sample test task title · Used by 'Add Test Items' settings action.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shake crumbs out of keyboard"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Krümel aus der Tastatur schütteln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shake crumbs out of keyboard"
+          }
+        }
+      }
+    },
     "debug.testtask.quick.1" : {
       "comment" : "Debug-only · Sample test task title (Quick category) · Used by 'Add Test Items' settings action.",
       "extractionState" : "manual",

--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -1349,74 +1349,74 @@
         }
       }
     },
-    "category.thisMonth.name" : {
-      "comment" : "Backlog · Default category for tasks due this month · Noun phrase.",
+    "category.nextFewWeeks.name" : {
+      "comment" : "Backlog · Default category for tasks due in the next couple of weeks · Noun phrase.",
       "extractionState" : "manual",
       "localizations" : {
         "base" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "This Month"
+            "value" : "Next couple of weeks"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diesen Monat"
+            "value" : "Die nächsten Wochen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This Month"
+            "value" : "Next couple of weeks"
           }
         }
       }
     },
-    "category.thisWeek.name" : {
-      "comment" : "Backlog · Default category for tasks due this week · Noun phrase.",
+    "category.nextFewDays.name" : {
+      "comment" : "Backlog · Default category for tasks due in the next couple of days · Noun phrase.",
       "extractionState" : "manual",
       "localizations" : {
         "base" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "This Week"
+            "value" : "Next couple of days"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Woche"
+            "value" : "Die nächsten Tage"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This Week"
+            "value" : "Next couple of days"
           }
         }
       }
     },
-    "category.thisYear.name" : {
-      "comment" : "Backlog · Default category for tasks due this year · Noun phrase.",
+    "category.nextFewMonths.name" : {
+      "comment" : "Backlog · Default category for tasks due in the next couple of months · Noun phrase.",
       "extractionState" : "manual",
       "localizations" : {
         "base" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "This Year"
+            "value" : "Next couple of months"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieses Jahr"
+            "value" : "Die nächsten Monate"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This Year"
+            "value" : "Next couple of months"
           }
         }
       }

--- a/App/Sources/Models/Category.swift
+++ b/App/Sources/Models/Category.swift
@@ -109,7 +109,16 @@ final class Category {
     /// (re-)lokalisierte Variante aus `TaskCategory.displayName` zurück.
     /// Dadurch funktioniert ein Sprachwechsel weiterhin korrekt.
     var displayName: String {
-        isNameCustomized ? name : categoryType.displayName
+        if isNameCustomized {
+            return name
+        }
+        if isRecurring && categoryType == .custom {
+            return String(
+                localized: "category.recurring.default.name",
+                defaultValue: "Recurring Tasks"
+            )
+        }
+        return categoryType.displayName
     }
 
     /// SF-Symbol für die UI. Folgt der gleichen Logik wie `displayName`.

--- a/App/Sources/Models/TaskCategory.swift
+++ b/App/Sources/Models/TaskCategory.swift
@@ -16,14 +16,14 @@ enum TaskCategory: String, Codable, CaseIterable {
     /// Schnell erledigen
     case quick
     
-    /// Diese Woche
-    case thisWeek
+    /// Nächste Tage
+    case nextFewDays = "thisWeek"
     
-    /// Diesen Monat
-    case thisMonth
+    /// Nächste Wochen
+    case nextFewWeeks = "thisMonth"
     
-    /// Dieses Jahr
-    case thisYear
+    /// Nächste Monate
+    case nextFewMonths = "thisYear"
     
     /// Irgendwann
     case someday
@@ -39,12 +39,12 @@ enum TaskCategory: String, Codable, CaseIterable {
         switch self {
         case .quick:
             return String(localized: "category.quick.name", defaultValue: "Quick")
-        case .thisWeek:
-            return String(localized: "category.thisWeek.name", defaultValue: "This Week")
-        case .thisMonth:
-            return String(localized: "category.thisMonth.name", defaultValue: "This Month")
-        case .thisYear:
-            return String(localized: "category.thisYear.name", defaultValue: "This Year")
+        case .nextFewDays:
+            return String(localized: "category.nextFewDays.name", defaultValue: "Next couple of days")
+        case .nextFewWeeks:
+            return String(localized: "category.nextFewWeeks.name", defaultValue: "Next couple of weeks")
+        case .nextFewMonths:
+            return String(localized: "category.nextFewMonths.name", defaultValue: "Next couple of months")
         case .someday:
             return String(localized: "category.someday.name", defaultValue: "Someday")
         case .uncategorized:
@@ -59,11 +59,11 @@ enum TaskCategory: String, Codable, CaseIterable {
         switch self {
         case .quick:
             return "bolt.fill"
-        case .thisWeek:
+        case .nextFewDays:
             return "calendar"
-        case .thisMonth:
+        case .nextFewWeeks:
             return "calendar.badge.clock"
-        case .thisYear:
+        case .nextFewMonths:
             return "calendar.badge.exclamationmark"
         case .someday:
             return "infinity"
@@ -79,18 +79,18 @@ enum TaskCategory: String, Codable, CaseIterable {
         switch self {
         case .quick:
             return 0
-        case .thisWeek:
+        case .nextFewDays:
             return 1
-        case .thisMonth:
+        case .nextFewWeeks:
             return 2
-        case .thisYear:
+        case .nextFewMonths:
             return 3
         case .someday:
-            return 4
-        case .uncategorized:
             return 5
-        case .custom:
+        case .uncategorized:
             return 6
+        case .custom:
+            return 7
         }
     }
 }

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -79,7 +79,7 @@ final class CategoryService {
             var allCategories = try modelContext.fetch(descriptor)
 
             if allCategories.isEmpty {
-                let types: [TaskCategory] = [.quick, .thisWeek, .thisMonth, .thisYear, .someday, .uncategorized]
+                let types: [TaskCategory] = [.quick, .nextFewDays, .nextFewWeeks, .nextFewMonths, .someday, .uncategorized]
                 for categoryType in types {
                     let category = Category(
                         categoryType: categoryType,
@@ -103,16 +103,16 @@ final class CategoryService {
                 )
                 modelContext.insert(recurring)
                 try modelContext.save()
-            } else {
-                try repositionDefaultRecurringBeforeUncategorizedIfNeeded()
-                try modelContext.save()
             }
+            try repositionDefaultRecurringBeforeUncategorizedIfNeeded()
+            try repositionDefaultRecurringBeforeSomedayIfNeeded()
+            try modelContext.save()
         } catch {
             print("Fehler bei Standard-Kategorien / wiederkehrender Default: \(error)")
         }
     }
 
-    // MARK: - Recurring default placement (direkt vor „Unkategorisiert“)
+    // MARK: - Recurring default placement
 
     private static let fallbackDefaultRecurringNames: Set<String> = [
         "Recurring Tasks",
@@ -143,6 +143,22 @@ final class CategoryService {
         allCategories: inout [Category],
         defaultName: String
     ) throws -> Category {
+        let sorted = allCategories.sorted()
+        if let someday = sorted.first(where: { $0.categoryType == .someday }) {
+            let target = someday.orderIndex
+            shiftOrderIndicesUp(from: target, excluding: nil)
+            return Category(
+                categoryType: .custom,
+                name: defaultName,
+                iconName: "arrow.triangle.2.circlepath",
+                orderIndex: target,
+                isUncategorized: false,
+                isNameCustomized: false,
+                isIconCustomized: true,
+                isRecurring: true
+            )
+        }
+
         guard let uncat = getUncategorizedCategory() else {
             let next = (allCategories.map(\.orderIndex).max() ?? -1) + 1
             return Category(
@@ -151,7 +167,7 @@ final class CategoryService {
                 iconName: "arrow.triangle.2.circlepath",
                 orderIndex: next,
                 isUncategorized: false,
-                isNameCustomized: true,
+                isNameCustomized: false,
                 isIconCustomized: true,
                 isRecurring: true
             )
@@ -164,13 +180,14 @@ final class CategoryService {
             iconName: "arrow.triangle.2.circlepath",
             orderIndex: target,
             isUncategorized: false,
-            isNameCustomized: true,
+            isNameCustomized: false,
             isIconCustomized: true,
             isRecurring: true
         )
     }
 
     private static let recurringOrderMigratedKey = "DawnyMigratedRecurringDefaultBeforeUncategorizedV1"
+    private static let recurringOrderBeforeSomedayMigratedKey = "DawnyMigratedRecurringDefaultBeforeSomedayV2"
 
     /// Einmal: Standard-„Wiederkehrende Aufgaben“ (falls noch unter Unkategorisiert) vorschieben. Danach bleibt die manuelle Sortierung.
     private func repositionDefaultRecurringBeforeUncategorizedIfNeeded() throws {
@@ -193,6 +210,38 @@ final class CategoryService {
 
         rec.orderIndex = 999_999
         let target = uncat.orderIndex
+        for c in all where c.id != rec.id && c.orderIndex >= target {
+            c.orderIndex += 1
+        }
+        rec.orderIndex = target
+    }
+
+    /// Einmal: Standard-„Wiederkehrende Aufgaben“ direkt vor „Someday“ schieben.
+    private func repositionDefaultRecurringBeforeSomedayIfNeeded() throws {
+        guard !UserDefaults.standard.bool(forKey: Self.recurringOrderBeforeSomedayMigratedKey) else { return }
+        defer { UserDefaults.standard.set(true, forKey: Self.recurringOrderBeforeSomedayMigratedKey) }
+
+        let descriptor = FetchDescriptor<Category>()
+        let all = try modelContext.fetch(descriptor)
+        guard let someday = all.first(where: { $0.categoryType == .someday }) else { return }
+        let candidates = all.filter { isLikelyDefaultRecurringCategory($0) }
+        guard let rec = candidates.sorted(by: { $0.createdAt < $1.createdAt }).first else { return }
+
+        // Frühere Defaults wurden als "customized" gespeichert. Für dynamische Lokalisierung zurücksetzen.
+        if Self.fallbackDefaultRecurringNames.contains(rec.name) {
+            rec.isNameCustomized = false
+        }
+
+        let sorted = all.sorted()
+        guard
+            let somedayIndex = sorted.firstIndex(where: { $0.id == someday.id }),
+            let recIndex = sorted.firstIndex(where: { $0.id == rec.id })
+        else { return }
+
+        if recIndex < somedayIndex { return }
+
+        rec.orderIndex = 999_999
+        let target = someday.orderIndex
         for c in all where c.id != rec.id && c.orderIndex >= target {
             c.orderIndex += 1
         }

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -651,6 +651,10 @@ final class BacklogViewModel {
         let assignableCategories = categories
             .sorted()
             .filter { $0.categoryType != .uncategorized }
+        let defaultByType = Dictionary(
+            uniqueKeysWithValues: assignableCategories.map { ($0.categoryType, $0) }
+        )
+        let fallbackCategory = assignableCategories.first
 
         let todayDate = Calendar.current.startOfDay(for: Date())
 
@@ -666,6 +670,20 @@ final class BacklogViewModel {
                 if item.placeInToday {
                     task.moveToDailyFocus(date: todayDate)
                 }
+            }
+        }
+
+        for item in Self.archivedDebugTestItems() {
+            guard
+                let category = defaultByType[item.categoryType] ?? fallbackCategory,
+                let task = addTask(title: item.title, category: category)
+            else { continue }
+
+            task.isCompleted = false
+            task.archive()
+            if let archivedAt = Calendar.current.date(byAdding: .day, value: -item.daysAgo, to: Date()) {
+                task.archivedAt = archivedAt
+                task.modifiedAt = archivedAt
             }
         }
 
@@ -685,6 +703,13 @@ final class BacklogViewModel {
     private struct DebugTestItem {
         let title: String
         let placeInToday: Bool
+    }
+
+    /// Beschreibt einen Debug-Test-Task, der direkt archiviert erzeugt wird.
+    private struct ArchivedDebugTestItem {
+        let title: String
+        let categoryType: TaskCategory
+        let daysAgo: Int
     }
 
     /// Liefert die fünf Beispiel-Tasks für die gegebene Kategorie. Für unbekannte
@@ -824,6 +849,91 @@ final class BacklogViewModel {
             DebugTestItem(
                 title: String(localized: "debug.testtask.recurring.3", defaultValue: "5 min stretch break"),
                 placeInToday: false
+            )
+        ]
+    }
+
+    private static func archivedDebugTestItems() -> [ArchivedDebugTestItem] {
+        [
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.1", defaultValue: "Finally unsubscribe from that annoying newsletter"),
+                categoryType: .quick,
+                daysAgo: 2
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.2", defaultValue: "Clean up the YouTube 'Watch later' list"),
+                categoryType: .quick,
+                daysAgo: 3
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.3", defaultValue: "Make an iPhone backup (for real!)"),
+                categoryType: .nextFewDays,
+                daysAgo: 4
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.4", defaultValue: "Delete nearly identical selfies from gallery"),
+                categoryType: .quick,
+                daysAgo: 5
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.5", defaultValue: "Clean the window that gets full sun"),
+                categoryType: .nextFewDays,
+                daysAgo: 6
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.6", defaultValue: "Tame the cable mess behind the TV"),
+                categoryType: .nextFewWeeks,
+                daysAgo: 7
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.7", defaultValue: "Take out the waste paper"),
+                categoryType: .quick,
+                daysAgo: 8
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.8", defaultValue: "Repot flowers that are outgrowing the pot"),
+                categoryType: .nextFewWeeks,
+                daysAgo: 9
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.9", defaultValue: "Shake crumbs out of keyboard"),
+                categoryType: .quick,
+                daysAgo: 10
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.10", defaultValue: "Find fresh batteries for the remote"),
+                categoryType: .nextFewDays,
+                daysAgo: 11
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.11", defaultValue: "Find the partner for the lonely blue sock"),
+                categoryType: .quick,
+                daysAgo: 12
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.12", defaultValue: "Sort the top layer of the chaos drawer"),
+                categoryType: .nextFewDays,
+                daysAgo: 13
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.13", defaultValue: "Try the tea that's been in cabinet since 2023"),
+                categoryType: .someday,
+                daysAgo: 14
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.14", defaultValue: "Pick a new desktop wallpaper"),
+                categoryType: .quick,
+                daysAgo: 15
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.15", defaultValue: "Throw all coin change into piggy bank"),
+                categoryType: .nextFewDays,
+                daysAgo: 16
+            ),
+            ArchivedDebugTestItem(
+                title: String(localized: "debug.testtask.archived.16", defaultValue: "Figure out that one fridge noise"),
+                categoryType: .nextFewMonths,
+                daysAgo: 17
             )
         ]
     }

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -714,7 +714,7 @@ final class BacklogViewModel {
                     placeInToday: false
                 )
             ]
-        case .thisWeek:
+        case .nextFewDays:
             return [
                 DebugTestItem(
                     title: String(localized: "debug.testtask.thisweek.1", defaultValue: "RSVP to Carla’s wedding 💌"),
@@ -737,7 +737,7 @@ final class BacklogViewModel {
                     placeInToday: false
                 )
             ]
-        case .thisMonth:
+        case .nextFewWeeks:
             return [
                 DebugTestItem(
                     title: String(localized: "debug.testtask.thismonth.1", defaultValue: "Replace printer cartridge"),
@@ -760,7 +760,7 @@ final class BacklogViewModel {
                     placeInToday: false
                 )
             ]
-        case .thisYear:
+        case .nextFewMonths:
             return [
                 DebugTestItem(
                     title: String(localized: "debug.testtask.thisyear.1", defaultValue: "Buy a new fridge"),

--- a/DawnyTests/Services/CategoryServiceTests.swift
+++ b/DawnyTests/Services/CategoryServiceTests.swift
@@ -27,6 +27,9 @@ final class CategoryServiceTests: XCTestCase {
         UserDefaults.standard.removeObject(
             forKey: "DawnyMigratedRecurringDefaultBeforeUncategorizedV1"
         )
+        UserDefaults.standard.removeObject(
+            forKey: "DawnyMigratedRecurringDefaultBeforeSomedayV2"
+        )
         container = try TestModelContainer.create()
         context = container.mainContext
         service = CategoryService(modelContext: context)
@@ -69,7 +72,7 @@ final class CategoryServiceTests: XCTestCase {
     // MARK: - Rename
 
     func testRenameTrimsWhitespaceAndMarksCustomized() throws {
-        let cat = try category(.thisWeek)
+        let cat = try category(.nextFewDays)
         XCTAssertFalse(cat.isNameCustomized)
 
         try service.rename(cat, to: "  Wichtig  ")
@@ -80,7 +83,7 @@ final class CategoryServiceTests: XCTestCase {
     }
 
     func testRenameEmptyThrows() throws {
-        let cat = try category(.thisWeek)
+        let cat = try category(.nextFewDays)
 
         XCTAssertThrowsError(try service.rename(cat, to: "   ")) { error in
             guard case CategoryEditError.nameEmpty = error else {
@@ -91,7 +94,7 @@ final class CategoryServiceTests: XCTestCase {
     }
 
     func testRenameTooLongThrows() throws {
-        let cat = try category(.thisWeek)
+        let cat = try category(.nextFewDays)
         let tooLong = String(repeating: "x", count: CategoryService.maxNameLength + 1)
 
         XCTAssertThrowsError(try service.rename(cat, to: tooLong)) { error in
@@ -124,7 +127,7 @@ final class CategoryServiceTests: XCTestCase {
     // MARK: - Update Icon
 
     func testUpdateIconMarksCustomized() throws {
-        let cat = try category(.thisWeek)
+        let cat = try category(.nextFewDays)
         XCTAssertFalse(cat.isIconCustomized)
 
         try service.updateIcon(cat, to: "star.fill")
@@ -135,7 +138,7 @@ final class CategoryServiceTests: XCTestCase {
     }
 
     func testUpdateIconEmptyResetsCustomFlag() throws {
-        let cat = try category(.thisWeek)
+        let cat = try category(.nextFewDays)
         try service.updateIcon(cat, to: "star.fill")
         XCTAssertTrue(cat.isIconCustomized)
 
@@ -143,7 +146,7 @@ final class CategoryServiceTests: XCTestCase {
 
         XCTAssertFalse(cat.isIconCustomized)
         // Display fällt auf Default zurück
-        XCTAssertEqual(cat.displayIconName, TaskCategory.thisWeek.iconName)
+        XCTAssertEqual(cat.displayIconName, TaskCategory.nextFewDays.iconName)
     }
 
     func testUpdateIconUncategorizedThrowsProtected() throws {
@@ -160,7 +163,7 @@ final class CategoryServiceTests: XCTestCase {
 
     func testDeleteWithStrategyDeleteTasksRemovesTasks() throws {
         let backlog = makeBacklog()
-        let cat = try category(.thisMonth)
+        let cat = try category(.nextFewWeeks)
         makeTask(in: backlog, category: cat, title: "A")
         makeTask(in: backlog, category: cat, title: "B")
 
@@ -168,7 +171,7 @@ final class CategoryServiceTests: XCTestCase {
 
         // Kategorie weg
         let remaining = service.getCategoriesSorted()
-        XCTAssertNil(remaining.first { $0.categoryType == .thisMonth })
+        XCTAssertNil(remaining.first { $0.categoryType == .nextFewWeeks })
 
         // Tasks weg
         let allTasks = try context.fetch(FetchDescriptor<Task>())
@@ -177,7 +180,7 @@ final class CategoryServiceTests: XCTestCase {
 
     func testDeleteWithStrategyMoveMovesTasksToUncategorized() throws {
         let backlog = makeBacklog()
-        let cat = try category(.thisMonth)
+        let cat = try category(.nextFewWeeks)
         let uncat = try category(.uncategorized)
         makeTask(in: backlog, category: cat, title: "A")
         makeTask(in: backlog, category: cat, title: "B")
@@ -185,7 +188,7 @@ final class CategoryServiceTests: XCTestCase {
         try service.delete(cat, strategy: .moveToUncategorized)
 
         // Kategorie weg
-        XCTAssertNil(service.getCategory(type: .thisMonth))
+        XCTAssertNil(service.getCategory(type: .nextFewWeeks))
 
         // Tasks existieren weiterhin und gehören jetzt zu Uncategorized
         let allTasks = try context.fetch(FetchDescriptor<Task>())
@@ -216,8 +219,8 @@ final class CategoryServiceTests: XCTestCase {
     }
 
     func testDeleteResetsDefaultCategoryFallback() throws {
-        AppSettings.shared.defaultCategoryType = .thisYear
-        let cat = try category(.thisYear)
+        AppSettings.shared.defaultCategoryType = .nextFewMonths
+        let cat = try category(.nextFewMonths)
 
         try service.delete(cat, strategy: .moveToUncategorized)
 
@@ -226,12 +229,12 @@ final class CategoryServiceTests: XCTestCase {
     }
 
     func testDeleteDoesNotChangeDefaultIfDifferentCategory() throws {
-        AppSettings.shared.defaultCategoryType = .thisWeek
-        let cat = try category(.thisMonth)
+        AppSettings.shared.defaultCategoryType = .nextFewDays
+        let cat = try category(.nextFewWeeks)
 
         try service.delete(cat, strategy: .moveToUncategorized)
 
-        XCTAssertEqual(AppSettings.shared.defaultCategoryType, .thisWeek)
+        XCTAssertEqual(AppSettings.shared.defaultCategoryType, .nextFewDays)
     }
 
     // MARK: - Display Properties
@@ -263,7 +266,7 @@ final class CategoryServiceTests: XCTestCase {
         XCTAssertTrue(quick.canToggleRecurring)
         XCTAssertTrue(quick.hasAnyEditCapability)
 
-        let week = try category(.thisWeek)
+        let week = try category(.nextFewDays)
         XCTAssertTrue(week.canRename)
         XCTAssertTrue(week.canChangeIcon)
         XCTAssertTrue(week.canDelete)
@@ -279,17 +282,33 @@ final class CategoryServiceTests: XCTestCase {
         XCTAssertEqual(recurring[0].categoryType, .custom)
     }
 
-    func testRecurringDefaultPlacedBeforeUncategorized() throws {
+    func testRecurringDefaultPlacedBeforeSomedayAndUncategorized() throws {
+        let someday = try category(.someday)
         let uncat = try category(.uncategorized)
         let rec = try XCTUnwrap(
             service.getCategoriesSorted().first(where: { $0.isRecurring })
         )
-        XCTAssertLessThan(rec.orderIndex, uncat.orderIndex, "Wiederkehrende Aufgaben unmittelbar vor Unkategorisiert (orderIndex)")
+        XCTAssertLessThan(rec.orderIndex, someday.orderIndex, "Wiederkehrende Aufgaben vor Someday (orderIndex)")
+        XCTAssertLessThan(someday.orderIndex, uncat.orderIndex, "Someday vor Unkategorisiert (orderIndex)")
 
         let order = service.getCategoriesSorted()
         let rIdx = try XCTUnwrap(order.firstIndex(where: { $0.id == rec.id }))
+        let sIdx = try XCTUnwrap(order.firstIndex(where: { $0.id == someday.id }))
         let uIdx = try XCTUnwrap(order.firstIndex(where: { $0.id == uncat.id }))
-        XCTAssertLessThan(rIdx, uIdx, "Kategorie-Liste: wiederkehrend vor Unkategorisiert")
+        XCTAssertLessThan(rIdx, sIdx, "Kategorie-Liste: wiederkehrend vor Someday")
+        XCTAssertLessThan(sIdx, uIdx, "Kategorie-Liste: Someday vor Unkategorisiert")
+    }
+
+    func testDefaultRecurringCategoryUsesLocalizedDisplayName() throws {
+        let rec = try XCTUnwrap(
+            service.getCategoriesSorted().first(where: { $0.isRecurring })
+        )
+        XCTAssertFalse(rec.isNameCustomized)
+        let expected = String(
+            localized: "category.recurring.default.name",
+            defaultValue: "Recurring Tasks"
+        )
+        XCTAssertEqual(rec.displayName, expected)
     }
 
     func testCreateCustomRecurringSetsIconAndFlag() throws {
@@ -301,7 +320,7 @@ final class CategoryServiceTests: XCTestCase {
     }
 
     func testSetRecurringToggle() throws {
-        let cat = try category(.thisMonth)
+        let cat = try category(.nextFewWeeks)
         XCTAssertFalse(cat.isRecurring)
         try service.setRecurring(cat, to: true)
         XCTAssertTrue(cat.isRecurring)

--- a/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
+++ b/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
@@ -59,7 +59,7 @@ final class BacklogViewModelPlacementTests: XCTestCase {
 
     func testAddTask_bottomPlacement_appendsAtEndOfCategory() throws {
         let backlog = try XCTUnwrap(viewModel.currentBacklog)
-        let cat = try category(.thisWeek)
+        let cat = try category(.nextFewDays)
 
         let base = Date()
         let t1 = backlog.addTask(title: "Zuerst")

--- a/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
+++ b/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
@@ -98,4 +98,15 @@ final class BacklogViewModelPlacementTests: XCTestCase {
         let titles = Set(backlog.backlogTasks.map(\.title))
         XCTAssertEqual(titles, ["Task 1", "Task 2", "Task 3"])
     }
+
+    func testAddDebugTestItems_createsArchivedUncompletedTasks() throws {
+        viewModel.addDebugTestItems(settings: AppSettings.shared)
+
+        let tasks = try context.fetch(FetchDescriptor<Task>())
+        let archived = tasks.filter { $0.status == .archived }
+
+        XCTAssertEqual(archived.count, 16)
+        XCTAssertTrue(archived.allSatisfy { !$0.isCompleted })
+        XCTAssertTrue(archived.allSatisfy { $0.archivedAt != nil })
+    }
 }


### PR DESCRIPTION
Diese Änderung erweitert den Debug-Workflow „Test Items“, damit realistischere Archiv-Daten für UI-Tests vorhanden sind.

## Was wurde geändert?

- `BacklogViewModel.addDebugTestItems(...)` erstellt jetzt zusätzlich 16 archivierte Debug-Tasks.
- Die neuen Aufgaben sind absichtlich „kleine/nervige Alltagsaufgaben“ (z. B. Newsletter abbestellen, iPhone-Backup machen, Kabelsalat bändigen).
- Archiv-Tasks werden korrekt über `task.archive()` erzeugt, bleiben explizit **unerledigt** (`isCompleted = false`) und werden zeitlich in die Vergangenheit datiert (`daysAgo`), damit sie sofort sichtbar und plausibel sortiert im Archiv erscheinen.
- Neue Lokalisierungs-Keys `debug.testtask.archived.1` bis `.16` in `Localizable.xcstrings` mit deutschen und englischen Texten.
- Neuer Test in `BacklogViewModelPlacementTests` prüft:
  - archivierte Tasks werden erzeugt,
  - Anzahl stimmt (16),
  - alle sind nicht erledigt,
  - alle haben ein `archivedAt`-Datum.

## Warum?

Bisher wurden über den Debug-Button nur Backlog-/Heute-Testaufgaben erzeugt.  
Für die Archiv-Ansicht fehlten dadurch realistische Testdaten. Mit dieser Änderung ist das Archiv nach einem Klick direkt sinnvoll befüllt und besser testbar.

## Teststatus

- Unit-Test `DawnyTests/BacklogViewModelPlacementTests` läuft erfolgreich.
- Linter: keine neuen Fehler in den geänderten Dateien.