### PR TITLE
chore: ignore RELEASE_RUNBOOK.md in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ pnpm-debug.log*
 *.pem
 *.p12
 *.mobileprovision
+
+# Persönliche Betriebsdokumente
+docs/RELEASE_RUNBOOK.md


### PR DESCRIPTION
## Summary

- Adds `docs/RELEASE_RUNBOOK.md` to `.gitignore`
- The file is a personal release operations checklist, not relevant for the shared codebase

## Test plan

- [ ] Verify `docs/RELEASE_RUNBOOK.md` is not tracked after merge (`git status` should not list it)