### PR TITLE
website: Desktop-TBT senken — Script-Initialisierung deferrieren

### DIFF
--- a/website/src/components/SunriseStage.astro
+++ b/website/src/components/SunriseStage.astro
@@ -104,7 +104,6 @@
           stage.style.setProperty("--dawn-progress", progress.toFixed(4));
         });
       };
-      update();
       window.addEventListener("scroll", update, { passive: true });
       window.addEventListener("resize", update);
     }

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -90,25 +90,32 @@ const appleTouchIcon = await getImage({ src: appleTouchIconSrc, width: 180, heig
     <Footer lang={lang} />
 
     <script>
-      const reveals = document.querySelectorAll<HTMLElement>(".reveal");
-      const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      if (reduce) {
-        reveals.forEach((el) => el.classList.add("is-visible"));
-      } else if ("IntersectionObserver" in window) {
-        const io = new IntersectionObserver(
-          (entries) => {
-            entries.forEach((entry) => {
-              if (entry.isIntersecting) {
-                entry.target.classList.add("is-visible");
-                io.unobserve(entry.target);
-              }
-            });
-          },
-          { threshold: 0.15 }
-        );
-        reveals.forEach((el) => io.observe(el));
+      const init = () => {
+        const reveals = document.querySelectorAll<HTMLElement>(".reveal");
+        const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        if (reduce) {
+          reveals.forEach((el) => el.classList.add("is-visible"));
+        } else if ("IntersectionObserver" in window) {
+          const io = new IntersectionObserver(
+            (entries) => {
+              entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                  entry.target.classList.add("is-visible");
+                  io.unobserve(entry.target);
+                }
+              });
+            },
+            { threshold: 0.15 }
+          );
+          reveals.forEach((el) => io.observe(el));
+        } else {
+          reveals.forEach((el) => el.classList.add("is-visible"));
+        }
+      };
+      if ("requestIdleCallback" in window) {
+        requestIdleCallback(init, { timeout: 1000 });
       } else {
-        reveals.forEach((el) => el.classList.add("is-visible"));
+        setTimeout(init, 0);
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary

- **SunriseStage.astro**: Initialen `update()`-Aufruf entfernt — beim Laden ist `scroll = 0`, daher ist `--dawn-progress` bereits `0` (CSS-Default). Der Aufruf hat `getBoundingClientRect()` per `requestAnimationFrame` erzwungen ohne visuellen Nutzen.
- **Base.astro**: Reveal-IntersectionObserver-Setup in `requestIdleCallback(init, { timeout: 1000 })` verschoben, damit der Setup-Task nicht ins TBT-Fenster fällt. Fallback auf `setTimeout(init, 0)` für Safari < 16.4.

**Erwarteter Effekt:** Desktop TBT: 310ms 🟠 → <150ms ✅

## Test plan

- [ ] PSI Desktop messen: TBT muss unter 200ms fallen
- [ ] Scroll-Animation auf SunriseStage prüfen: startet beim ersten Scroll-Event korrekt
- [ ] Below-fold `.reveal`-Animationen prüfen: Sektionen blenden beim Scrollen ein
- [ ] `prefers-reduced-motion` testen: alle Elemente sofort sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)