### PR TITLE
feat: in-app feedback + App Store review prompt

### DIFF
--- a/App/Sources/DawnyApp.swift
+++ b/App/Sources/DawnyApp.swift
@@ -76,7 +76,10 @@ struct DawnyApp: App {
     /// Führt wichtige Tasks beim App-Start aus
     private func performAppLaunchTasks() async {
         print("🚀 Dawny App Launching...")
-        
+
+        // 0. Launch-Counter erhöhen (für Review-Prompt-Eligibility)
+        AppSettings.shared.appLaunchCount += 1
+
         // 1. Request Calendar Permissions (falls noch nicht erteilt)
         do {
             let granted = try await calendarService.requestAccess()

--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -4166,6 +4166,114 @@
         }
       }
     },
+    "settings.feedback.header": {
+      "comment": "Settings · Feedback section header.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        }
+      }
+    },
+    "settings.feedback.send": {
+      "comment": "Settings · Feedback section · Opens mail composer to send feedback.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback senden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
+          }
+        }
+      }
+    },
+    "settings.feedback.nomail.title": {
+      "comment": "Settings · Feedback · Alert title when no mail client is available.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein E-Mail-Konto"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Mail Account"
+          }
+        }
+      }
+    },
+    "settings.feedback.nomail.message": {
+      "comment": "Settings · Feedback · Alert message when no mail client is available. %@ is the email address.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein E-Mail-Client eingerichtet. Schreib uns direkt an info@dawnyapp.com."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No mail client is set up on this device. You can reach us at info@dawnyapp.com."
+          }
+        }
+      }
+    },
+    "settings.feedback.nomail.copy": {
+      "comment": "Settings · Feedback · Alert button to copy the email address to clipboard.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adresse kopieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Address"
+          }
+        }
+      }
+    },
+    "general.ok": {
+      "comment": "General · OK button label.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
     "sync.status.days_ago": {
       "comment": "Sync status · Relative time label · %lld is the number of days. Plural-aware via CLDR.",
       "extractionState": "manual",

--- a/App/Sources/Models/AppSettings.swift
+++ b/App/Sources/Models/AppSettings.swift
@@ -26,6 +26,9 @@ final class AppSettings {
         static let hasSeenWelcome = "DawnyHasSeenWelcome"
         static let makeItCountThreshold = "DawnyMakeItCountThreshold"
         static let hasNewArchivedTasks = "DawnyHasNewArchivedTasks"
+        static let appLaunchCount = "DawnyAppLaunchCount"
+        static let totalResetEventCount = "DawnyTotalResetEventCount"
+        static let lastReviewPromptDate = "DawnyLastReviewPromptDate"
     }
     
     // MARK: - Properties
@@ -79,6 +82,27 @@ final class AppSettings {
         }
     }
     
+    /// Anzahl der App-Starts (für Review-Prompt-Eligibility)
+    var appLaunchCount: Int {
+        didSet {
+            UserDefaults.standard.set(appLaunchCount, forKey: Keys.appLaunchCount)
+        }
+    }
+
+    /// Anzahl abgeschlossener Reset-Events (für Review-Prompt-Eligibility)
+    var totalResetEventCount: Int {
+        didSet {
+            UserDefaults.standard.set(totalResetEventCount, forKey: Keys.totalResetEventCount)
+        }
+    }
+
+    /// Datum des letzten Review-Prompts (Rate-Limiting)
+    var lastReviewPromptDate: Date? {
+        didSet {
+            UserDefaults.standard.set(lastReviewPromptDate, forKey: Keys.lastReviewPromptDate)
+        }
+    }
+
     /// Standard-Kategorie für neue Tasks (wenn Kategorien aktiviert)
     var defaultCategoryType: TaskCategory {
         didSet {
@@ -99,6 +123,9 @@ final class AppSettings {
         self.hasSeenWelcome = UserDefaults.standard.bool(forKey: Keys.hasSeenWelcome)
         self.makeItCountThreshold = UserDefaults.standard.object(forKey: Keys.makeItCountThreshold) as? Int ?? 1
         self.hasNewArchivedTasks = UserDefaults.standard.bool(forKey: Keys.hasNewArchivedTasks)
+        self.appLaunchCount = UserDefaults.standard.object(forKey: Keys.appLaunchCount) as? Int ?? 0
+        self.totalResetEventCount = UserDefaults.standard.object(forKey: Keys.totalResetEventCount) as? Int ?? 0
+        self.lastReviewPromptDate = UserDefaults.standard.object(forKey: Keys.lastReviewPromptDate) as? Date
         
         // Lade defaultCategoryType
         if let data = UserDefaults.standard.data(forKey: Keys.defaultCategoryType),
@@ -110,8 +137,19 @@ final class AppSettings {
         }
     }
     
+    // MARK: - Computed
+
+    /// True wenn alle Bedingungen für den Review-Prompt erfüllt sind
+    var isEligibleForReviewPrompt: Bool {
+        guard appLaunchCount >= 5, totalResetEventCount >= 2 else { return false }
+        if let last = lastReviewPromptDate {
+            return Date().timeIntervalSince(last) >= 60 * 60 * 24 * 60
+        }
+        return true
+    }
+
     // MARK: - Singleton
-    
+
     /// Shared Instance für App-weite Nutzung
     static let shared = AppSettings()
 }

--- a/App/Sources/Services/FeedbackService.swift
+++ b/App/Sources/Services/FeedbackService.swift
@@ -1,0 +1,45 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  FeedbackService.swift
+//  Dawny
+//
+//  Hilfsfunktionen für In-App-Feedback via E-Mail
+//
+
+import UIKit
+
+enum FeedbackService {
+    static let recipient = "info@dawnyapp.com"
+
+    static func mailSubject(version: String, build: String) -> String {
+        "Dawny Feedback – v\(version) (\(build))"
+    }
+
+    static func deviceInfoBody() -> String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let systemVersion = UIDevice.current.systemVersion
+        let model = UIDevice.current.model
+        let locale = Locale.current.identifier
+        let resetHour = AppSettings.shared.resetHour
+
+        return """
+
+
+——
+Dawny \(version) (\(build)) · iOS \(systemVersion) · \(model)
+Locale: \(locale) · Reset: \(String(format: "%02d:00", resetHour))
+"""
+    }
+
+    static func mailtoFallbackURL(version: String, build: String) -> URL? {
+        let subject = mailSubject(version: version, build: build)
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let body = deviceInfoBody()
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        return URL(string: "mailto:\(recipient)?subject=\(subject)&body=\(body)")
+    }
+}

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -115,7 +115,8 @@ final class ResetEngine {
             print("❌ Failed to save reset: \(error)")
         }
         
-        // Speichere Reset-Zeitpunkt
+        // Speichere Reset-Zeitpunkt und zähle Event für Review-Eligibility
+        AppSettings.shared.totalResetEventCount += 1
         saveLastResetDate(referenceDate)
     }
     

--- a/App/Sources/Views/DailyFocusView.swift
+++ b/App/Sources/Views/DailyFocusView.swift
@@ -10,11 +10,13 @@
 //
 
 import SwiftUI
+import StoreKit
 
 struct DailyFocusView: View {
     @Bindable var viewModel: DailyFocusViewModel
     var backlogViewModel: BacklogViewModel
     @State private var focusedTaskID: UUID?
+    @Environment(\.requestReview) private var requestReview
 
     var body: some View {
         NavigationStack {
@@ -34,6 +36,11 @@ struct DailyFocusView: View {
             }
             .onAppear {
                 viewModel.loadDailyTasks()
+            }
+            .onChange(of: viewModel.openTasks) { _, newOpen in
+                if newOpen.isEmpty && !viewModel.completedTasks.isEmpty {
+                    maybeRequestReview()
+                }
             }
             .overlay(alignment: .top) {
                 if let error = viewModel.errorMessage {
@@ -145,6 +152,13 @@ struct DailyFocusView: View {
         }
     }
     
+    private func maybeRequestReview() {
+        let settings = AppSettings.shared
+        guard settings.isEligibleForReviewPrompt else { return }
+        settings.lastReviewPromptDate = Date()
+        requestReview()
+    }
+
     private var syncIndicatorView: some View {
         VStack {
             Spacer()

--- a/App/Sources/Views/MailComposeView.swift
+++ b/App/Sources/Views/MailComposeView.swift
@@ -1,0 +1,56 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  MailComposeView.swift
+//  Dawny
+//
+//  SwiftUI-Wrapper für MFMailComposeViewController
+//
+
+import SwiftUI
+import MessageUI
+
+struct MailComposeView: UIViewControllerRepresentable {
+    let recipients: [String]
+    let subject: String
+    let body: String
+    var screenshotAttachment: UIImage? = nil
+    @Binding var isPresented: Bool
+
+    func makeUIViewController(context: Context) -> MFMailComposeViewController {
+        let vc = MFMailComposeViewController()
+        vc.mailComposeDelegate = context.coordinator
+        vc.setToRecipients(recipients)
+        vc.setSubject(subject)
+        vc.setMessageBody(body, isHTML: false)
+        if let screenshot = screenshotAttachment,
+           let data = screenshot.pngData() {
+            vc.addAttachmentData(data, mimeType: "image/png", fileName: "screenshot.png")
+        }
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: MFMailComposeViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isPresented: $isPresented)
+    }
+
+    final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+        @Binding var isPresented: Bool
+
+        init(isPresented: Binding<Bool>) {
+            _isPresented = isPresented
+        }
+
+        func mailComposeController(
+            _ controller: MFMailComposeViewController,
+            didFinishWith result: MFMailComposeResult,
+            error: Error?
+        ) {
+            isPresented = false
+        }
+    }
+}

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -11,6 +11,7 @@
 
 import SwiftUI
 import UIKit
+import MessageUI
 
 struct SettingsView: View {
 
@@ -23,6 +24,8 @@ struct SettingsView: View {
     let onRequestShowWelcome: (() -> Void)?
 
     @State private var resetTime: Date
+    @State private var showingFeedbackMail = false
+    @State private var showingNoMailAlert = false
     
     init(
         settings: AppSettings = .shared,
@@ -53,10 +56,31 @@ struct SettingsView: View {
                 synchronisationSection
                 appearanceSection
                 welcomeSection
+                feedbackSection
             }
             .listSectionSpacing(.compact)
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 settingsBottomChrome
+            }
+            .sheet(isPresented: $showingFeedbackMail) {
+                MailComposeView(
+                    recipients: [FeedbackService.recipient],
+                    subject: FeedbackService.mailSubject(version: appVersion, build: appBuild),
+                    body: FeedbackService.deviceInfoBody(),
+                    isPresented: $showingFeedbackMail
+                )
+                .ignoresSafeArea()
+            }
+            .alert(
+                String(localized: "settings.feedback.nomail.title", defaultValue: "No Mail Account"),
+                isPresented: $showingNoMailAlert
+            ) {
+                Button(String(localized: "settings.feedback.nomail.copy", defaultValue: "Copy Address")) {
+                    UIPasteboard.general.string = FeedbackService.recipient
+                }
+                Button(String(localized: "general.ok", defaultValue: "OK"), role: .cancel) {}
+            } message: {
+                Text(String(localized: "settings.feedback.nomail.message", defaultValue: "No mail client is set up on this device. You can reach us at \(FeedbackService.recipient)."))
             }
             .navigationTitle(String(localized: "settings.title", defaultValue: "Settings"))
             .navigationBarTitleDisplayMode(.inline)
@@ -231,6 +255,35 @@ struct SettingsView: View {
         }
     }
     
+    private var feedbackSection: some View {
+        Section {
+            Button {
+                if MFMailComposeViewController.canSendMail() {
+                    showingFeedbackMail = true
+                } else if let url = FeedbackService.mailtoFallbackURL(version: appVersion, build: appBuild) {
+                    UIApplication.shared.open(url, options: [:]) { success in
+                        if !success {
+                            DispatchQueue.main.async { showingNoMailAlert = true }
+                        }
+                    }
+                } else {
+                    showingNoMailAlert = true
+                }
+            } label: {
+                Label(
+                    String(localized: "settings.feedback.send", defaultValue: "Send Feedback"),
+                    systemImage: "envelope"
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundStyle(.primary)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("SettingsFeedbackSendButton")
+        } header: {
+            Text(String(localized: "settings.feedback.header", defaultValue: "Feedback"))
+        }
+    }
+
     private var settingsBottomChrome: some View {
         Text(versionBuildFooterLine)
             .font(.caption2)


### PR DESCRIPTION
## Summary

- **Email feedback button** in Settings: opens `MFMailComposeViewController` with pre-filled recipient (`info@dawnyapp.com`), subject (version + build), and device info body. Falls back to `mailto:` URL, then shows a "No Mail Account" alert with a "Copy Address" button if both fail (covers Simulator and unconfigured devices).
- **App Store review prompt** via StoreKit `requestReview()`: fires when all Daily Focus tasks are completed, gated by ≥5 app launches AND ≥2 reset events, with a 60-day cooldown between prompts. Works in TestFlight without affecting App Store ratings.
- New `AppSettings` properties: `appLaunchCount`, `totalResetEventCount`, `lastReviewPromptDate`.
- New files: `FeedbackService.swift` (mail helpers), `MailComposeView.swift` (UIViewControllerRepresentable wrapper).

## Test plan

- [ ] Settings → "Send Feedback": mail compose sheet opens with correct recipient, subject, and device info
- [ ] Settings → "Send Feedback" on Simulator / device without mail: alert appears with "Copy Address" button that copies `info@dawnyapp.com`
- [ ] Complete all Daily Focus tasks with eligible launch/reset counts: StoreKit review prompt appears
- [ ] Review prompt does not re-appear within 60 days of last prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)