### PR TITLE
chore: update TestFlight invite link to 758Xfan6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <a href="https://testflight.apple.com/join/h9JSWasd">
+  <a href="https://testflight.apple.com/join/758Xfan6">
     <img alt="Join the TestFlight Beta" src="https://img.shields.io/badge/TestFlight-Join%20the%20Beta-000000?style=for-the-badge&logo=apple">
   </a>
 </p>
@@ -35,7 +35,7 @@ The codebase is Swift 6 with SwiftUI and SwiftData, zero third-party dependencie
 
 ## Getting Dawny
 
-Install via the [TestFlight beta](https://testflight.apple.com/join/h9JSWasd). Dawny will be available on the App Store soon. Any feedback before the 1.0 release is much appreciated.
+Install via the [TestFlight beta](https://testflight.apple.com/join/758Xfan6). Dawny will be available on the App Store soon. Any feedback before the 1.0 release is much appreciated.
 
 ---
 

--- a/docs/AI Input/AI_INPUT.md
+++ b/docs/AI Input/AI_INPUT.md
@@ -18,7 +18,7 @@ Last source-code review for factual product state: April 27, 2026. Re-verify bef
 | One-liner | "Dawny turns unfinished tasks into a clear priority signal." |
 | Platform | iOS 26.2+, native SwiftUI. Designed and tested primarily for iPhone; do not position as an iPad-optimized product unless separately verified. |
 | Distribution | Public Beta via TestFlight |
-| TestFlight link | https://testflight.apple.com/join/h9JSWasd |
+| TestFlight link | https://testflight.apple.com/join/758Xfan6 |
 | App Store | Not yet live |
 | Pricing | Free during beta. No pricing commitment for post-launch. |
 | Developer | Florian Schneider, Karlsruhe, Germany |
@@ -283,7 +283,7 @@ For the app, zero developer-side task-data collection is not a setting or a plan
 ## 7. CURRENT STATUS & DISTRIBUTION
 
 - **Stage:** Public beta
-- **Access:** TestFlight — https://testflight.apple.com/join/h9JSWasd
+- **Access:** TestFlight — https://testflight.apple.com/join/758Xfan6
 - **App Store:** Not yet live
 - **Feedback:** TestFlight beta testers directly shape the product
 - **Pricing post-launch:** Not publicly defined. Marketing must not make pricing commitments in either direction.
@@ -319,7 +319,7 @@ For rapid orientation when generating marketing copy:
 | Who is it for? | People overwhelmed by their own task systems; minimalists; dynamic workers; neurodivergent-friendly |
 | What makes it different? | Zero-Overdue by design, 3 AM Reset, Make It Count archiving, recoverable Archive, radical reduction |
 | What does it NOT do? | No due dates, no subtasks, no team features, no cross-platform, no iPad-optimized promise |
-| How do I get it? | TestFlight beta: https://testflight.apple.com/join/h9JSWasd |
+| How do I get it? | TestFlight beta: https://testflight.apple.com/join/758Xfan6 |
 | Who made it? | Florian Schneider, indie developer, Karlsruhe, Germany |
 | What should the tone be? | Calm, confident, honest, anti-hustle, slightly poetic |
 | What phrases are established? | "Start fresh.", "No overdue.", "Make it count.", "The 3 AM Reset", "Just clarity." |

--- a/website/src/content/blog/cognitive-load-productivity.md
+++ b/website/src/content/blog/cognitive-load-productivity.md
@@ -118,4 +118,4 @@ The productivity tools that feel most powerful. The ones with the most features,
 
 The alternative isn't about being minimalist for aesthetic reasons. It's about designing your system so that it demands as little as possible from you, and gives you back the mental bandwidth to do your best work. That means shorter daily lists, automatic cleanup of undone tasks, and a clean separation between your daily focus and everything else waiting in the wings. Simpler systems win not because they're simpler, but because they respect the limits of human attention.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/daily-planning-system.md
+++ b/website/src/content/blog/daily-planning-system.md
@@ -162,4 +162,4 @@ The five-step framework in this guide (capture, choose, protect, reset, review) 
 
 The relationship between you and your task list should not feel adversarial. It should feel like a tool that helps you make good decisions — one that resets cleanly when the day is done and starts fresh when the next one begins.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/dawny-vs-todoist.md
+++ b/website/src/content/blog/dawny-vs-todoist.md
@@ -150,4 +150,4 @@ Dawny is not trying to out-feature Todoist. It is trying to do one thing differe
 
 It is a beta, it is iOS-only, and it has fewer features than almost every other app in this category. But for the right person, that is exactly the point.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/decision-fatigue-task-management.md
+++ b/website/src/content/blog/decision-fatigue-task-management.md
@@ -142,4 +142,4 @@ The fix is architectural. A separate backlog for everything. A small daily list 
 
 When your task system stops demanding constant re-evaluation and starts reflecting deliberate commitments, the list stops being something you avoid and starts being something you actually use. That's not a small thing. The difference between a list you open every morning and one you haven't touched in a week is, more often than not, a design problem with a structural solution.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/morning-routine-task-reset.md
+++ b/website/src/content/blog/morning-routine-task-reset.md
@@ -132,4 +132,4 @@ That decision takes five minutes. It requires choosing 2–3 tasks from a clear,
 
 The reset philosophy. Where unfinished tasks return to the backlog overnight rather than accumulating as overdue items. Makes the morning decision genuinely clean. You're not choosing which failures to rescue. You're choosing what today's opportunities are. That shift in framing is small but profound. If you want to experience what that feels like in practice, the article on choosing your [three most important tasks](/en/blog/three-most-important-tasks/) is a useful next step.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/productivity-apps-adhd.md
+++ b/website/src/content/blog/productivity-apps-adhd.md
@@ -145,4 +145,4 @@ The most common mistake in productivity app design for ADHD brains isn't a missi
 
 The developer behind Dawny built the app because he had ADHD and kept hitting this exact wall. Not to build a productivity product. To stop dreading his own task list. The result isn't an app with ADHD features. It's an app where the usual sources of friction have been removed. Tasks reset instead of becoming overdue. The daily view is intentionally small. Nothing punishes you for being human.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/three-most-important-tasks.md
+++ b/website/src/content/blog/three-most-important-tasks.md
@@ -129,4 +129,4 @@ The research on decision fatigue and the psychology of incomplete tasks both poi
 
 The final piece is what happens to the tasks you don't finish. A system that turns them red and calls them overdue is working against you. A system that returns them to your backlog, quietly, without accusation. Lets you choose again tomorrow with fresh eyes. That's not lowering the bar. That's being honest about the fact that priorities change and days are finite.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/two-list-system-backlog.md
+++ b/website/src/content/blog/two-list-system-backlog.md
@@ -113,4 +113,4 @@ Separating your tasks into a backlog and a daily focus list changes the emotiona
 
 The two-list system isn't a new idea. But it remains one of the most effective structures available, precisely because it matches how humans actually make decisions, one day at a time, with a reasonable number of choices, in a context where they don't feel guilty for what they didn't do yesterday.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/what-is-task-debt.md
+++ b/website/src/content/blog/what-is-task-debt.md
@@ -110,4 +110,4 @@ Task debt is real, it's common, and it's not a character flaw. It's what happens
 
 The solution isn't a more aggressive system with harder deadlines and more red indicators. It's a system that treats unfinished tasks not as failures, but as undecided choices. One that resets daily, keeps your active list small, and lets patterns reveal themselves over time rather than forcing you to maintain everything manually. That shift, from debt to reset, changes the entire relationship with your task list.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/content/blog/why-to-do-lists-fail.md
+++ b/website/src/content/blog/why-to-do-lists-fail.md
@@ -122,4 +122,4 @@ Decision fatigue, the guilt spiral of the Zeigarnik effect, infinite accumulatio
 
 A system worth using looks different, a safe backlog for everything, a small daily list you choose deliberately, and automatic resets that prevent the guilt from building. It's not about being more productive. It's about removing the friction that makes you avoid the list entirely.
 
-If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/h9JSWasd) is free to test on TestFlight.
+If you want to try a task app built around this philosophy, [Dawny](https://testflight.apple.com/join/758Xfan6) is free to test on TestFlight.

--- a/website/src/i18n/index.ts
+++ b/website/src/i18n/index.ts
@@ -32,6 +32,6 @@ export function alternateLang(lang: Lang): Lang {
   return lang === "en" ? "de" : "en";
 }
 
-export const TESTFLIGHT_URL = "https://testflight.apple.com/join/h9JSWasd";
+export const TESTFLIGHT_URL = "https://testflight.apple.com/join/758Xfan6";
 export const GITHUB_URL = "https://github.com/flrnsndr/Dawny";
 export const CONTACT_EMAIL = "info@dawnyapp.com";


### PR DESCRIPTION
Replace all TestFlight beta invite links from h9JSWasd to 758Xfan6 across:
- README.md
- Astro website blog articles (10 files)
- Marketing context (AI_INPUT.md)
- I18n configuration

Bisherige Testgruppe umbenannt zu Freunde und Bekannte. 