### PR TITLE
website: CSS inline rendern — Render-Blocking eliminieren

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
   trailingSlash: "ignore",
   build: {
     format: "directory",
+    inlineStylesheets: "always",
   },
   i18n: {
     defaultLocale: "en",


### PR DESCRIPTION
## Summary
- `build.inlineStylesheets: 'always'` in `astro.config.mjs` gesetzt
- Astro schreibt CSS jetzt als `<style>` direkt in den HTML-Stream statt als separate `<link rel="stylesheet">` Dateien
- Eliminiert 2 render-blocking CSS-Requests (13.1 KiB total, PSI: 1.080ms Einsparung)

## Erwarteter Impact
LCP Mobile: 3.0s → ~2.0s (unter die grüne 2.5s-Schwelle)

## Test plan
- [ ] PSI Mobile nach Deploy: LCP muss unter 2.5s fallen (grün)
- [ ] Visuell keine FOUC-Auffälligkeiten (nicht möglich bei `always`, da CSS synchron im HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)