### PR TITLE
Website DE/EN: Copy, Manifest, Reset-Animation, AI_INPUT

### DIFF
--- a/docs/AI_INPUT.md
+++ b/docs/AI_INPUT.md
@@ -15,7 +15,7 @@ Last source-code review for factual product state: April 27, 2026. Re-verify bef
 | Name | Dawny |
 | Category | iOS task management app |
 | Official tagline | "A task app that deletes yesterday's tasks. On purpose." |
-| One-liner | "Dawny turns unfinished tasks into signal—not failure." |
+| One-liner | "Dawny turns unfinished tasks into a clear priority signal." |
 | Platform | iOS 26.2+, native SwiftUI. Designed and tested primarily for iPhone; do not position as an iPad-optimized product unless separately verified. |
 | Distribution | Public Beta via TestFlight |
 | TestFlight link | https://testflight.apple.com/join/h9JSWasd |
@@ -33,14 +33,14 @@ Last source-code review for factual product state: April 27, 2026. Re-verify bef
 Every design decision in Dawny follows from one thesis:
 
 > **Overdue tasks are a design flaw.**
-> Most task apps assume unfinished = failure. Dawny assumes unfinished = information.
+> Most task apps treat unfinished tasks as overdue. Dawny treats them as a priority signal.
 
-If a task didn't get done, it usually wasn't the actual priority. Classic tools punish this with red badges and overdue flags — creating guilt, not clarity. Dawny removes that mechanism entirely.
+If a task didn't get done, it usually wasn't the actual priority. Classic tools keep surfacing it with red badges and overdue flags — creating artificial urgency instead of clarity. Dawny removes that mechanism entirely.
 
 ### Core principles that are non-negotiable
 
 **Zero-Overdue Policy**
-There are no overdue tasks in Dawny. No red. No late. No accumulated guilt. If something is not done by the daily reset, it is processed without judgment: it either returns to the Backlog or, once the Make It Count threshold is reached, moves to the Archive.
+There are no overdue tasks in Dawny. No red. No late. No accumulated pressure. If something is not done by the daily reset, it is processed without judgment: it either returns to the Backlog or, once the Make It Count threshold is reached, moves to the Archive.
 
 **The 3 AM Reset**
 The default reset time is 3 AM. This is also the product metaphor and recommended marketing phrase. In the app, the reset hour is configurable in Settings. The reset is checked when the app launches or becomes active, and Dawny also schedules a local background refresh when iOS allows it. The promise is not "an exact server-side cron job"; the promise is that the user's Daily Focus is cleared automatically without manual cleanup.
@@ -48,7 +48,7 @@ The default reset time is 3 AM. This is also the product metaphor and recommende
 **Make It Count**
 Make It Count is Dawny's mechanism for turning repeated non-completion into a clear signal. Each non-recurring task tracks how many times it was in Daily Focus and still incomplete at the daily reset. The threshold is configurable from 1–7 missed resets, with a default of 1. When the task reaches that threshold, it is moved to the Archive instead of being quietly returned to the Backlog again.
 
-The Archive is not deletion and not punishment. It is a visible, recoverable holding area for tasks that the user's actual behavior has repeatedly deprioritized. Archived tasks are out of the way, but not lost: the user can restore them to Backlog, restore them directly to Today/Daily Focus, or delete them permanently. This is central to Dawny's philosophy: an unfinished task is information, not failure.
+The Archive is not punishment. It is a visible, recoverable holding area for tasks that the user's actual behavior has repeatedly deprioritized. Archived tasks are out of the way, but not lost: the user can restore them to Backlog, restore them directly to Today/Daily Focus, or delete them permanently. This is central to Dawny's philosophy: repeated non-completion is a signal about priority.
 
 Make It Count is a core feature and cannot be disabled. Recurring-category tasks are the exception: they return to Backlog at reset and are not archived by Make It Count.
 
@@ -91,7 +91,7 @@ Dawny enforces a deliberate daily choice. Nothing moves to Today automatically. 
 - Completed tasks are not archived by Make It Count
 - Tasks in recurring categories are not archived by Make It Count; they return to Backlog at reset
 - Make It Count cannot be disabled — it is a core feature
-- Marketing framing: this is not shame, punishment, or deletion. It is a calm signal that the task has repeatedly not been the real priority.
+- Marketing framing: this is not punishment and not a moral judgment. It is a calm signal that the task has repeatedly not been the real priority.
 
 **Categories**
 - Lightweight grouping within the Backlog
@@ -158,12 +158,12 @@ Dawny enforces a deliberate daily choice. Nothing moves to Today automatically. 
 - Reliably capture tasks, but the list grows faster than it shrinks
 - Accumulated backlog becomes emotionally draining and loses relevance
 - Repeatedly reschedule tasks rather than deciding
-- Feel guilt or avoidance when opening their task app
+- Feel overload or avoidance when opening their task app
 - Have tried multiple tools; none stick long-term
 
 **Key insight:** They do not fail at discipline. The system fails them by design.
 
-**What Dawny offers this group:** A system that acknowledges reality instead of fighting it. Tasks don't become overdue — they return to the pool. Each day is a fresh start.
+**What Dawny offers this group:** A system that acknowledges reality instead of fighting it. Tasks don't become overdue — they return to the pool or move to the Archive. Each day is a fresh start.
 
 ### High-relevance sub-segment — neurodivergent people (especially ADHD)
 
@@ -171,7 +171,7 @@ Dawny enforces a deliberate daily choice. Nothing moves to Today automatically. 
 
 **Why the fit exists:**
 - Difficulty with long-term prioritization → Dawny only asks: "what matters today?"
-- Fluctuating energy across days → the reset means yesterday's missed tasks don't haunt today
+- Fluctuating energy across days → the reset means yesterday's missed tasks don't fill today's view
 - High sensitivity to visual overload and "open loops" → Dawny removes both with the reset
 - Low attachment to artificial deadlines → Dawny has none
 - Classic tools often get abandoned entirely → Dawny's simplicity reduces that risk
@@ -188,7 +188,7 @@ Dawny enforces a deliberate daily choice. Nothing moves to Today automatically. 
 **Knowledge workers with dynamic priorities**
 - Product managers, founders, freelancers, creatives
 - Their priorities genuinely shift daily; deadline-based tools create false urgency
-- Need to feel "done enough" at end of day without guilt
+- Need to end the day without dragging every open loop into tomorrow
 
 **"Tool fatigue" users**
 - Have tried Todoist, Things, Notion, Reminders, etc.
@@ -210,7 +210,7 @@ Dawny enforces a deliberate daily choice. Nothing moves to Today automatically. 
 
 | Competitor | Core model | Dawny's difference |
 |---|---|---|
-| Todoist | Due dates, projects, labels, karma score | Dawny has no due dates; no score; no guilt mechanism |
+| Todoist | Due dates, projects, labels, karma score | Dawny has no due dates; no score; no overdue-pressure mechanism |
 | Things 3 | Areas, projects, deadlines, "Today" list | Things' Today list doesn't reset; overdue stays overdue |
 | Microsoft To Do | Lists, due dates, "My Day" (manual) | My Day is manual and doesn't enforce a reset philosophy |
 | Apple Reminders | Date/time reminders, lists | Reminder-centric; missed = overdue notification |
@@ -226,7 +226,7 @@ Other apps could add a "hide overdue" setting. Dawny removes the concept entirel
 The daily reset is a primary product behavior and brand metaphor. It is memorable and genuinely changes how users relate to their list. Avoid unverified absolute claims such as "no competitor does this."
 
 **3. Make It Count as honest signal**
-Instead of letting ignored tasks silently pile up, Dawny acknowledges them: if a task repeatedly misses the user's chosen day, it gets archived into a visible, recoverable place. This respects the user's intelligence without turning non-completion into failure.
+Instead of letting ignored tasks silently pile up, Dawny acknowledges them: if a task repeatedly misses the user's chosen day, it gets archived into a visible, recoverable place. This respects the user's intelligence and treats repeated non-completion as a priority signal.
 
 **4. Radical reduction as a deliberate choice**
 Dawny documents what it doesn't do and explains why. This is rare in the productivity app market and resonates strongly with burned-out users.
@@ -236,7 +236,7 @@ For the app, zero developer-side task-data collection is not a setting or a plan
 
 ### Single-sentence differentiator
 
-*"Dawny treats an unfinished task as information, not failure — and enforces that philosophy in its architecture."*
+*"Dawny treats repeated non-completion as a priority signal — and enforces that philosophy in its architecture."*
 
 ---
 
@@ -259,23 +259,24 @@ For the app, zero developer-side task-data collection is not a setting or a plan
 
 ### Approved neurodivergence phrasing
 
-- English: "Dawny tends to work especially well for people who don't fit rigid productivity systems — including many neurodivergent thinkers."
-- German: "Dawny passt oft besonders gut zu Menschen, die in starre Produktivitätssysteme nicht hineinpassen — darunter viele neurodivergente Köpfe."
+- English: "Dawny tends to work especially well for people who find classic productivity systems too rigid — including many neurodivergent thinkers."
+- German: "Dawny passt oft besonders gut zu Menschen, für die klassische Produktivitätssysteme zu starr sind — darunter auch viele neurodivergente Köpfe."
 - Do not say Dawny treats ADHD, improves mental health, reduces symptoms, or is a medical/clinical tool.
 
 ### Existing key phrases (cleared for reuse)
 
 - "Start fresh. Every single day."
-- "No overdue. No carryover. No guilt."
+- "No overdue. No carryover. Just clarity."
 - "Just clarity."
 - "Your to-do list that wakes up fresh every morning, free from yesterday's clutter."
 - "The 3 AM Reset"
 - "Make it count"
 - "Intentional days"
 - "Overdue tasks are a design flaw."
-- "Unfinished = information, not failure."
+- "Not done does not mean failed. It means: maybe it wasn't important enough for today."
+- German: "Nicht erledigt heißt nicht gescheitert. Es heißt: vielleicht war es nicht wichtig genug für heute."
 - "A clean slate."
-- "No red. No guilt. No unfinished tasks blocking your list."
+- "No red. No artificial urgency. No unfinished tasks blocking your list."
 
 ---
 
@@ -314,7 +315,7 @@ For rapid orientation when generating marketing copy:
 | Question | Answer |
 |---|---|
 | What is Dawny? | A minimalist iOS task app, designed primarily for iPhone, that resets daily and removes overdue entirely |
-| What problem does it solve? | Task list anxiety, guilt from accumulated undone items, tool fatigue |
+| What problem does it solve? | Task list overload, stale tasks blocking today's focus, tool fatigue |
 | Who is it for? | People overwhelmed by their own task systems; minimalists; dynamic workers; neurodivergent-friendly |
 | What makes it different? | Zero-Overdue by design, 3 AM Reset, Make It Count archiving, recoverable Archive, radical reduction |
 | What does it NOT do? | No due dates, no subtasks, no team features, no cross-platform, no iPad-optimized promise |

--- a/git cheat sheet.html
+++ b/git cheat sheet.html
@@ -253,6 +253,31 @@ git push origin --delete v0.5.0</code>
             </div>
         </div>
 
+        <div class="card status">
+            <h2>🌐 Website lokal starten</h2>
+            <p style="margin:0; font-size: 0.85rem; color: var(--text-dim);">Marketing-Website aus dem aktuellen Branch auf localhost bauen:</p>
+            <div class="command-group">
+                <span class="label">Dev-Server (Live Hot Reload — zum aktiven Arbeiten)</span>
+                <code>cd website
+npm ci
+npm run dev</code>
+            </div>
+            <div class="command-group">
+                <span class="label">Produktions-Preview (exakt wie auf IONOS — zum Prüfen vor Deploy)</span>
+                <code>cd website
+npm run build
+npm run preview</code>
+            </div>
+            <div class="command-group">
+                <span class="label">Schnellstart (ohne Asset-Generierung)</span>
+                <code>cd website
+npx astro dev</code>
+            </div>
+            <div class="tip">
+                <b>Wann was?</b> <code style="display:inline; padding:2px 6px; border:none;">npm run dev</code> → wenn du aktiv an der Seite arbeitest (Änderungen erscheinen sofort im Browser dank Live Hot Reload). <code style="display:inline; padding:2px 6px; border:none;">npm run build + preview</code> → wenn du vor dem Deploy prüfen willst, ob alles korrekt gebaut wird (Minifizierung, Routing, Assets). <code style="display:inline; padding:2px 6px; border:none;">npx astro dev</code> → Schnellstart, wenn Assets schon existieren. Alles auf <b>http://localhost:4321</b>
+            </div>
+        </div>
+
         <div class="card danger">
             <h2>🛠️ Rettung</h2>
             <div class="command-group">

--- a/website/src/components/ManifestStatement.astro
+++ b/website/src/components/ManifestStatement.astro
@@ -27,6 +27,11 @@ const dict = getDict(lang);
       <p class="manifesto-quote text-display text-[clamp(2.25rem,6.5vw,5rem)] leading-[1.02] tracking-tight">
         &ldquo;{dict.manifesto.quote}&rdquo;
       </p>
+      {dict.manifesto.quoteSub && (
+        <p class="manifesto-quote-sub mt-8 text-lg sm:text-xl leading-relaxed">
+          {dict.manifesto.quoteSub}
+        </p>
+      )}
     </blockquote>
 
     <div
@@ -57,6 +62,14 @@ const dict = getDict(lang);
       in oklab,
       #ffffff calc((1 - var(--dawn-progress, 0)) * 100%),
       var(--color-ink) calc(var(--dawn-progress, 0) * 100%)
+    );
+  }
+
+  .manifesto-quote-sub {
+    color: color-mix(
+      in oklab,
+      rgba(255, 255, 255, 0.85) calc((1 - var(--dawn-progress, 0)) * 100%),
+      var(--color-ink-soft) calc(var(--dawn-progress, 0) * 100%)
     );
   }
 

--- a/website/src/components/ResetAnimation.astro
+++ b/website/src/components/ResetAnimation.astro
@@ -16,7 +16,7 @@ const resetArrowParts = timeline.arrowReset.split("·").map((part) => part.trim(
 // Alles, was am Tagesende unerledigt war, wandert beim 3-Uhr-Reset zurück ins Backlog.
 // Referenz ist der letzte aktive Step (vor dem cleared-Step).
 const lastActiveStep = [...steps].reverse().find((s) => !s.cleared) ?? steps[0];
-const returnedTasks = tasks.slice(lastActiveStep.doneCount);
+const returnedTasks = tasks.slice(0, tasks.length - lastActiveStep.doneCount);
 const migratedTask = returnedTasks[0];
 ---
 
@@ -88,7 +88,7 @@ const migratedTask = returnedTasks[0];
                 </li>
               ) : (
                 tasks.map((task, taskIndex) => {
-                  const done = taskIndex < step.doneCount;
+                  const done = taskIndex >= tasks.length - step.doneCount;
                   return (
                     <li class={done ? "is-done" : ""}>
                       <span class="reset-card-bullet" aria-hidden="true">
@@ -415,6 +415,8 @@ const migratedTask = returnedTasks[0];
 
   .reset-card-list li.is-done .reset-card-text {
     color: rgba(255, 255, 255, 0.55);
+    text-decoration: line-through;
+    text-decoration-color: rgba(255, 255, 255, 0.4);
   }
 
   .reset-card-empty {

--- a/website/src/i18n/de.json
+++ b/website/src/i18n/de.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "title": "Dawny — Eine Task-App, die gestern löscht. Absichtlich.",
-    "description": "Kein Overdue. Kein Übertrag. Kein schlechtes Gewissen. Dawny setzt deinen Tag um 3 Uhr morgens zurück — jeden Tag von vorn.",
+    "title": "Dawny - To Do App, die Aufgaben von gestern löscht",
+    "description": "Dawny ist eine minimalistische To Do App fürs iPhone. Keine überfälligen Aufgaben, kein tägliches Mitschleppen. Dein Daily Focus startet jeden Morgen frisch.",
     "ogAlt": "Dawny — jeden Tag frisch starten"
   },
   "nav": {
@@ -11,24 +11,25 @@
   },
   "hero": {
     "eyebrow": "iOS · TestFlight Beta",
-    "headline": ["Eine Task-App,", "die gestern löscht.", "Absichtlich."],
-    "sub": ["Kein Mitschleifen mehr.", "Dawny archiviert deinen Ballast automatisch – damit du jeden Morgen mit klarem Fokus startest."],
+    "headline": ["Eine To Do App, die", "deine Aufgaben löscht.", "Absichtlich."],
+    "sub": ["Was gestern offen blieb, blockiert heute nicht.", "Du entscheidest jeden Morgen neu, was wirklich zählt."],
     "ctaPrimary": "TestFlight-Beta beitreten",
     "ctaSecondary": "Manifest lesen"
   },
   "manifesto": {
-    "quote": "Overdue ist ein Design-Fehler.",
-    "bodyMid": "Wenn alte Aufgaben nie verschwinden, ertrinkt das, was heute zählt, in dem, was letzten Monat mal zählte.",
+    "quote": "Warum zeigt dir deine App noch, was gestern nicht abgehakt wurde?",
+    "quoteSub": "Dein Tag sollte nicht mit dem anfangen, was gestern übrig blieb.",
+    "bodyMid": "Je länger alte Aufgaben stehen bleiben, desto schwerer findest du den Fokus für heute.",
     "bodyExtra": "Dein Leben ist kein Projekt, bei dem du jeden Tag Wochen im Voraus planen kannst.",
-    "bodyAside": "Wenn eine Aufgabe seit zwei Wochen auf deiner Liste steht – ist sie dann noch eine Priorität?"
+    "bodyAside": "Wenn eine Aufgabe seit zwei Wochen auf deiner Liste steht – wird sie dort besser oder nur älter?"
   },
   "reset": {
     "eyebrow": "Der 3-Uhr-Reset",
     "title": "Während du schläfst,",
     "titleAccent": "startet dein Tag neu.",
-    "body": "Um 3 Uhr morgens leert Dawny leise deinen Daily Focus. Unerledigte Aufgaben werden entweder archiviert oder wandern zurück ins Backlog. Du wachst mit einer leeren Liste auf. Nichts geht verloren.",
+    "body": "Um 3 Uhr morgens räumt Dawny deinen Daily Focus auf. Offene Aufgaben wandern ins Archiv oder zurück ins Backlog. Du startest mit einer leeren Heute-Liste. Nichts geht verloren.",
     "screenLabel": "Heute",
-    "tasks": ["Hund Gassi führen", "Hochzeit zusagen", "Keller aufräumen"],
+    "tasks": ["Keller aufräumen", "Mit Hund raus", "Hochzeit zusagen"],
     "steps": [
       { "time": ["Morgens", "8:00"], "phase": "Tag 1", "doneCount": 0, "cleared": false, "footer": "0 von 3 erledigt" },
       { "time": ["Abends", "22:00"], "phase": "Tag 1", "doneCount": 2, "cleared": false, "footer": "2 von 3 erledigt" },
@@ -45,13 +46,13 @@
   },
   "twoLists": {
     "eyebrow": "So funktioniert es",
-    "title": "Zwei Listen. Mehr nicht.",
+    "title": "Eine Liste, ein Fokus, ein Archiv. Mehr nicht.",
     "backlogLabel": "Backlog",
-    "backlogText": "Alles, was dir wichtig ist — festhalten, was zählt, und später entscheiden, wann es deinen Fokus verdient.",
+    "backlogText": "Deine Aufgaben — Sammle hier alles, was du erledigen möchtest.",
     "focusLabel": "Daily Focus",
-    "focusText": "Deine Zusagen für heute — verschiebe Aufgaben hierher, wenn du bereit bist, sie zählen zu lassen.",
-    "progressLabel": "Zurück ins Backlog",
-    "progressText": "Ein sicherer Ort für alte Aufgaben — Dawny räumt vernachlässigte Zusagen aus dem Weg, hält sie aber erreichbar.",
+    "focusText": "Was heute zählt — Verschiebe Aufgaben hierher, wenn sie heute deinen Fokus verdienen.",
+    "progressLabel": "Archiv",
+    "progressText": "Für Liegengebliebenes — Was nicht wichtig genug war, wird weggeräumt.",
     "captionBacklog": "Backlog — deine Sammlung von Vielleichts",
     "captionFocus": "Daily Focus — heute, mit Absicht",
     "captionProgress": "Daily Focus — offen und erledigt"
@@ -64,27 +65,27 @@
     "rightLabel": "Dawny",
     "rows": [
       { "left": "Eine wachsende Liste wird zum Grundrauschen", "right": "Heute bleibt fokussiert" },
-      { "left": "Rote Overdue-Daten machen Schuldgefühle", "right": "Verpasste Aufgaben werden neutrale Signale" },
+      { "left": "Rote Überfällig-Markierungen erzeugen künstliche Dringlichkeit", "right": "Verpasste Aufgaben werden neutrale Signale" },
       { "left": "Alte Pläne konkurrieren mit echten Prioritäten", "right": "Veraltete Aufgaben rücken aus dem Blick" },
       { "left": "Du schleppst alles weiter", "right": "Du entscheidest, was einen neuen Tag verdient" }
     ]
   },
   "audience": {
     "eyebrow": "Für wen Dawny gemacht ist",
-    "title": "Das fühlt sich richtig an, wenn…",
+    "title": "Dawny passt zu dir, wenn…",
     "items": [
-      "deine Task-Liste zum Friedhof guter Vorsätze geworden ist.",
-      "du dieselben Aufgaben immer weiter verschiebst, ohne sie neu zu wählen.",
-      "du ein klares Heute willst, kein weiteres Produktivitätssystem zum Pflegen.",
-      "du einen Ort für spätere Aufgaben brauchst, der die Gegenwart nicht überfüllt."
+      "deine To Do Liste zum Friedhof guter Vorsätze geworden ist.",
+      "du Aufgaben mitschleppst, die du seit Tagen nicht mehr anschaust.",
+      "du für deine Tagesplanung kein komplexes Projektmanagement-Tool verwalten willst.",
+      "du Aufgaben zeitlich einordnen willst, ohne ihnen ein künstliches Datum zu geben."
     ],
-    "footnote": "Dawny funktioniert besonders gut für Menschen, die in starre Produktivitätssysteme nicht hineinpassen, darunter viele neurodivergente Köpfe."
+    "footnote": "Dawny passt oft besonders gut zu Menschen, denen klassische Planungsregeln oft zu starr sind. Das gilt ganz besonders auch für viele neurodivergente Menschen."
   },
   "makeItCount": {
     "eyebrow": "Make It Count",
-    "title": "Wenn eine Aufgabe seit zwei Wochen auf deiner Liste steht —",
+    "title": "Wenn eine Aufgabe immer wieder liegen bleibt —",
     "titleAccent": "ist sie dann noch eine Priorität?",
-    "narrative": "Unerledigt ist kein Versagen. Es ist Information. Eine Aufgabe für Heute zu wählen, ist eine Zusage an dich selbst. Wenn diese Zusage immer wieder bricht, nimmt Dawny das Signal ernst.",
+    "narrative": "Nicht erledigt heißt nicht gescheitert. Es heißt: vielleicht war es nicht wichtig genug für heute. Wenn eine Aufgabe immer wieder liegen bleibt, nimmt Dawny dieses Signal ernst.",
     "logicLabel": "So funktioniert es",
     "logic": "Schaffst du eine Heute-Aufgabe nicht, wandert sie zurück ins Backlog. Bleibt sie immer wieder liegen, verschiebt Dawny sie leise ins Archiv – dein digitaler Ballast, aus dem Weg.",
     "safetyLabel": "Dein Sicherheitsnetz",
@@ -109,7 +110,7 @@
     "qrAlt": "QR-Code scannen, um TestFlight auf iOS zu öffnen"
   },
   "footer": {
-    "tagline": "Eine Task-App, die gestern löscht. Absichtlich.",
+    "tagline": "Eine To Do App, die Aufgaben von gestern löscht. Absichtlich.",
     "rights": "© {year} Florian Schneider. Mit Sorgfalt in Deutschland gemacht.",
     "links": {
       "privacy": "Datenschutz",

--- a/website/src/i18n/en.json
+++ b/website/src/i18n/en.json
@@ -18,6 +18,7 @@
   },
   "manifesto": {
     "quote": "Overdue tasks are a design flaw.",
+    "quoteSub": "",
     "bodyMid": "When old tasks never leave, what matters today drowns in what mattered last month.",
     "bodyExtra": "Your life isn't a project where you can plan each day weeks in advance.",
     "bodyAside": "If a task has been on your list for two weeks, is it still a priority?"
@@ -28,7 +29,7 @@
     "titleAccent": "your day resets.",
     "body": "At 3 AM, Dawny quietly clears your Daily Focus. Unfinished tasks are either archived or return to the Backlog. You wake up to a clean slate. Nothing is lost.",
     "screenLabel": "Today",
-    "tasks": ["Walk the dog", "RSVP to wedding", "Clean basement"],
+    "tasks": ["Clean basement", "Walk the dog", "RSVP to wedding"],
     "steps": [
       { "time": ["Morning", "8 AM"], "phase": "Day 1", "doneCount": 0, "cleared": false, "footer": "0 of 3 done" },
       { "time": ["Evening", "10 PM"], "phase": "Day 1", "doneCount": 2, "cleared": false, "footer": "2 of 3 done" },
@@ -45,13 +46,13 @@
   },
   "twoLists": {
     "eyebrow": "How it works",
-    "title": "Two lists. That's it.",
+    "title": "One list, one focus, one archive. That's it.",
     "backlogLabel": "Backlog",
-    "backlogText": "Everything that matters to you — Capture what matters, then decide when it deserves your focus.",
+    "backlogText": "Your tasks — Collect everything you want to get done.",
     "focusLabel": "Daily Focus",
-    "focusText": "Your commitments for today — Move tasks here when you're ready to make them count.",
-    "progressLabel": "Back to Backlog",
-    "progressText": "A safe place for stale tasks — Dawny moves neglected commitments aside, but keeps them within reach.",
+    "focusText": "What matters today — Move tasks here when they deserve your focus today.",
+    "progressLabel": "Archive",
+    "progressText": "For what kept slipping — What wasn't important enough gets cleared away.",
     "captionBacklog": "Backlog — your library of maybes",
     "captionFocus": "Daily Focus — today, on purpose",
     "captionProgress": "Daily Focus — open and completed tasks"
@@ -76,7 +77,7 @@
       "Your task list has become a graveyard of good intentions.",
       "You keep moving the same tasks forward without choosing them again.",
       "You want a clean today, not another productivity system to maintain.",
-      "You need a place for future tasks that doesn't crowd the present."
+      "You want tasks to have a sense of \"when\" without forcing due dates on them."
     ],
     "footnote": "Dawny tends to work especially well for people who don't fit rigid productivity systems, including many neurodivergent thinkers."
   },


### PR DESCRIPTION
## Kurzfassung
Überarbeitete ** deutschsprachige Marketing-Texte** auf der Landingpage sowie **angepasste englische Strings** dazu; kleine **UI-/Markup-Anpassungen** für Manifest und Reset-Sektion; **Marketing-Kontext** in `docs/AI_INPUT.md` sprachlich gemildert/neu gerahmt — ohne neue Produktclaims.

## Website (Inhalte)
- **`website/src/i18n/de.json`**: unter anderem Hero und Meta, neues zweiteiliges Manifest (Hauptzitat + Subheadline), drei Spalten unter „Das Problem“, Abschnitte Reset, zwei/zwei-Spalten-Begriffe, Vergleich, Zielgruppe (inklusive Fußnote zu Planungsregeln und neurodivergenten Menschen), Make It Count und Footer/Social-Flair.
- **`website/src/i18n/en.json`**: zweiteiliges Manifest-Platzhalterfeld, konsistentere englische Parallelen (u. a. drei-Bereiche-Block „One list …“, vierter Audience-Punkt zu „sense of when“ ohne Pflicht‑Due Dates), Reset-Referenzliste in gleicher Reihenfolge wie DE.

## Website (Komponenten)
- **`ManifestStatement.astro`**: optionales Feld **`quoteSub`** für einen zweiten Absatz unter dem Hauptzitat (Gestaltung und Farblogik analog Hero-Subheadline-Stil wo schon angelegt).
- **`ResetAnimation.astro`**: Erledigung von **unteren** Tasks bei `doneCount`, **Durchstreichen** erledigter Zeilen; `returnedTasks`/`migratedTask` passend zur neuen Semantik; DE/EN-Taskliste so sortiert, dass die **oberste Aufgabe** die offene (Archiv‑) Bewegungslogik abbildet.

## Marketing-Dokument
- **`docs/AI_INPUT.md`**: weniger Schuldzuweisungen, stärker **Klarheit, Druck, Prioritätssignale**; Formulierungen zur Zielgruppe und Wettbewerbsvergleich angepasst; neurodivergente Erwähnung ohne Übertreibungen.

## Sonstiges
- **`git cheat sheet.html`**: Cheat-Sheet um Einträge ergänzt (bitte prüfen, ob das in denselben PR gehört oder separat).

## Nach dem Copy & Paste
Wenn du die PR-Beschreibung in **GitHub** einfügst: die **vier führenden Leerzeichen pro Zeile** dieses Blocks entfernen (sonst wird der Text oft als Festbreiten-/Codeblock statt Markdown gerendert).