### PR TITLE
website: LCP fetchpriority + esnext build target

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -32,5 +32,8 @@ export default defineConfig({
   ],
   vite: {
     plugins: [tailwindcss()],
+    build: {
+      target: "esnext",
+    },
   },
 });

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -38,6 +38,7 @@ const altHref = pathMap[segment]?.[altLang] ?? `/${altLang}/`;
           sizes="36px"
           class="h-9 w-9 rounded-[8px] shadow-[0_8px_24px_-12px_rgba(245,176,66,0.6)]"
           loading="eager"
+          fetchpriority="high"
           decoding="async"
         />
       </span>


### PR DESCRIPTION
## Summary

- **`fetchpriority=\"high\"` auf dem Header-Icon** — PSI flaggt das App-Icon als LCP-Element und verlangt `fetchpriority=high`. Das Icon hat bereits `loading=\"eager\"`, aber ohne explizite Fetch-Priorität landet es hinter anderen Netzwerk-Requests. Der Fix signalisiert dem Browser, diesen Request bevorzugt zu behandeln.

- **`vite.build.target: \"esnext\"`** — PSI zeigt 9.8kB Legacy-JavaScript aus dem Astro-Bundle (Polyfills + Transforms für alte Browser). Da Dawny iOS 26.2+ targetiert, kann die Website bedenkenlos nur moderne Browser ansprechen. `esnext` eliminiert überflüssige Transpilierungen.

## Erwarteter Effekt

- LCP: 3.1s → deutlich darunter (fetchpriority priorisiert den LCP-Request)
- JS-Bundle: ~9.8kB kleiner (weniger Polyfills)
- Performance-Score: 93 → Richtung 96–98

## Test plan

- [ ] Nach Deploy: PSI Mobile neu messen — LCP sollte unter 2.5s fallen
- [ ] Visuelle Prüfung: Header-Icon lädt korrekt, kein Flash/Layout-Shift
- [ ] PSI zeigt \"fetchpriority=high should be applied\" nicht mehr

🤖 Generated with [Claude Code](https://claude.ai/claude-code)