### PR TITLE
Git-Cheat-Sheet erweitern und Swift-Testwarnung beheben

### DIFF
--- a/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
+++ b/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
@@ -126,7 +126,7 @@ final class DailyFocusRecurringTests: XCTestCase {
         try context.save()
 
         await vm.completeTask(t1)
-        var clone1 = try XCTUnwrap(try findTask(id: t1.recurringCloneID!))
+        let clone1 = try XCTUnwrap(try findTask(id: t1.recurringCloneID!))
         clone1.moveToDailyFocus(date: Calendar.current.startOfDay(for: Date()))
         try context.save()
 

--- a/git cheat sheet.html
+++ b/git cheat sheet.html
@@ -175,8 +175,16 @@ git push -u origin HEAD</code>
 git branch -av</code>
             </div>
             <div class="command-group">
-                <span class="label">Grafischer Verlauf</span>
+                <span class="label">Grafischer Verlauf (letzte 10)</span>
                 <code>git log --oneline --graph --all -n 10</code>
+            </div>
+            <div class="command-group">
+                <span class="label">Visuelle Übersicht: alle Branches & Commits</span>
+                <code>git log --all --oneline --graph --decorate</code>
+            </div>
+            <div class="command-group">
+                <span class="label">Kompakter Überblick: nur Branch-/Tag-Refs</span>
+                <code>git log --all --oneline --graph --decorate --simplify-by-decoration</code>
             </div>
         </div>
 


### PR DESCRIPTION
Diese Änderung erweitert das Git-Cheat-Sheet um zwei praktische Log-Befehle: eine vollständige visuelle Übersicht über alle Branches und Commits sowie eine kompakte Ansicht nur für Branch- und Tag-Referenzen.

Zusätzlich wird im Recurring-Test eine unnötige var-Deklaration durch let ersetzt. Das behebt die Xcode-Warnung aus App Store Connect, ohne das Testverhalten zu verändern.