### PR TITLE
legal: replace street address with P.O. Box

### DIFF
--- a/docs/PRIVACY.de.md
+++ b/docs/PRIVACY.de.md
@@ -16,9 +16,9 @@
 Verantwortlicher im Sinne der DSGVO ist:
 
 **Florian Schneider**  
-[BITTE ERGÄNZEN: Straße und Hausnummer]  
-76133 Karlsruhe  
-[BITTE ERGÄNZEN: Land]
+Postfach 11 13 15  
+76063 Karlsruhe  
+Deutschland
 
 E-Mail: info@dawnyapp.com
 

--- a/docs/PRIVACY.en.md
+++ b/docs/PRIVACY.en.md
@@ -15,9 +15,9 @@
 The data controller under the GDPR is:
 
 **Florian Schneider**  
-[PLEASE FILL IN: Street and number]  
-76133 Karlsruhe  
-[PLEASE FILL IN: Country]
+Postfach 11 13 15  
+76063 Karlsruhe  
+Germany
 
 Email: info@dawnyapp.com
 

--- a/website/src/pages/de/datenschutz.md
+++ b/website/src/pages/de/datenschutz.md
@@ -15,8 +15,8 @@ altCanonicalPath: "/privacy/"
 Verantwortlicher im Sinne der DSGVO ist:
 
 **Florian Schneider**
-Kreuzstraße 26
-76133 Karlsruhe
+Postfach 11 13 15
+76063 Karlsruhe
 Deutschland
 
 E-Mail: info@dawnyapp.com

--- a/website/src/pages/de/impressum.md
+++ b/website/src/pages/de/impressum.md
@@ -10,8 +10,8 @@ altCanonicalPath: "/imprint/"
 ## Angaben gemäß § 5 DDG
 
 **Florian Schneider**
-Kreuzstraße 26
-76133 Karlsruhe
+Postfach 11 13 15
+76063 Karlsruhe
 Deutschland
 
 ## Kontakt

--- a/website/src/pages/en/imprint.md
+++ b/website/src/pages/en/imprint.md
@@ -10,8 +10,8 @@ altCanonicalPath: "/impressum/"
 ## Information according to § 5 DDG
 
 **Florian Schneider**
-Kreuzstraße 26
-76133 Karlsruhe
+Postfach 11 13 15
+76063 Karlsruhe
 Germany
 
 ## Contact

--- a/website/src/pages/en/privacy.md
+++ b/website/src/pages/en/privacy.md
@@ -15,8 +15,8 @@ altCanonicalPath: "/datenschutz/"
 The data controller under the GDPR is:
 
 **Florian Schneider**
-Kreuzstraße 26
-76133 Karlsruhe
+Postfach 11 13 15
+76063 Karlsruhe
 Germany
 
 Email: info@dawnyapp.com


### PR DESCRIPTION
## Summary

- Replaces `Kreuzstraße 26, 76133 Karlsruhe` with `Postfach 11 13 15, 76063 Karlsruhe` in all 6 legal pages
- Affected: website imprint (DE/EN), website privacy (DE/EN), docs privacy policy source files (DE/EN)
- Also fills in the previously missing country placeholder in `docs/PRIVACY.*.md`

## Files changed

- `website/src/pages/de/impressum.md`
- `website/src/pages/en/imprint.md`
- `website/src/pages/de/datenschutz.md`
- `website/src/pages/en/privacy.md`
- `docs/PRIVACY.de.md`
- `docs/PRIVACY.en.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)