### PR TITLE
fix: hide debug settings section in Release builds

### DIFF
--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -98,10 +98,10 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showingSettings) {
             SettingsView(
-                onRequestAddTestItems: {
-                    triggerTestWorkflow()
-                },
+                #if DEBUG
+                onRequestAddTestItems: { triggerTestWorkflow() },
                 onRequestDeleteAll: clearAllAction,
+                #endif
                 onRequestShowWelcome: {
                     showingSettings = false
                     showWelcome = true


### PR DESCRIPTION
## Summary

- `onRequestAddTestItems` wurde in `ContentView` immer als non-nil Closure übergeben, auch in Release Builds
- `SettingsView.debugSection` prüft nur auf `!= nil` und zeigte den "Add Test Items"-Button daher auch im App Store Build an
- Fix: beide Debug-Callbacks (`onRequestAddTestItems`, `onRequestDeleteAll`) hinter `#if DEBUG` gesetzt, konsistent mit dem bestehenden `clearAllAction`-Pattern

## Test plan

- [ ] Debug-Build: Settings öffnen → Debug-Sektion mit "Add Test Items" und "Delete All Tasks" sichtbar
- [ ] Release-Build (Scheme → Edit Scheme → Run → Build Configuration: Release): Settings öffnen → kein Debug-Bereich sichtbar
