### PR TITLE
Website: PostHog cookieless integrieren

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,6 +27,9 @@ jobs:
       - run: npm ci
 
       - run: npm run build
+        env:
+          PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.PUBLIC_POSTHOG_PROJECT_TOKEN }}
+          PUBLIC_POSTHOG_HOST: ${{ secrets.PUBLIC_POSTHOG_HOST }}
 
       - name: Install lftp
         run: sudo apt-get update && sudo apt-get install -y lftp

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,0 +1,4 @@
+# PostHog – cookieless web analytics (EU Cloud)
+# Get your token from https://eu.posthog.com → Project Settings
+PUBLIC_POSTHOG_PROJECT_TOKEN=phc_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/website/src/components/FinalCTA.astro
+++ b/website/src/components/FinalCTA.astro
@@ -49,6 +49,9 @@ const dict = getDict(lang);
           target="_blank"
           rel="noopener"
           class="btn-primary text-base"
+          data-ph-event="testflight_click"
+          data-ph-location="final_cta"
+          data-ph-target="testflight"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M17.5 12.5c0-3 2.5-4.4 2.6-4.5-1.4-2-3.6-2.3-4.4-2.4-1.9-.2-3.6 1.1-4.6 1.1-.9 0-2.4-1.1-4-1-2 0-3.9 1.2-5 3-2.1 3.7-.5 9.1 1.5 12.1 1 1.5 2.2 3.1 3.8 3.1 1.5-.1 2.1-1 3.9-1 1.8 0 2.4 1 4 .9 1.6 0 2.7-1.5 3.7-3 1.2-1.7 1.6-3.4 1.7-3.5-.1 0-3.2-1.2-3.2-4.8zM14.6 3.5c.8-1 1.4-2.4 1.2-3.8-1.2 0-2.6.8-3.4 1.8-.8.9-1.5 2.4-1.3 3.7 1.3.1 2.7-.7 3.5-1.7z"/>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -41,16 +41,22 @@ const imprintPath = lang === "de" ? "/de/impressum/" : "/en/imprint/";
       <a
         href={privacyPath}
         class="text-white/60 hover:text-white transition-colors"
+        data-ph-event="legal_click"
+        data-ph-target="privacy"
       >{dict.footer.links.privacy}</a>
       <a
         href={imprintPath}
         class="text-white/60 hover:text-white transition-colors"
+        data-ph-event="legal_click"
+        data-ph-target="imprint"
       >{dict.footer.links.imprint}</a>
       <a
         href={GITHUB_URL}
         target="_blank"
         rel="noopener"
         class="text-white/60 hover:text-white transition-colors inline-flex items-center gap-1.5"
+        data-ph-event="outbound_click"
+        data-ph-target="github"
       >
         {dict.footer.links.github}
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -60,6 +66,8 @@ const imprintPath = lang === "de" ? "/de/impressum/" : "/en/imprint/";
       <a
         href={`mailto:${CONTACT_EMAIL}`}
         class="text-white/60 hover:text-white transition-colors"
+        data-ph-event="outbound_click"
+        data-ph-target="mail"
       >{dict.footer.links.mail}</a>
     </nav>
   </div>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -47,6 +47,8 @@ const altHref = pathMap[segment]?.[altLang] ?? `/${altLang}/`;
         href={altHref}
         hreflang={altLang}
         class="text-xs sm:text-sm font-medium text-white/65 hover:text-white transition-colors px-3 py-2 rounded-full hover:bg-white/8"
+        data-ph-event="language_toggle"
+        data-ph-target={altLang}
       >
         <span class="uppercase tracking-wider">{altLang}</span>
       </a>
@@ -55,6 +57,9 @@ const altHref = pathMap[segment]?.[altLang] ?? `/${altLang}/`;
         target="_blank"
         rel="noopener"
         class="hidden sm:inline-flex items-center gap-1.5 text-xs font-semibold text-white/85 hover:text-white px-3.5 py-2 rounded-full bg-white/8 hover:bg-white/12 backdrop-blur transition"
+        data-ph-event="testflight_click"
+        data-ph-location="header"
+        data-ph-target="testflight"
       >
         <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M17.5 12.5c0-3 2.5-4.4 2.6-4.5-1.4-2-3.6-2.3-4.4-2.4-1.9-.2-3.6 1.1-4.6 1.1-.9 0-2.4-1.1-4-1-2 0-3.9 1.2-5 3-2.1 3.7-.5 9.1 1.5 12.1 1 1.5 2.2 3.1 3.8 3.1 1.5-.1 2.1-1 3.9-1 1.8 0 2.4 1 4 .9 1.6 0 2.7-1.5 3.7-3 1.2-1.7 1.6-3.4 1.7-3.5-.1 0-3.2-1.2-3.2-4.8zM14.6 3.5c.8-1 1.4-2.4 1.2-3.8-1.2 0-2.6.8-3.4 1.8-.8.9-1.5 2.4-1.3 3.7 1.3.1 2.7-.7 3.5-1.7z"/>

--- a/website/src/components/HeroSunrise.astro
+++ b/website/src/components/HeroSunrise.astro
@@ -52,13 +52,16 @@ const dict = getDict(lang);
         target="_blank"
         rel="noopener"
         class="btn-primary"
+        data-ph-event="testflight_click"
+        data-ph-location="hero"
+        data-ph-target="testflight"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M17.5 12.5c0-3 2.5-4.4 2.6-4.5-1.4-2-3.6-2.3-4.4-2.4-1.9-.2-3.6 1.1-4.6 1.1-.9 0-2.4-1.1-4-1-2 0-3.9 1.2-5 3-2.1 3.7-.5 9.1 1.5 12.1 1 1.5 2.2 3.1 3.8 3.1 1.5-.1 2.1-1 3.9-1 1.8 0 2.4 1 4 .9 1.6 0 2.7-1.5 3.7-3 1.2-1.7 1.6-3.4 1.7-3.5-.1 0-3.2-1.2-3.2-4.8zM14.6 3.5c.8-1 1.4-2.4 1.2-3.8-1.2 0-2.6.8-3.4 1.8-.8.9-1.5 2.4-1.3 3.7 1.3.1 2.7-.7 3.5-1.7z"/>
         </svg>
         {dict.hero.ctaPrimary}
       </a>
-      <a href="#manifesto" class="btn-ghost text-white/80">
+      <a href="#manifesto" class="btn-ghost text-white/80" data-ph-event="scroll_to_manifesto" data-ph-location="hero">
         {dict.hero.ctaSecondary}
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
           <path d="M12 5v14M19 12l-7 7-7-7"/>

--- a/website/src/components/PostHog.astro
+++ b/website/src/components/PostHog.astro
@@ -1,0 +1,38 @@
+---
+const token = import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN ?? "";
+const host = import.meta.env.PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
+---
+
+{token ? (
+  <script is:inline define:vars={{ token, host }}>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init(token, {
+      api_host: host,
+      cookieless_mode: 'always',
+      persistence: 'memory',
+      autocapture: false,
+      disable_session_recording: true,
+      disable_surveys: true,
+      capture_pageview: true,
+      capture_pageleave: true,
+      defaults: '2026-01-30',
+    });
+
+    document.addEventListener('click', function (ev) {
+      var el = ev.target.closest('[data-ph-event]');
+      if (!el || !window.posthog) return;
+      var name = el.dataset.phEvent;
+      var props = {};
+      var keys = Object.keys(el.dataset);
+      for (var i = 0; i < keys.length; i++) {
+        var k = keys[i];
+        if (k !== 'phEvent' && k.indexOf('ph') === 0) {
+          var prop = k.charAt(2).toLowerCase() + k.slice(3);
+          props[prop] = el.dataset[k];
+        }
+      }
+      if (el.tagName === 'A' && el.href) props.href = el.href;
+      window.posthog.capture(name, props);
+    }, true);
+  </script>
+) : null}

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import "@/styles/global.css";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
+import PostHog from "@/components/PostHog.astro";
 import { type Lang, getDict, alternateLang } from "@/i18n";
 
 interface Props {
@@ -63,6 +64,7 @@ const altUrl = `${site}/${altLang}${canonicalPath}`.replace(/\/+$/, "/");
     <meta name="twitter:image" content={ogImage} />
 
     <meta name="generator" content={Astro.generator} />
+    <PostHog />
   </head>
   <body class={bodyClass}>
     <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-[var(--color-night)] focus:px-4 focus:py-2 focus:text-[var(--color-paper)]">

--- a/website/src/pages/de/datenschutz.md
+++ b/website/src/pages/de/datenschutz.md
@@ -1,12 +1,12 @@
 ---
 layout: "@/layouts/Legal.astro"
 title: "Datenschutzerklärung"
-description: "Datenschutzerklärung für Dawny. Kein Tracking. Keine Analytics. Keine Drittanbieter-SDKs."
+description: "Datenschutzerklärung für Dawny. Privatsphäre-zuerst. Keine Drittanbieter-SDKs in der App. Cookieless Web-Analyse."
 lang: "de"
 canonicalPath: "/datenschutz/"
 ---
 
-**Stand:** 19. April 2026
+**Stand:** 27. April 2026
 **Sprache:** Deutsch ([English version](/en/privacy/))
 
 ## 1. Verantwortlicher
@@ -91,4 +91,25 @@ Diese Datenschutzerklärung kann angepasst werden, wenn sich die App ändert. We
 
 ## 10. Diese Webseite
 
-Diese Webseite (`dawnyapp.com`) wird statisch bei IONOS in Deutschland gehostet. Es werden weder Cookies noch Tracking oder Analytics eingesetzt. Standardmäßige Server-Zugriffslogs können vom Hosting-Anbieter zum Betrieb des Dienstes temporär vorgehalten werden. Weitere Informationen zur Datenverarbeitung durch IONOS findest du in der [Datenschutzerklärung von IONOS](https://www.ionos.de/terms-gtc/datenschutzerklaerung/).
+Diese Webseite (`dawnyapp.com`) wird statisch bei IONOS in Deutschland gehostet. Standardmäßige Server-Zugriffslogs können vom Hosting-Anbieter zum Betrieb des Dienstes temporär vorgehalten werden. Weitere Informationen zur Datenverarbeitung durch IONOS findest du in der [Datenschutzerklärung von IONOS](https://www.ionos.de/terms-gtc/datenschutzerklaerung/).
+
+### 10.1 Cookielose Web-Analyse (PostHog)
+
+Zur Reichweiten- und Conversion-Messung setzt diese Webseite **PostHog** ein – im vollständig **cookielosen Modus**. Das bedeutet:
+
+- Es werden **keine Cookies** gesetzt.
+- Es wird **kein `localStorage` oder `sessionStorage`** genutzt.
+- Es findet **kein Cross-Device-Tracking** und **keine Nutzer-Identifikation** statt.
+- Es gibt keinen Cookie-Banner, da keine Informationen auf deinem Endgerät gespeichert oder ausgelesen werden (§ 25 TDDDG / Art. 5 Abs. 3 ePrivacy-Richtlinie).
+
+**Anbieter:** PostHog, Inc., wobei die Daten ausschließlich in der **EU (Frankfurt, AWS eu-central-1)** verarbeitet werden.
+
+**Wie es funktioniert:** Beim Seitenaufruf werden IP-Adresse und User-Agent an PostHog-Server in Frankfurt übertragen. PostHog erzeugt daraus einen **irreversiblen Hash** (`Hash aus Team-ID + Tages-Salt + IP + User-Agent + Hostname`). Der Tages-Salt rotiert täglich und wird nach Verarbeitung gelöscht. Aus dem Hash lassen sich keine personenbezogenen Daten zurückgewinnen.
+
+**Erfasste Informationen:** Seitenaufrufe, ungefähre Verweildauer, Scroll-Tiefe, Gerätetyp, Browser, Betriebssystem, ungefähre geographische Region (aus IP abgeleitet, nicht gespeichert), Referrer und UTM-Parameter sowie explizit gemessene Klicks auf Download-/TestFlight-Buttons.
+
+**Rechtsgrundlage:** Berechtigtes Interesse an der Reichweitenmessung und Verbesserung der Webseite (Art. 6 Abs. 1 lit. f DSGVO). Da keine Informationen auf deinem Endgerät gespeichert werden, ist keine Einwilligung nach § 25 TDDDG erforderlich.
+
+**Widerspruch:** Du kannst die Verarbeitung verhindern, indem du JavaScript in deinem Browser deaktivierst oder einen Content-/Tracking-Blocker verwendest.
+
+Weitere Informationen: [PostHog Datenschutzrichtlinie](https://posthog.com/privacy), [PostHog DPA / Auftragsverarbeitungsvertrag](https://posthog.com/dpa).

--- a/website/src/pages/en/privacy.md
+++ b/website/src/pages/en/privacy.md
@@ -1,12 +1,12 @@
 ---
 layout: "@/layouts/Legal.astro"
 title: "Privacy Policy"
-description: "Dawny's privacy policy. No tracking. No analytics. No third-party SDKs."
+description: "Dawny's privacy policy. Privacy-first. No third-party SDKs in the app. Cookieless web analytics."
 lang: "en"
 canonicalPath: "/privacy/"
 ---
 
-**Last updated:** April 19, 2026
+**Last updated:** April 27, 2026
 **Language:** English ([Deutsche Version](/de/datenschutz/))
 
 ## 1. Data Controller
@@ -91,4 +91,25 @@ This privacy policy may be updated as the app evolves. Material changes will be 
 
 ## 10. Website
 
-This website (`dawnyapp.com`) is statically hosted on IONOS in Germany. It does not use cookies, analytics, or tracking. Standard server access logs may be temporarily kept by the hosting provider for the purpose of operating the service. For more information on how IONOS processes data, see [IONOS's privacy policy](https://www.ionos.de/terms-gtc/datenschutzerklaerung/).
+This website (`dawnyapp.com`) is statically hosted on IONOS in Germany. Standard server access logs may be temporarily kept by the hosting provider for the purpose of operating the service. For more information on how IONOS processes data, see [IONOS's privacy policy](https://www.ionos.de/terms-gtc/datenschutzerklaerung/).
+
+### 10.1 Cookieless web analytics (PostHog)
+
+For audience measurement and conversion tracking, this website uses **PostHog** in fully **cookieless mode**. This means:
+
+- **No cookies** are set.
+- **No `localStorage` or `sessionStorage`** is used.
+- There is **no cross-device tracking** and **no user identification**.
+- No cookie banner is needed because no information is stored on or read from your device.
+
+**Provider:** PostHog, Inc. All data is processed exclusively in the **EU (Frankfurt, AWS eu-central-1)**.
+
+**How it works:** When you visit a page, your IP address and user agent are sent to PostHog servers in Frankfurt. PostHog generates an **irreversible hash** (`hash of team ID + daily salt + IP + user agent + hostname`). The daily salt rotates every day and is deleted after processing. No personal data can be derived from the hash.
+
+**Information collected:** Page views, approximate time on page, scroll depth, device type, browser, operating system, approximate geographic region (derived from IP, not stored), referrer and UTM parameters, and explicitly measured clicks on Download/TestFlight buttons.
+
+**Legal basis:** Legitimate interest in audience measurement and website improvement (Art. 6(1)(f) GDPR). Since no information is stored on your device, consent under the ePrivacy Directive is not required.
+
+**Opt-out:** You can prevent processing by disabling JavaScript in your browser or using a content/tracking blocker.
+
+More information: [PostHog Privacy Policy](https://posthog.com/privacy), [PostHog DPA](https://posthog.com/dpa).


### PR DESCRIPTION
Diese Änderung integriert PostHog für die Astro-Website als cookieless Web-Analytics-Lösung. Das Tracking wird zentral über PostHog.astro eingebunden, nutzt den EU-Host und wird nur aktiviert, wenn ein PUBLIC_POSTHOG_PROJECT_TOKEN gesetzt ist.

Die Website misst keine allgemeinen Autocapture-Interaktionen, sondern nur explizit markierte Events wie TestFlight-Klicks, Sprachwechsel, Legal-Links sowie GitHub- und Mail-Klicks. Session Recordings, Surveys und Autocapture bleiben deaktiviert.

Zusätzlich wurden die Datenschutzseiten auf Deutsch und Englisch aktualisiert und der Deploy-Workflow so erweitert, dass PostHog-Token und Host über GitHub Secrets in den Build gegeben werden können. website/.env.example dokumentiert die benötigten Variablen.