### PR TITLE
Deploy-Action auf SCP umstellen & Version auf 0.4.0

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,13 +28,13 @@ jobs:
 
       - run: npm run build
 
-      - name: Deploy to IONOS via SFTP
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+      - name: Deploy to IONOS via SCP
+        uses: appleboy/scp-action@v0.1.7
         with:
-          server: ${{ secrets.IONOS_FTP_HOST }}
+          host: ${{ secrets.IONOS_FTP_HOST }}
           username: ${{ secrets.IONOS_FTP_USER }}
           password: ${{ secrets.IONOS_FTP_PASSWORD }}
           port: 22
-          local_path: ./website/dist/
-          remote_path: ${{ secrets.IONOS_FTP_REMOTE_DIR }}
-          sftp_only: true
+          source: ./website/dist/*
+          target: ${{ secrets.IONOS_FTP_REMOTE_DIR }}
+          strip_components: 3

--- a/Dawny.xcodeproj/project.pbxproj
+++ b/Dawny.xcodeproj/project.pbxproj
@@ -135,7 +135,7 @@
 						CreatedOnToolsVersion = 26.2;
 						TestTargetID = 5C9C9EBE2F0180D90092AD03;
 					};
-			};
+				};
 			};
 			buildConfigurationList = 5C9C9EBA2F0180D90092AD03 /* Build configuration list for PBXProject "Dawny" */;
 			developmentRegion = en;
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Florian.Dawny.MVP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -397,7 +397,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = Florian.Dawny.MVP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
Website-Deployment von wlixcc/SFTP-Deploy-Action auf appleboy/scp-action gewechselt, da die alte Action einen SSH-Key als Pflichtfeld verlangt hat. Marketing-Version von 0.3.0 auf 0.4.0 erhöht.