### PR TITLE
Website: Scrolltiefe in PostHog lesbar gruppieren

### DIFF
--- a/website/src/components/PostHog.astro
+++ b/website/src/components/PostHog.astro
@@ -66,6 +66,7 @@ const host = import.meta.env.PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
               firedDepths.push(d);
               window.posthog.capture('scroll_depth_reached', {
                 depth: d,
+                depth_bucket: d + '%',
                 path: window.location.pathname,
                 lang: document.documentElement.lang || undefined
               });


### PR DESCRIPTION
Diese Änderung ergänzt das PostHog-Event scroll_depth_reached um die zusätzliche Event-Property depth_bucket.

Bisher wurde die Scrolltiefe nur numerisch als depth gesendet. PostHog behandelt numerische Breakdown-Properties als Zahlenwerte und gruppiert sie automatisch in Bereiche, wodurch statt 25, 50, 75, 100 unklare Bins angezeigt wurden. Mit depth_bucket wird zusätzlich ein lesbarer Textwert wie 25%, 50%, 75% oder 100% gesendet.

Für Insights sollte künftig der Breakdown auf depth_bucket statt auf depth gesetzt werden.