### PR TITLE
Archiv: Swipe-Reihenfolge Backlog/Heute tauschen

### DIFF
--- a/App/Sources/Views/ArchiveView.swift
+++ b/App/Sources/Views/ArchiveView.swift
@@ -80,16 +80,6 @@ struct ArchiveView: View {
         )
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             Button {
-                viewModel.unarchiveToDailyFocus(taskID: task.id)
-            } label: {
-                Label(
-                    String(localized: "archive.swipe.today", defaultValue: "Today"),
-                    systemImage: "sun.max.fill"
-                )
-            }
-            .tint(.orange)
-
-            Button {
                 viewModel.unarchiveToBacklog(taskID: task.id)
             } label: {
                 Label(
@@ -98,6 +88,16 @@ struct ArchiveView: View {
                 )
             }
             .tint(.blue)
+
+            Button {
+                viewModel.unarchiveToDailyFocus(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.today", defaultValue: "Today"),
+                    systemImage: "sun.max.fill"
+                )
+            }
+            .tint(.orange)
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {


### PR DESCRIPTION
Im Archiv waren die Leading-Swipe-Actions bisher so angeordnet, dass „Heute" ganz links und „Backlog" rechts daneben erschien. Die Reihenfolge wurde getauscht: Backlog ist jetzt der erste (linkeste) Button, Heute der zweite. Damit ändert sich auch die Full-Swipe-Aktion von „Heute" auf „Backlog". Nur die Deklarationsreihenfolge in ArchiveView.swift wurde angepasst – Logik, Labels, Farben und Lokalisierungs-Keys bleiben unverändert.