### PR TITLE
Website-Deployment auf SFTP via lftp umstellen

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,13 +28,14 @@ jobs:
 
       - run: npm run build
 
-      - name: Deploy to IONOS via SCP
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.IONOS_FTP_HOST }}
-          username: ${{ secrets.IONOS_FTP_USER }}
-          password: ${{ secrets.IONOS_FTP_PASSWORD }}
-          port: 22
-          source: ./website/dist/*
-          target: ${{ secrets.IONOS_FTP_REMOTE_DIR }}
-          strip_components: 3
+      - name: Install lftp
+        run: sudo apt-get update && sudo apt-get install -y lftp
+        working-directory: .
+
+      - name: Deploy to IONOS via SFTP
+        run: |
+          lftp -u "${{ secrets.IONOS_FTP_USER }},${{ secrets.IONOS_FTP_PASSWORD }}" \
+            sftp://${{ secrets.IONOS_FTP_HOST }} -e "
+            set sftp:auto-confirm yes;
+            mirror --reverse --delete --verbose dist/ ${{ secrets.IONOS_FTP_REMOTE_DIR }};
+            quit"

--- a/git cheat sheet.html
+++ b/git cheat sheet.html
@@ -192,6 +192,16 @@ git fetch -p</code>
                 <span class="label">2. Branch lokal löschen</span>
                 <code>git branch -d feature-name</code>
             </div>
+            <div class="command-group">
+                <span class="label">Alle lokalen Branches außer main (nur gemergt, <b>-d</b>)</span>
+                <code>git checkout main
+git branch --format='%(refname:short)' | grep -vx 'main' | xargs git branch -d</code>
+            </div>
+            <div class="command-group">
+                <span class="label">Alle lokalen Branches außer main (inkl. ungemergt, <b>-D</b>)</span>
+                <code>git checkout main
+git branch --format='%(refname:short)' | grep -vx 'main' | xargs git branch -D</code>
+            </div>
         </div>
 
         <div class="card">


### PR DESCRIPTION
appleboy/scp-action funktionierte nicht, da IONOS kein SCP unterstützt. Stattdessen wird jetzt lftp mit SFTP-Protokoll und Passwort-Auth verwendet. mirror --reverse --delete synchronisiert den dist-Ordner und räumt alte Dateien automatisch auf.

## Zusammenfassung

- **Deploy-Action durch lftp ersetzt:** `appleboy/scp-action` schlug fehl, da IONOS Shared Hosting kein SCP unterstützt – nur SFTP. Statt einer weiteren externen Action wird jetzt `lftp` direkt im Workflow genutzt.
- **SFTP mit Passwort-Auth:** Funktioniert mit den bestehenden GitHub Secrets ohne zusätzliche SSH-Key-Konfiguration.
- **Automatisches Aufräumen:** `mirror --reverse --delete` löscht alte Dateien auf dem Server, die lokal nicht mehr existieren.
- **Git Cheat Sheet erweitert:** Befehle zum Löschen aller lokalen Branches (außer main) hinzugefügt.

## Hinweise

- Keine Änderung an GitHub Secrets nötig
- `lftp` wird im Workflow per `apt-get install` installiert (wenige Sekunden)