### PR TITLE
Website GitHub link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,5 +75,5 @@ No package manager setup is needed. Dawny has zero third-party dependencies.
 
 ## Reporting security issues
 
-Do not open public issues for security reports. Email **dawny@posteo.de** with
+Do not open public issues for security reports. Email **info@dawnyapp.com** with
 details. I will respond as fast as a single developer can.

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
 
 <https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Required Notice: Copyright (c) 2025-2026 Florian Schneider (dawny@posteo.de)
+Required Notice: Copyright (c) 2025-2026 Florian Schneider (info@dawnyapp.com)
 
 ## Acceptance
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 Dawny
 =====
 
-Required Notice: Copyright (c) 2025-2026 Florian Schneider (dawny@posteo.de)
+Required Notice: Copyright (c) 2025-2026 Florian Schneider (info@dawnyapp.com)
 
 Source code in this repository is licensed under the PolyForm Noncommercial
 License 1.0.0. See the LICENSE file in the root of this repository, or visit
@@ -13,7 +13,7 @@ Any commercial use - including, but not limited to, distributing the
 software (in original or modified form) as a paid app, a free app that
 generates revenue through ads or in-app purchases, or as part of any
 service or product that generates revenue - is NOT permitted under this
-license. For commercial licensing, contact dawny@posteo.de.
+license. For commercial licensing, contact info@dawnyapp.com.
 
 ------------------------------------------------------------------------
 
@@ -55,4 +55,4 @@ Contact
 -------
 
 Commercial licensing, trademark questions, security reports, or anything
-else legal: dawny@posteo.de
+else legal: info@dawnyapp.com

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Florian Schneider and are not licensed under PolyForm. Forks must be renamed
 and rebranded. See [NOTICE](NOTICE) for details on trademarks, asset
 licensing, and contact info.
 
-For commercial licensing inquiries, write to **dawny@posteo.de**.
+For commercial licensing inquiries, write to **info@dawnyapp.com**.
 
 Contributions are welcome under the terms described in
 [CONTRIBUTING.md](CONTRIBUTING.md), which include an inbound-equals-outbound

--- a/docs/AI_INPUT.md
+++ b/docs/AI_INPUT.md
@@ -20,7 +20,7 @@ This document is the complete, authoritative product context for Dawny. It is st
 | App Store | Not yet live |
 | Pricing | Free during beta. No pricing commitment for post-launch. |
 | Developer | Florian Schneider, Karlsruhe, Germany |
-| Contact | dawny@posteo.de |
+| Contact | info@dawnyapp.com |
 | Project type | Independent (indie), no VC backing, noncommercial license |
 | Trademark | "Dawny" and the Dawny logo are common-law trademarks. Correct capitalization must be maintained. |
 

--- a/docs/PRIVACY.de.md
+++ b/docs/PRIVACY.de.md
@@ -20,7 +20,7 @@ Verantwortlicher im Sinne der DSGVO ist:
 76133 Karlsruhe  
 [BITTE ERGÄNZEN: Land]
 
-E-Mail: dawny@posteo.de
+E-Mail: info@dawnyapp.com
 
 ## 2. Überblick
 
@@ -121,7 +121,7 @@ Apple bzw. von dir selbst auf deinem Gerät auszuüben:
 
 ## 8. Kontakt
 
-Bei Fragen zum Datenschutz: **dawny@posteo.de**
+Bei Fragen zum Datenschutz: **info@dawnyapp.com**
 
 ## 9. Änderungen dieser Datenschutzerklärung
 

--- a/docs/PRIVACY.en.md
+++ b/docs/PRIVACY.en.md
@@ -19,7 +19,7 @@ The data controller under the GDPR is:
 76133 Karlsruhe  
 [PLEASE FILL IN: Country]
 
-Email: dawny@posteo.de
+Email: info@dawnyapp.com
 
 ## 2. Overview
 
@@ -115,7 +115,7 @@ either against Apple or by you directly on your device:
 
 ## 8. Contact
 
-For privacy-related questions: **dawny@posteo.de**
+For privacy-related questions: **info@dawnyapp.com**
 
 ## 9. Changes to this privacy policy
 

--- a/website/src/i18n/index.ts
+++ b/website/src/i18n/index.ts
@@ -34,4 +34,4 @@ export function alternateLang(lang: Lang): Lang {
 
 export const TESTFLIGHT_URL = "https://testflight.apple.com/join/h9JSWasd";
 export const GITHUB_URL = "https://github.com/flrnsndr/Dawny";
-export const CONTACT_EMAIL = "dawny@posteo.de";
+export const CONTACT_EMAIL = "info@dawnyapp.com";

--- a/website/src/i18n/index.ts
+++ b/website/src/i18n/index.ts
@@ -33,5 +33,5 @@ export function alternateLang(lang: Lang): Lang {
 }
 
 export const TESTFLIGHT_URL = "https://testflight.apple.com/join/h9JSWasd";
-export const GITHUB_URL = "https://github.com/Floschdev/Dawny";
+export const GITHUB_URL = "https://github.com/flrnsndr/Dawny";
 export const CONTACT_EMAIL = "dawny@posteo.de";

--- a/website/src/pages/de/datenschutz.md
+++ b/website/src/pages/de/datenschutz.md
@@ -18,7 +18,7 @@ Kreuzstraße 26
 76133 Karlsruhe
 Deutschland
 
-E-Mail: dawny@posteo.de
+E-Mail: info@dawnyapp.com
 
 ## 2. Überblick
 
@@ -83,7 +83,7 @@ Da Dawny keine personenbezogenen Daten beim Entwickler verarbeitet, sind viele D
 
 ## 8. Kontakt
 
-Bei Fragen zum Datenschutz: **dawny@posteo.de**
+Bei Fragen zum Datenschutz: **info@dawnyapp.com**
 
 ## 9. Änderungen dieser Datenschutzerklärung
 

--- a/website/src/pages/de/impressum.md
+++ b/website/src/pages/de/impressum.md
@@ -15,7 +15,7 @@ Deutschland
 
 ## Kontakt
 
-E-Mail: dawny@posteo.de
+E-Mail: info@dawnyapp.com
 
 ## Verantwortlich für den Inhalt nach § 18 Abs. 2 MStV
 

--- a/website/src/pages/en/imprint.md
+++ b/website/src/pages/en/imprint.md
@@ -15,7 +15,7 @@ Germany
 
 ## Contact
 
-Email: dawny@posteo.de
+Email: info@dawnyapp.com
 
 ## Responsible for content under § 18 (2) MStV
 

--- a/website/src/pages/en/privacy.md
+++ b/website/src/pages/en/privacy.md
@@ -18,7 +18,7 @@ Kreuzstraße 26
 76133 Karlsruhe
 Germany
 
-Email: dawny@posteo.de
+Email: info@dawnyapp.com
 
 ## 2. Overview
 
@@ -83,7 +83,7 @@ Because Dawny does not process personal data on the developer's side, many GDPR 
 
 ## 8. Contact
 
-For privacy-related questions: **dawny@posteo.de**
+For privacy-related questions: **info@dawnyapp.com**
 
 ## 9. Changes to this privacy policy
 


### PR DESCRIPTION
## Zusammenfassung

Die öffentlich sichtbare Kontakt-E-Mail **dawny@posteo.de** wird nicht mehr verwendet. Stattdessen ist überall die zentrale Adresse **info@dawnyapp.com** hinterlegt.

## Änderungen

- **Website:** `CONTACT_EMAIL` in der i18n-Konfiguration angepasst (betrifft u. a. den Footer mit `mailto:`). Impressum und Datenschutzerklärung (Deutsch und Englisch) zeigen die neue Adresse.
- **Repository:** README (Kommerzlizenz), CONTRIBUTING (Security Reports), LICENSE und NOTICE (Copyright-Hinweis, kommerzielle Lizenzierung, allgemeiner Rechts-/Kontaktblock).
- **Dokumentation:** `docs/AI_INPUT.md`, `docs/PRIVACY.de.md` und `docs/PRIVACY.en.md` auf den gleichen Kontaktstand gebracht wie die veröffentlichten Seiten.

## Hintergrund

Eine einheitliche Domain-Adresse für öffentliche Anfragen ersetzt die frühere Posteo-Adresse und reduziert die Verbreitung der privaten Mailbox in der Öffentlichkeit.