### PR TITLE
Kategorien im Backlog über Sortiermodus verschieben

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -497,6 +497,30 @@
         }
       }
     },
+    "category.action.reorder" : {
+      "comment" : "Backlog · Confirmation dialog button · Verb. Enters category sorting mode.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Move"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verschieben"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move"
+          }
+        }
+      }
+    },
     "category.action.makeRecurring" : {
       "comment" : "Backlog · Confirmation dialog button · Marks a category as recurring.",
       "extractionState" : "manual",
@@ -541,6 +565,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Remove recurring"
+          }
+        }
+      }
+    },
+    "category.sort.title" : {
+      "comment" : "Backlog · Category sorting mode overlay title.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "base" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arrange Categories"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kategorien sortieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrange Categories"
           }
         }
       }

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -559,6 +559,37 @@ final class BacklogViewModel {
             return nil
         }
     }
+
+    /// Sortiert Kategorien im dedizierten Sortiermodus um und persistiert die neue Reihenfolge.
+    func reorderCategories(from source: IndexSet, to destination: Int) {
+        var sorted = categories.sorted()
+        guard !source.isEmpty else { return }
+
+        var itemsToMove: [Category] = []
+        let sortedIndices = source.sorted(by: >)
+        for index in sortedIndices {
+            itemsToMove.insert(sorted.remove(at: index), at: 0)
+        }
+
+        let maxSourceIndex = sortedIndices.last!
+        let insertIndex = destination > maxSourceIndex ? destination - itemsToMove.count : destination
+
+        for (index, item) in itemsToMove.enumerated() {
+            sorted.insert(item, at: insertIndex + index)
+        }
+
+        for (index, category) in sorted.enumerated() {
+            category.orderIndex = index
+        }
+
+        do {
+            try modelContext.save()
+            loadCategories()
+            HapticFeedback.light()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
     
     /// Verschiebt Tasks innerhalb einer Kategorie (Drag & Drop)
     func moveTasksWithinCategory(category: Category, from source: IndexSet, to destination: Int) {

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -21,6 +21,8 @@ struct BacklogView: View {
 
     @State private var expandedCategories: Set<UUID> = []
     @State private var focusedTaskID: UUID?
+    @State private var isSortingCategories = false
+    @State private var expandedCategoriesBeforeSort: Set<UUID> = []
 
     // MARK: - Category Editing State
 
@@ -37,8 +39,12 @@ struct BacklogView: View {
         NavigationStack {
             ZStack {
                 if settings.showCategories {
-                    ScrollViewReader { proxy in
-                        categorizedTaskListView(scrollProxy: proxy)
+                    if isSortingCategories {
+                        sortModeView
+                    } else {
+                        ScrollViewReader { proxy in
+                            categorizedTaskListView(scrollProxy: proxy)
+                        }
                     }
                 } else {
                     ScrollViewReader { proxy in
@@ -59,6 +65,7 @@ struct BacklogView: View {
                     actionsCategory: $actionsCategory,
                     onEdit: { category in beginRenaming(category) },
                     onDelete: { category in requestDelete(category) },
+                    onReorder: { category in activateSortMode(startingWith: category) },
                     onToggleRecurring: { category in
                         _ = viewModel.toggleRecurring(category)
                     }
@@ -99,13 +106,38 @@ struct BacklogView: View {
                 }
             }
             .overlay(alignment: .top) {
-                if let error = viewModel.errorMessage {
-                    ErrorBannerView(message: error) {
-                        viewModel.errorMessage = nil
+                VStack(spacing: 8) {
+                    if isSortingCategories {
+                        HStack {
+                            Text(
+                                String(
+                                    localized: "category.sort.title",
+                                    defaultValue: "Arrange Categories"
+                                )
+                            )
+                            .font(.headline)
+
+                            Spacer()
+
+                            Button(
+                                String(localized: "common.done", defaultValue: "Done")
+                            ) {
+                                exitSortMode()
+                            }
+                            .fontWeight(.semibold)
+                        }
+                        .padding()
+                        .background(.regularMaterial)
                     }
-                    .padding(.top, 8)
-                    .onAppear {
-                        HapticFeedback.error()
+
+                    if let error = viewModel.errorMessage {
+                        ErrorBannerView(message: error) {
+                            viewModel.errorMessage = nil
+                        }
+                        .padding(.horizontal, 8)
+                        .onAppear {
+                            HapticFeedback.error()
+                        }
                     }
                 }
             }
@@ -167,6 +199,65 @@ struct BacklogView: View {
         .listStyle(.plain)
         .listSectionSpacing(.compact)
         .environment(\.defaultMinListRowHeight, 36)
+    }
+
+    /// Sortiermodus: flache Liste aller Kategorien ohne Tasks, Quick-Entry oder Add-Row.
+    private var sortModeView: some View {
+        let grouped = viewModel.groupedTasks
+        let sortedCategories = viewModel.categories.sorted()
+
+        return List {
+            ForEach(sortedCategories, id: \.id) { category in
+                sortModeCategoryRow(
+                    category: category,
+                    taskCount: grouped[category.id]?.count ?? 0
+                )
+            }
+            .onMove { source, destination in
+                viewModel.reorderCategories(from: source, to: destination)
+            }
+        }
+        .listStyle(.plain)
+        .environment(\.editMode, .constant(.active))
+        .environment(\.defaultMinListRowHeight, 44)
+    }
+
+    @ViewBuilder
+    private func sortModeCategoryRow(category: Category, taskCount: Int) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: category.displayIconName)
+                .foregroundColor(.secondary)
+                .frame(width: 18)
+
+            Text(category.displayName)
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            if category.isRecurring {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .accessibilityLabel(
+                        String(
+                            localized: "task.recurring.badge",
+                            defaultValue: "Recurring"
+                        )
+                    )
+            }
+
+            Spacer()
+
+            if taskCount > 0 {
+                Text(taskCount, format: .number)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.2))
+                    .clipShape(Capsule())
+            }
+        }
+        .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
     }
 
     @ViewBuilder
@@ -421,6 +512,29 @@ struct BacklogView: View {
     
     // MARK: - Category Editing Actions
 
+    private func activateSortMode(startingWith _: Category) {
+        guard !isSortingCategories else { return }
+        actionsCategory = nil
+        editingCategoryID = nil
+        iconPickerCategory = nil
+        focusedTaskID = nil
+        expandedCategoriesBeforeSort = expandedCategories
+        withAnimation(.easeInOut(duration: 0.2)) {
+            expandedCategories = []
+            isSortingCategories = true
+        }
+        HapticFeedback.light()
+    }
+
+    private func exitSortMode() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            isSortingCategories = false
+            expandedCategories = expandedCategoriesBeforeSort
+            expandedCategoriesBeforeSort = []
+        }
+        HapticFeedback.light()
+    }
+
     private func beginRenaming(_ category: Category) {
         guard category.canRename else { return }
         // Kategorie ausklappen, damit Tastatur das Feld nicht verdeckt
@@ -482,6 +596,7 @@ private struct CategoryActionMenu: ViewModifier {
     @Binding var actionsCategory: Category?
     let onEdit: (Category) -> Void
     let onDelete: (Category) -> Void
+    let onReorder: (Category) -> Void
     let onToggleRecurring: (Category) -> Void
 
     func body(content: Content) -> some View {
@@ -500,6 +615,14 @@ private struct CategoryActionMenu: ViewModifier {
                 ) {
                     onEdit(category)
                 }
+            }
+            Button(
+                String(
+                    localized: "category.action.reorder",
+                    defaultValue: "Move"
+                )
+            ) {
+                onReorder(category)
             }
             if category.canToggleRecurring {
                 Button {


### PR DESCRIPTION
Diese PR führt das Verschieben von Kategorien im Backlog ein – inklusive eines stabilen, leicht verständlichen Bedienkonzepts.

Warum diese Änderung?
Bisher konnten Kategorien nicht zuverlässig als Ganzes neu sortiert werden. Direkte Drag-&-Drop-Gesten auf Section-Headern in SwiftUI-Listen sind technisch anfällig (Gesture-Konflikte mit Tap/Long-Press).
Mit dieser PR wird das Verhalten auf einen dedizierten Sortiermodus umgestellt, der robust funktioniert und sich für Nutzer klar anfühlt.

Was ist neu?
Neue Aktion „Verschieben“ im Kategorie-Long-Press-Menü

Long-Press auf eine Kategorie öffnet wie bisher das Aktionsmenü.
Zusätzlich gibt es jetzt den Eintrag „Verschieben“.
Eigener Sortiermodus für Kategorien

Nach Klick auf „Verschieben“ wird ein separater Sortiermodus aktiviert.
In diesem Modus werden nur Kategorien als flache Liste angezeigt.
Alle Kategorien sind dabei eingeklappt; Tasks, Quick-Entry und Add-Category sind ausgeblendet.
Die Reihenfolge wird per nativer SwiftUI-onMove-Interaktion geändert.
Beenden über „Fertig“

Oben erscheint eine „Fertig“-Schaltfläche.
Beim Verlassen des Sortiermodus wird der vorherige Ein-/Ausklappstatus der Kategorien wiederhergestellt.
Persistente Reihenfolge

Die neue Sortierung wird über orderIndex gespeichert und bleibt dauerhaft erhalten.
Technische Umsetzung (kurz)
Neuer UI-State in BacklogView für Sortiermodus + gesicherten Expand-State.
Neue sortModeView mit flacher Kategorienliste und .onMove.
Neue reorderCategories(from:to:)-Logik im BacklogViewModel zur Persistierung.
Lokalisierungen ergänzt (category.action.reorder, category.sort.title).
Frühere, instabile Header-Drag-Ansätze wurden entfernt.
Ergebnis
Kategorien lassen sich nun zuverlässig neu anordnen – inklusive „als Ganzes“-Verhalten mit allen enthaltenen Items – über einen klaren, wartbaren Sortiermodus statt fragiler Header-Gesten.