### PR TITLE
website: SunriseStage forced reflow eliminieren

### DIFF
--- a/website/src/components/SunriseStage.astro
+++ b/website/src/components/SunriseStage.astro
@@ -95,17 +95,22 @@
       stage.style.setProperty("--dawn-progress", "0");
     } else {
       let raf = 0;
+      let total = Math.max(1, stage.offsetHeight - window.innerHeight);
+
       const update = () => {
         cancelAnimationFrame(raf);
         raf = requestAnimationFrame(() => {
           const rect = stage.getBoundingClientRect();
-          const total = Math.max(1, stage.offsetHeight - window.innerHeight);
           const progress = Math.max(0, Math.min(1, -rect.top / total));
           stage.style.setProperty("--dawn-progress", progress.toFixed(4));
         });
       };
+
       window.addEventListener("scroll", update, { passive: true });
-      window.addEventListener("resize", update);
+      window.addEventListener("resize", () => {
+        total = Math.max(1, stage.offsetHeight - window.innerHeight);
+        update();
+      });
     }
   }
 </script>


### PR DESCRIPTION
## Summary

- `stage.offsetHeight` aus dem Scroll-RAF-Callback herausgelöst und als gecachten Wert `total` gespeichert
- `total` wird nur beim `resize`-Event neu berechnet (Wert ändert sich nicht beim Scrollen)
- Eliminiert 41ms Forced Reflow pro Scroll-Interaktion (PSI-Audit: "Forced reflow")

**Vorher:** Jeder Scroll-RAF las `stage.offsetHeight` — ein Layout-Read, der einen Reflow erzwingt wenn das Layout zwischenzeitlich dirty wurde.

**Nachher:** Scroll-RAF liest nur `getBoundingClientRect()`. `offsetHeight` wird einmalig beim Init und dann nur noch bei `resize` gelesen.

## Test plan

- [ ] Nach Deploy: PSI Mobile neu messen — "Forced reflow" sollte nicht mehr erscheinen
- [ ] Scroll-Animation auf SunriseStage läuft weiterhin korrekt
- [ ] Resize (z.B. Landscape/Portrait-Wechsel) aktualisiert die Animation korrekt

🤖 Generated with [Claude Code](https://claude.ai/claude-code)