### PR TITLE
website: Hero-Einblend-Animation entfernen (LCP-Fix)

### DIFF
--- a/website/src/components/HeroSunrise.astro
+++ b/website/src/components/HeroSunrise.astro
@@ -30,7 +30,7 @@ const dict = getDict(lang);
 
     <h1 class="reveal text-display text-white text-[clamp(2.5rem,7vw,5.75rem)] leading-[0.98] max-w-[18ch]">
       {dict.hero.headline.map((line, i) => (
-        <span class="block" style={`transition-delay: ${120 + i * 80}ms`}>
+        <span class="block">
           {i === dict.hero.headline.length - 1 ? (
             <span class="text-blend-exclusion-warm">{line}</span>
           ) : (
@@ -137,41 +137,10 @@ const dict = getDict(lang);
     z-index: 3;
   }
 
-  /* Reveal stagger inside hero */
-  [data-hero] .reveal {
-    opacity: 0;
-    transform: translateY(18px);
-    will-change: auto;
-    transition: opacity 900ms var(--ease-soft, ease), transform 900ms var(--ease-soft, ease);
-  }
-  [data-hero].is-loaded .reveal {
-    opacity: 1;
-    transform: none;
-  }
-  [data-hero] .reveal.is-visible {
-    transform: none;
-  }
-  [data-hero].is-loaded .reveal:nth-child(1) { transition-delay: 100ms; }
-  [data-hero].is-loaded .reveal:nth-child(2) { transition-delay: 220ms; }
-  [data-hero].is-loaded .reveal:nth-child(3) { transition-delay: 460ms; }
-  [data-hero].is-loaded .reveal:nth-child(4) { transition-delay: 600ms; }
-
   @media (prefers-reduced-motion: reduce) {
     .hero-sunrise-glow {
       animation: none !important;
     }
-    [data-hero] .reveal {
-      opacity: 1;
-      transform: none;
-    }
   }
 </style>
 
-<script>
-  const hero = document.querySelector<HTMLElement>("[data-hero]");
-  if (hero) {
-    requestAnimationFrame(() => {
-      hero.classList.add("is-loaded");
-    });
-  }
-</script>


### PR DESCRIPTION
## Was & Warum

PSI zeigte LCP **Element render delay: 2.840 ms** — der Hero-Subtitle-Text startete mit `opacity: 0` und wurde erst nach 460 ms Delay + 900 ms CSS-Transition sichtbar. Auf Mobile kam JS-Startzeit hinzu → 2,84 s gesamt.

## Änderungen

**`website/src/components/HeroSunrise.astro`**
- `[data-hero] .reveal` CSS-Block entfernt (`opacity: 0`, `transform: translateY`, `transition`, `will-change`)
- `is-loaded`-Regeln und alle `nth-child`-Delay-Rules entfernt
- Inline `transition-delay` von `<h1>`-Spans entfernt
- `<script>` (addierte `is-loaded`-Klasse via `requestAnimationFrame`) entfernt

Die dekorative Sonne (`glow-pulse`) und alle Scroll-Animationen für Below-fold-Content sind unverändert.

## Erwartetes Ergebnis

LCP render delay: 2.840 ms → <200 ms  
LCP gesamt: 3.1 s → ~1.0–1.5 s (Ziel: <2.5 s grün)

🤖 Generated with [Claude Code](https://claude.com/claude-code)