### PR TITLE
Website: Footer-Logo auf helles Standard-Icon

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -23,7 +23,7 @@ const imprintPath = lang === "de" ? "/de/impressum/" : "/en/imprint/";
     <div class="space-y-4">
       <div class="flex items-center gap-3">
         <img
-          src="/assets/icons/dawny-icon-tinted.png"
+          src="/assets/icons/dawny-icon-light.png"
           alt=""
           width="32"
           height="32"


### PR DESCRIPTION
Footer nutzt dawny-icon-light.png statt tinted, konsistent zum App-Branding.