### PR TITLE
Website: Scroll-Depth-Tracking ergänzen

### DIFF
--- a/website/src/components/PostHog.astro
+++ b/website/src/components/PostHog.astro
@@ -34,5 +34,45 @@ const host = import.meta.env.PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
       if (el.tagName === 'A' && el.href) props.href = el.href;
       window.posthog.capture(name, props);
     }, true);
+
+    (function () {
+      var milestones = [25, 50, 75, 100];
+      var firedDepths = [];
+      var content = document.querySelector('main');
+      if (!content) return;
+
+      var lastCall = 0;
+      function throttledCheck() {
+        var now = Date.now();
+        if (now - lastCall < 200) return;
+        lastCall = now;
+        checkScrollDepth();
+      }
+
+      function checkScrollDepth() {
+        if (!window.posthog) return;
+        var rect = content.getBoundingClientRect();
+        var vh = window.innerHeight || document.documentElement.clientHeight;
+        var totalH = content.scrollHeight;
+        if (!totalH) return;
+        var visible = vh - rect.top;
+        var pct = Math.max(0, Math.min(100, Math.floor((visible / totalH) * 100)));
+        for (var i = 0; i < milestones.length; i++) {
+          var d = milestones[i];
+          if (pct >= d && firedDepths.indexOf(d) === -1) {
+            firedDepths.push(d);
+            window.posthog.capture('scroll_depth_reached', {
+              depth: d,
+              path: window.location.pathname,
+              lang: document.documentElement.lang || undefined
+            });
+          }
+        }
+      }
+
+      document.addEventListener('scroll', throttledCheck, { passive: true });
+      window.addEventListener('resize', throttledCheck);
+      checkScrollDepth();
+    })();
   </script>
 ) : null}


### PR DESCRIPTION
Ergänzt die bestehende cookieless PostHog-Integration um ein explizites Scroll-Depth-Event. Wenn Besucher beim Scrollen 25 %, 50 %, 75 % oder 100 % des <main>-Bereichs erreichen, wird jeweils einmalig ein scroll_depth_reached-Event an PostHog gesendet.

Event-Properties: depth (25/50/75/100), path, lang
Throttling auf 200 ms für Performance
Kein Autocapture, keine Heatmaps, keine Cookies
Datenschutzseiten mussten nicht angepasst werden, da Scroll-Tiefe dort bereits als erfasste Information genannt ist