### PR TITLE
fix: use computed property pattern for addTestItemsAction

### DIFF
--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -30,6 +30,14 @@ struct ContentView: View {
     @State private var listContentRemount = 0
     #endif
 
+    private var addTestItemsAction: (() -> Void)? {
+        #if DEBUG
+        return { triggerTestWorkflow() }
+        #else
+        return nil
+        #endif
+    }
+
     private var clearAllAction: (() -> Void)? {
         #if DEBUG
         return { showingClearAllConfirm = true }
@@ -98,10 +106,8 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showingSettings) {
             SettingsView(
-                #if DEBUG
-                onRequestAddTestItems: { triggerTestWorkflow() },
+                onRequestAddTestItems: addTestItemsAction,
                 onRequestDeleteAll: clearAllAction,
-                #endif
                 onRequestShowWelcome: {
                     showingSettings = false
                     showWelcome = true


### PR DESCRIPTION
#if DEBUG inside a function argument list is invalid Swift syntax. Replace with a computed property returning nil in Release — identical to the existing clearAllAction pattern.