### PR TITLE
Website: Add German blog posts with Astro Content Collections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ Two active locales: **English (en)** and **German (de)**. All strings live in `A
 
 `/website/` is an Astro 5 + Tailwind CSS 4 site deployed to IONOS via GitHub Actions (`.github/workflows/deploy-website.yml`). It is fully independent from the iOS app. Deploy triggers on pushes to `main` affecting `website/**`.
 
+### Blogposts
+
+Blogposts are located in `website/dist/en/blog/` (English) and `website/dist/de/blog/` (German, being added). Each post has a subdirectory with `index.html`. When working on post content, load posts individually into context — never load all posts at once. Load only the specific post being edited. Posts should be loaded only when directly editing their content; use commit history or file listing for references.
+
 ## Further Documentation
 
 The following files exist but are excluded from auto-indexing. Read them explicitly when relevant.

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -11,8 +11,8 @@ const { lang } = Astro.props;
 const dict = getDict(lang);
 const altLang = alternateLang(lang);
 
-// Map equivalent paths between languages so the language toggle on legal
-// pages keeps the visitor on the equivalent page instead of 404'ing.
+// Map equivalent paths between languages for pages with different slugs per locale.
+// Blog posts share the same slug across locales — handled by URL string-replace below.
 const pathMap: Record<string, { en: string; de: string }> = {
   "": { en: "/en/", de: "/de/" },
   privacy: { en: "/en/privacy/", de: "/de/datenschutz/" },
@@ -22,7 +22,11 @@ const pathMap: Record<string, { en: string; de: string }> = {
 };
 
 const segment = (Astro.url.pathname.split("/")[2] ?? "").replace(/\/+$/, "");
-const altHref = pathMap[segment]?.[altLang] ?? `/${altLang}/`;
+// For blog routes, swap the locale prefix in the current URL (slugs are identical across locales).
+// For all other routes, use the static pathMap or fall back to the alternate home.
+const altHref = segment === "blog"
+  ? Astro.url.pathname.replace(`/${lang}/`, `/${altLang}/`)
+  : (pathMap[segment]?.[altLang] ?? `/${altLang}/`);
 ---
 
 <header class="absolute top-0 left-0 right-0 z-30 pt-6 sm:pt-8">
@@ -48,6 +52,13 @@ const altHref = pathMap[segment]?.[altLang] ?? `/${altLang}/`;
     </a>
 
     <nav class="flex items-center gap-2 sm:gap-3" aria-label={dict.nav.languageLabel}>
+      <a
+        href={`/${lang}/blog/`}
+        class="hidden sm:inline-flex text-xs sm:text-sm font-medium text-white/65 hover:text-white transition-colors px-3 py-2 rounded-full hover:bg-white/8"
+        data-ph-event="blog_nav_click"
+      >
+        {dict.blog.title}
+      </a>
       <a
         href={altHref}
         hreflang={altLang}

--- a/website/src/content/blog/de/cognitive-load-productivity.md
+++ b/website/src/content/blog/de/cognitive-load-productivity.md
@@ -1,0 +1,125 @@
+---
+title: "Kognitive Last und Produktivität: Warum einfachere Systeme besser funktionieren"
+description: "Komplexe Task-Apps verbrauchen mentale Energie, bevor du anfängst zu arbeiten. Lerne, wie die Cognitive-Load-Theorie erklärt, warum einfachere Produktivitätssysteme durchweg besser abschneiden als Feature-reiche Lösungen."
+pubDate: 2026-05-10
+---
+
+# Kognitive Last und Produktivität: Warum einfachere Systeme besser funktionieren
+
+> **Kurz erklärt:** Kognitive Last in der Produktivität bezieht sich darauf, wie die mentale Anstrengung, die zur Verwaltung deines Task-Systems erforderlich ist, direkt deine Kapazität für die eigentliche Arbeit beeinflusst. Eine komplexe To-do-App mit 47 Aufgaben, mehreren Projekten, Labels und Unteraufgaben erzeugt hohe kognitive Last, noch bevor du echte Arbeit geleistet hast. Einfachere Systeme — mit weniger sichtbaren Aufgaben und klarem Daily Focus — reduzieren diese Belastung und geben dir mehr mentale Kapazität für die Arbeit selbst.
+
+Du hast das wahrscheinlich schon erlebt: Du öffnest eine Feature-reiche Task-App, verbringst 15 Minuten damit, Projekte umzugestalten und Tags hinzuzufügen, und schließt sie dann — irgendwie müder als vorher, ohne eine einzige echte Arbeit geleistet zu haben. Es ist nicht Faulheit. Es ist nicht schlechtes Zeitmanagement. Es ist kognitive Last, und deine Produktivitätswerkzeuge sollen sie reduzieren, nicht erzeugen. Die Tools, die auf dem Papier am mächtigsten aussehen, sind manchmal am anstrengendsten zu benutzen — und es gibt Jahrzehnte von Forschung, die genau erklärt, warum das so ist.
+
+## Was ist kognitive Last?
+
+Kognitive Last ist die gesamte mentale Anstrengung, die erforderlich ist, um Informationen zu verarbeiten und in jedem Moment Entscheidungen zu treffen. Das Konzept wurde von Pädagogipsychologe John Sweller in seiner 1988 erschienenen Arbeit zur kognitiven Lasttheorie formalisiert, ursprünglich entwickelt, um zu erklären, warum manche Unterrichtsdesigns Schülern beim Lernen helfen und andere sie überfordern. Die Theorie ist seitdem grundlegend für Interface-Design, Softwareentwicklung und — zunehmend — für die Gestaltung von Produktivitätssystemen geworden. Für einen wissenschaftlicheren Überblick siehe diese systematische Übersicht zur kognitiven Lasttheorie.
+
+Sweller identifizierte drei Arten von kognitiver Last. **Intrinsische Last** ist die inhärente Komplexität der Aufgabe selbst — eine schwierige E-Mail schreiben, ein technisches Problem lösen, eine strategische Entscheidung treffen. Du kannst intrinsische Last nicht eliminieren; sie ist die eigentliche Arbeit. **Extrinsische Last** ist die Belastung, die vom System auferlegt wird, in dem du arbeitest — verwirrende Interfaces, unnötige Entscheidungen, unklar strukturiert. Das ist die Art, die du minimieren möchtest. **Relevante Last** ist die mentale Anstrengung, die in den Aufbau von Verständnis und Fähigkeiten fließt — die Last, die dir tatsächlich dabei hilft, dich im Laufe der Zeit zu verbessern.
+
+Für Produktivitäts-Apps ist extrinsische Last der Feind. Wenn du mentale Energie für die Navigation deines Task-Systems aufbringst. Lange Listen scannst, Metadaten interpretierst, von Dutzenden sichtbarer Optionen entscheidest, was Priorität hat. Das ist extrinsische Last. Sie trägt nicht zu deiner Arbeit bei. Sie belastet einfach die mentalen Ressourcen, die du brauchst, um sie zu leisten.
+
+## Wie deine Task-App kognitive Last erhöht
+
+Die meisten Task-Apps sind für die Erfassung von Aufgaben optimiert, nicht für die Minimierung der mentalen Belastung durch ihre Nutzung. Das Ergebnis ist ein Design, das auf den ersten Blick mächtig wirkt, aber jedes Mal, wenn du es öffnest, erhebliche extrinsische Last erzeugt.
+
+**Eine lange Liste von Aufgaben zu scannen** ist selbst kognitiv anstrengend. Dein Gehirn sieht nicht einfach eine Liste. Es liest jedes Element, bewertet es auf Relevanz und verarbeitet es, bevor es zum nächsten übergeht. Eine Liste von 50 Aufgaben kostet keine Einheit Aufmerksamkeit; sie kostet fünfzig separate Micro-Evaluationen, von denen jede dein begrenzteres Arbeitsgedächtnis belastet.
+
+**Metadaten zu lesen** vervielfacht diese Kosten. Fälligkeitsdaten, Priority-Labels, Projekt-Tags, Unteraufgaben-Indikatoren, Zuordnungen, wiederkehrende Aufgaben-Markierungen. Jedes Metadaten-Element ist ein zusätzlicher Datenpunkt, den dein Gehirn verarbeiten und in sein Modell dessen, was getan werden muss, integrieren muss. Je mehr Metadaten pro Aufgabe, desto höher die extrinsische Last pro Element.
+
+**Prioritätsentscheidungen über viele Elemente zu treffen** ist vielleicht die kostspieligste kognitive Operation, die deine Task-App verlangt. Jedes Mal, wenn du deine Liste öffnest und entscheiden musst, was du nächstes tun sollst, führst du eine komplexe Bewertung über jedes sichtbare Element durch. Bei drei Aufgaben ist das machbar. Bei dreißig investierst du erhebliche kognitive Ressourcen nur, um zu entscheiden, wo du anfangen sollst.
+
+**Kontext zu merken** fügt noch eine weitere Ebene hinzu. Eine Aufgabe, die du vor zwei Wochen hinzugefügt hast: „Nachfolge zum Entwurf des Vorschlags". Erfordert mentale Rekonstruktion: Welcher Vorschlag? Welcher Entwurf? Was war der Status? Was bedeutet „Nachfolge" eigentlich hier? Jede kontextlose Aufgabe ist ein kleines Puzzle, das du lösen musst, bevor du entscheiden kannst, ob du es tun wirst.
+
+## Die kognitive Belastung durch überfällige Aufgaben
+
+Es gibt eine spezifische Art von kognitiver Belastung, die überfällige Aufgaben erzeugen — über die oben beschriebene allgemeine Belastung hinaus. Psychologen nennen es den Zeigarnik-Effekt: Unvollendete Aufgaben erzeugen anhaltende mentale Eindringungen. Dein Gehirn kehrt immer wieder zu unvollendeten Geschäften zurück, auch wenn du nominell etwas völlig anderes tust.
+
+Eine überfällige Aufgabe erscheint nicht nur einmal auf deiner Liste. Sie taucht in deinen Gedanken während Meetings wieder auf, während Gesprächen, in den Momenten, bevor du einschläfst. Jedes Wiederauftauchen ist eine kleine kognitive Gebühr. Eine Unterbrechung von dem, das du eigentlich versuchen wolltest zu denken. Vervielfache das über zehn oder zwanzig überfällige Elemente, und du trägst eine erhebliche Hintergrund-Last mentaler Eindringungen den ganzen Tag über.
+
+Das ist, was Task-Schuld wirklich kostet — nicht nur die Schuldgefühle, die roten Elemente zu sehen, sondern die anhaltende kognitive Belastung ungelöster offener Schleifen. Jede überfällige Aufgabe ist eine Micro-Entscheidung, die dein Gehirn immer wieder öffnet. Habe ich etwas vergessen? Sollte ich mich schlecht fühlen dabei? Muss ich das immer noch tun? Ist es zu spät? Jede dieser Fragen verbraucht mentale Kapazität, die deiner eigentlichen Arbeit zugute kommen könnte.
+
+## Warum einfachere Systeme kognitive Last reduzieren
+
+Das kognitive Last-Argument für einfachere Produktivitätssysteme handelt nicht von Ästhetik oder Minimalismus als Wert. Es geht um die Allokation von mentalen Ressourcen. Jede Einheit kognitiver Kapazität, die du für die Navigation deines Task-Systems aufbringst, ist eine Einheit, die du nicht für die Arbeit selbst ausgibst.
+
+Eine kürzere tägliche Task-Liste reduziert kognitive Last auf konkrete, messbare Weise — weniger sichtbare Elemente bedeuten weniger Evaluationen, weniger Entscheidungen und weniger Arbeitsgedächtnis, das von der Liste selbst verbraucht wird. Wenn deine Tagesansicht fünf statt fünfzig Aufgaben anzeigt, hast du die Scan-Kosten um den Faktor zehn reduziert, noch bevor du andere Änderungen vorgenommen hast.
+
+Die Daily-Focus-Liste funktioniert als das, was Kognitionswissenschaftler einen **kognitiven Container** nennen würden. Eine Grenze, die den Bereich begrenzt, den dein Gehirn aktiv verarbeiten muss. Wenn eine Aufgabe nicht auf deiner heutigen Liste ist, muss dein Gehirn sie sich jetzt nicht ins Arbeitsgedächtnis holen. Sie existiert im Backlog, abrufbar, wenn du sie brauchst, aber außerhalb des aktiven Verarbeitungsbereichs deines aktuellen Tages. Das ist das gleiche Prinzip wie die progressive Offenlegung im Interface-Design — zeige Menschen nur das, das sie gerade brauchen, und lass sie mehr abrufen, wenn sie danach fragen.
+
+Ein gutes tägliches Planungssystem schafft diese Grenze bewusst. Die Entscheidung, was auf die heutige Liste kommt, wird einmal zu Beginn des Tages getroffen. Und dann musst du das vollständige Backlog nicht weiter ständig neu bewerten, während du versuchst zu arbeiten.
+
+## Feature-Komplexität vs. Produktivität
+
+Es gibt ein gut dokumentiertes Paradoxon in Produktivitätssoftware: Die Apps mit den meisten Features sind oft diejenigen, die die wenigste echte Produktivität erzeugen. Das ist nicht, weil Features schlecht sind. Es ist, weil jedes Feature kognitive Belastung für das Werkzeug selbst hinzufügt.
+
+Jede zusätzliche Funktion in einer Task-App erzeugt neue Entscheidungen. Nutze ich Tags oder Projekte dafür? Sollte das eine Unteraufgabe oder eine eigenständige Aufgabe sein? Gehört das in den persönlichen Bereich oder den Arbeitsbereich? Sollte ich eine Prioritätsstufe setzen oder nur ein Fälligkeitsdatum oder beides? Diese Entscheidungen wirken wie kleine Wahlmöglichkeiten, aber sie summieren sich. Die Nutzung des Werkzeugs selbst wird zu einer kognitiven Aufgabe.
+
+Das ist Feature-Creep als Design-Problem. Nicht nur ein Software-Problem. Wenn Tooldesigner Features für Power-User hinzufügen, verschieben sie unwillkürlich die kognitive Belastung auf alle Nutzer, einschließlich derjenigen, die die erweiterten Features nie nutzen werden. Das Ergebnis ist eine App, die mehr von dir verlangt, nur um sie zu bedienen, und dir weniger Kapazität für die Arbeit lässt, die die App unterstützen soll.
+
+Eine Wahl zwischen Features zu treffen, ist selbst eine Entscheidung, und Entscheidungsmüdigkeit ist real. Je mehr kleine Entscheidungen du über dein System triffst, desto weniger Entscheidungskapazität hast du für deine eigentliche Arbeit. Einfachere Tools gewinnen — nicht, weil Einfachheit von Natur aus tugendhaft ist, sondern weil sie die kognitiven Ressourcen sparen, die wirklich zählen.
+
+## Das Designprinzip hinter Apps mit niedriger kognitiver Last
+
+Die Designentscheidungen, die kognitive Last in einer Produktivitäts-App reduzieren, folgen einer gemeinsamen Logik: Minimiere die Entscheidungen, die Nutzer über das System treffen müssen, damit sie sich auf die Arbeit konzentrieren können.
+
+**Progressive Offenlegung** bedeutet, nur das anzuzeigen, das gerade nötig ist, den Rest zugänglich aber nicht sichtbar zu halten. Ein Backlog, das von deiner Tagesansicht getrennt ist, verkörpert dieses Prinzip. Alles ist da, wenn du es brauchst, aber es fordert keine Verarbeitungsleistung, wenn du es nicht brauchst.
+
+**Voreinstellungen, die funktionieren** eliminieren die Notwendigkeit, das System zu konfigurieren, um Wert daraus zu bekommen. Wenn das Standard-Verhalten sinnvoll ist, müssen die meisten Nutzer die Einstellungen nie anfassen. Das bedeutet, dass sie nie kognitive Energie in diese Konfigurationsentscheidungen investieren.
+
+**Automatische Bereinigung** ist vielleicht der mächtigste Reduzierer kognitiver Last. Wenn ein System irrelevante Aufgaben für dich entfernt oder täglich zurückzusetzen, wenn unvollendete Aufgaben in einen neutralen Zustand zurückkehren. Es eliminiert eine ganze Kategorie von Entscheidungen — die laufende Sortierung, was man mit Dingen anfangen soll, die man nicht getan hat. In Dawny kehren unvollendete Daily-Focus-Aufgaben automatisch um 3 Uhr morgens zum Backlog zurück. Es gibt keine Überfällig-Labels. Es gibt keinen roten Zähler. Jeden Morgen beginnt mit einer sauberen Tafel, und das System verwaltet die Bereinigung, damit du das nicht musst.
+
+> „Ich dachte nie, dass der reduzierte Ansatz für mich richtig ist. Aber nach dem ersten Test habe ich Dawny einfach nicht mehr aufgehört zu nutzen." — Dawny-Beta-Tester
+
+Die Make-It-Count-Mechanik geht noch weiter — Aufgaben, die über mehrere Resets hinweg übersprungen werden, werden automatisch archiviert. Dein Gehirn muss nicht weiter evaluieren, ob diese Aufgabe noch wichtig ist. Das System bemerkt das Muster und entfernt es aus der Sicht. Die Einsicht ist, dass eine Aufgabe, die du fünfmal hintereinander umgangen hast, dir bereits gesagt hat, dass sie keine Priorität ist. Das System macht diese Realität nur sichtbar.
+
+## So reduzierst du kognitive Last in deinem aktuellen Setup
+
+Du brauchst keine neue App, um damit zu beginnen, kognitive Last in deinem Workflow zu reduzieren. Diese Schritte funktionieren in jedem System, das du bereits nutzt.
+
+**Archiviere alles, das du zwei Wochen nicht angefasst hast.** Wenn eine Aufgabe zwei Wochen auf deiner Liste ohne Auswahl zur Aktion ist, erzeugt sie kognitiven Overhead ohne Wert zu liefern. Verschiebe es aus deiner aktiven Ansicht. Zu einer Someday-Liste, einem Archiv oder lösche es ganz. Du gibst die Aufgabe nicht auf. Du machst eine ehrliche Bewertung ihrer aktuellen Priorität.
+
+**Reduziere deine sichtbaren täglichen Aufgaben auf 3–5.** Das ist die einzelne höchste Hebel-Veränderung, die die meisten Menschen machen können. Nicht, weil 5 Aufgaben das Maximum sind, das du an einem Tag erreichen kannst, sondern weil eine Begrenzung deiner Tages-Liste eine echte Prioritätsentscheidung zu Beginn erzwingt — und dich dann von ständiger Neu-Priorisierung während des ganzen Tages befreit.
+
+**Entferne Labels und Projekte, die keine Entscheidungen antreiben.** Metadaten sind nur wertvoll, wenn sie tatsächlich verändern, was du tust. Wenn du Tags oder Projekt-Kategorien hast, die existieren, aber nie beeinflussen, welche Aufgabe du nächstes auswählst, erzeugen sie kognitive Last ohne Nutzen. Überprüfe deine Labels gnadenlos — wenn du nicht beschreiben kannst, wie ein bestimmtes Tag deine Priorisierung beeinflusst, lösche es.
+
+**Erstelle eine „Someday"-Liste, die vollständig von deiner Tagesansicht getrennt ist.** Das Ziel ist eine harte kognitive Grenze zwischen „was ich für heute in Betracht ziehe" und „alles andere". Diese Trennung bedeutet, dass dein Gehirn die „alles andere"-Liste während der Arbeitszeit wirklich nicht mehr verarbeiten kann, weil es keine visuellen Erinnerung daran gibt, die um Aufmerksamkeit konkurriert.
+
+**Treffe eine Prioritätsentscheidung pro Tag, nicht eine pro Aufgabe.** Anstatt jede Aufgabe jedes Mal zu bewerten, wenn du deine Liste anschaust, verbringe fünf Minuten jeden Morgen damit zu entscheiden, was auf die heutige Liste kommt. Und höre dann auf zu evaluieren. Die Liste ist gesetzt. Arbeite danach. Das verschiebt die kognitive Last zu einem einzelnen, dedizierten Moment, anstatt sie über den ganzen Tag zu verteilen.
+
+## Häufig gestellte Fragen
+
+### Was ist kognitive Last in der Produktivität?
+
+Kognitive Last in der Produktivität bezieht sich auf die mentale Anstrengung, die erforderlich ist, um dein Task-System zu verwalten und zu navigieren — unterscheidbar von der mentalen Anstrengung, die echte Arbeit zu leisten. Hohe kognitive Last durch deine Task-App bedeutet weniger mentale Kapazität für die Arbeit, die zählt. Systeme mit niedriger kognitiver Last sind so gestaltet, dass sie den Overhead der Systemoperation minimieren, damit mehr mentale Ressourcen zum eigentlichen Output fließen.
+
+### Wie beeinflusst kognitive Last die Arbeitsleistung?
+
+Kognitive Last reduziert die Arbeitsgedächtnis-Kapazität direkt, was wiederum Entscheidungsfindung, Aufmerksamkeit und kreatives Problem-Lösen beeinträchtigt. Wenn dein Task-System hohe extrinsische kognitive Last erzeugt — durch komplexe Interfaces, große sichtbare Task-Listen oder laufende Prioritätsentscheidungen — startest du die echte Arbeit mit einem erschöpften kognitiven Budget. Forschung über Arbeitsgedächtnis zeigt durchgehend, dass überladene Systeme Output von niedrigerer Qualität und mehr Fehler produzieren.
+
+### Wie reduziere ich mentalen Overhead in meinem Workflow?
+
+Die effektivsten Schritte sind: Begrenze deine sichtbaren täglichen Aufgaben auf 3–5, verschiebe alles andere aus deiner Tagesansicht, eliminiere Metadaten, die keine echten Entscheidungen antreiben, und übernehme einen einzelnen täglichen Priorisierungs-Moment statt kontinuierlicher Neu-Evaluation. Automatische Bereinigungs-Systeme — Apps oder Gewohnheiten, die die Sortierung ungetaner Aufgaben handhaben — entfernen eine ganze Kategorie laufender Entscheidungen, die sonst als kognitiver Overhead akkumulieren.
+
+### Warum funktionieren einfachere To-do-Listen besser?
+
+Einfachere To-do-Listen funktionieren besser, weil sie die Anzahl der kognitiven Operationen, die erforderlich sind, um sie zu nutzen, reduzieren. Weniger sichtbare Elemente bedeuten weniger Scanning, weniger Prioritätsentscheidungen und weniger Arbeitsgedächtnis, das von der Liste selbst verbraucht wird. Das Ziel einer Task-Liste ist, deine Arbeit zu unterstützen, nicht selbst zu einer kognitiven Aufgabe zu werden. Wenn die Liste kurz genug ist, um sie in deinem Kopf zu halten, kannst du dich auf die Aufgaben konzentrieren, anstatt das System zu verwalten.
+
+### Welche Beziehung besteht zwischen kognitiver Last und Entscheidungsmüdigkeit?
+
+Kognitive Last und Entscheidungsmüdigkeit sind eng verwandt, aber unterschiedliche Konzepte. Kognitive Last beschreibt die mentale Anstrengung, die erforderlich ist, um Informationen in jedem Moment zu verarbeiten. Entscheidungsmüdigkeit beschreibt die Verschlechterung der Entscheidungsqualität, die nach vielen hintereinander getroffenen Entscheidungen auftritt. Ein hochbelastetes Task-System trägt zu Entscheidungsmüdigkeit bei, weil es viele kleine Entscheidungen erzwingt — über Priorisierung, Metadaten und Task-Relevanz — die die gleichen mentalen Ressourcen verbrauchen wie echte Arbeit. Kognitive Last in deinem System zu reduzieren ist einer der effektivsten Wege, um Entscheidungsqualität während des ganzen Tages zu bewahren.
+
+## Fazit
+
+Die Produktivitäts-Tools, die sich am mächtigsten anfühlen — diejenigen mit den meisten Features, der größten Kustomisierbarkeit, den meisten sichtbaren Informationen — machen dich oft weniger, nicht produktiver. Das ist kein Paradoxon, wenn du kognitive Lasttheorie verstehst. Komplexe Systeme fordern kognitive Ressourcen nur auf, um zu funktionieren. Jede Einheit Aufmerksamkeit, die für das Scannen einer langen Task-Liste, die Interpretation von Metadaten oder die Entscheidung, was priorisiert werden soll, aufgewendet wird, ist eine Einheit, die nicht für echte Arbeit aufgewendet wird.
+
+Die Alternative ist nicht, aus ästhetischen Gründen minimalistisch zu sein. Es geht darum, dein System so zu gestalten, dass es so wenig wie möglich von dir verlangt und dir die mentale Bandbreite zurückgibt, um deine beste Arbeit zu leisten. Das bedeutet kürzere Tages-Listen, automatische Bereinigung ungetaner Aufgaben und eine saubere Trennung zwischen deinem Daily Focus und allem anderen, das in den Flügeln wartet. Einfachere Systeme gewinnen nicht, weil sie einfacher sind, sondern weil sie die Grenzen menschlicher Aufmerksamkeit respektieren.
+
+Wenn du eine Task-App testen möchtest, die auf dieser Philosophie aufgebaut ist, kannst du Dawny kostenlos auf TestFlight ausprobieren.
+
+Der Entwickler hinter Dawny hat ADHD und hat die App nach Jahren des Versuchens — und Aufgebens — jeder Produktivitäts-App auf dem Markt gebaut.
+
+Möchtest du eine Task-App testen, die auf dieser Philosophie aufgebaut ist?
+
+Dawny ist kostenlos auf TestFlight zum Testen — keine Verpflichtung erforderlich.
+
+Probiere Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/daily-planning-system.md
+++ b/website/src/content/blog/de/daily-planning-system.md
@@ -1,0 +1,169 @@
+---
+title: "Wie du ein tägliches Planungssystem aufbaust, das du tatsächlich nutzt"
+description: "Lerne, wie du ein tägliches Planungssystem aufbaust, das funktioniert, indem du Aufgaben erfasst, eine tägliche Fokus-Liste führst, tägliche Resets nutzt und verstehst, warum Einfachheit Komplexität schlägt."
+pubDate: 2026-05-10
+---
+
+# Wie du ein tägliches Planungssystem aufbaust, das du tatsächlich nutzt
+
+> **Kurz gesagt:** Ein tägliches Planungssystem ist eine konsistente Methode, um morgens zu entscheiden, auf welche Aufgaben du dich heute konzentrieren wirst. Die effektivsten Systeme haben drei Eigenschaften: Sie sind einfach genug, um täglich gepflegt zu werden; Sie trennen deinen Backlog von deiner aktiven Fokus-Liste; und Sie bestrafen dich nicht, wenn ein Tag schiefgeht. Das beste System ist das, das du tatsächlich nutzt, nicht das sophistizierteste.
+
+Du hast wahrscheinlich schon versucht, Zeit in Blöcke einzuteilen. Vielleicht hast du sonntags ein aufwändiges Bullet-Journal-Layout gestaltet, farbcodiert und schön, und es dann bis Mittwoch aufgegeben. Vielleicht hast du von GTD gelesen, eine ganze Projekthierarchie aufgebaut und dem System nie so sehr vertraut, dass du aufgehört hast, dir Sorgen zu machen. Das Problem liegt nicht in den Methoden, sondern in der Reibung. Eine tägliche Planungsroutine funktioniert nur, wenn die Aufrechterhaltung fast nichts kostet. In dem Moment, in dem sie zur Pflicht wird, wird sie optional. Und optionale Gewohnheiten überstehen keinen schwierigen Alltag.
+
+Dieser Leitfaden deckt alles ab, was du brauchst, um ein tägliches Planungssystem aufzubauen, das du tatsächlich beibehältst. Er beginnt mit den Grundlagen dessen, was Planung funktionieren lässt, führt durch die fünf konkreten Schritte einer effektiven täglichen Routine und behandelt die häufigen Fehler, die even gute Systeme zum Scheitern bringen. Das ist das Gesamtbild, nicht die Abkürzung.
+
+## Was ist ein tägliches Planungssystem?
+
+Ein tägliches Planungssystem ist jede konsistente Methode, um täglich zu entscheiden, welche Aufgaben deine Aufmerksamkeit verdienen und welche warten können. Es erfüllt zwei Funktionen: **Erfassung** (Aufgaben aus deinem Kopf in einen vertrauenswürdigen Ort bringen) und **Commitment** (die kleine Anzahl von Aufgaben auswählen, auf die du dich heute konzentrierst). Jedes effektive Planungssystem erfüllt beide Funktionen. Die Fehlerfälle gehen meist darauf zurück, dass einer dieser Punkte kaputt oder fehlend ist.
+
+Ein System ohne gute Erfassung bedeutet, dass du ständig versuchen musst, dich daran zu erinnern, was es gibt. Ein System ohne echten Commitment-Schritt bedeutet, dass deine tägliche Liste nur dein komplettes Backlog ist – eine undifferenzierte Ansammlung ohne Hinweis darauf, was heute wirklich zählt.
+
+## Das Kernprinzip: Trenne deinen Backlog von deiner täglichen Liste
+
+Die Veränderung mit dem höchsten Hebel in deiner täglichen Planung ist, aufzuhören, eine einheitliche Liste für alles zu verwenden. Die meisten Menschen beginnen mit einer einzelnen To-do-Liste. Aufgaben kommen rein, Aufgaben (manchmal) gehen raus, und mit der Zeit wächst die Liste in etwas, das sich eher wie ein Schuldregister anfühlt als wie ein nützliches Planungstool.
+
+Das Problem mit einer einheitlichen Liste ist, dass sie zwei völlig unterschiedliche Arten von Elementen vermischt: Dinge, die du irgendwann tun möchtest, und Dinge, zu denen du dich heute wirklich verpflichtest. Diese erfordern unterschiedliche mentale Einstellungen. Wenn sie am selben Ort leben, kannst du sie auf den ersten Blick nicht auseinanderhalten, und am Ende wertest du jedes Mal die ganze Liste neu aus, wenn du versuchen möchtest, deinen Tag zu planen.
+
+Die Lösung ist ein Zwei-Listen-System mit einem echten Backlog. Dein Backlog enthält alles, das wichtig sein könnte – Ideen, zukünftige Aufgaben, niedrigpriorige Elemente, Vielleicht-später-Projekte. Deine Daily-Focus-Liste enthält nur, worauf du dich heute wirklich verpflichtest. Nichts wandert automatisch vom Backlog in deine Daily-Focus-Liste. Du wählst es absichtlich jeden Morgen. Dieser Auswahlakt selbst ist Planung.
+
+Diese Trennung bewirkt psychologisch etwas Wichtiges – sie macht deine tägliche Liste per Definition verwaltbar. Du versuchst nicht jedes Mal, wenn du einen Blick auf deine Aufgaben wirfst, Signal aus Rauschen zu extrahieren. Das Rauschen lebt im Backlog. Deine tägliche Ansicht zeigt nur, was du entschieden hast, dass heute wichtig ist.
+
+## Schritt 1: Erfasse alles (ohne Commitment)
+
+Der erste Schritt in jedem effektiven täglichen Planungssystem ist der Aufbau einer zuverlässigen Erfassungsgewohnheit. Wenn eine Aufgabe, Idee oder Verpflichtung dir in den Sinn kommt, schreib sie sofort auf. Bewerte sie nicht, priorisiere sie nicht, frag dich nicht, ob sie es wert ist getan zu werden. Erfasse sie einfach.
+
+Der Zweck dieses Schritts ist es, Dinge aus deinem Kopf und in ein vertrauenswürdiges externes System zu bekommen. Dein Gehirn ist großartig beim Erzeugen von Ideen und furchtbar beim zuverlässigen Speichern von ihnen. Jede Aufgabe, die du im Arbeitsspeicher halten versuchst, verbraucht kognitive Ressourcen, die nützliche Arbeit leisten könnten. Der Akt, etwas aufzuschreiben (in einem Backlog, einer Notiz-App oder einem physischen Notizbuch), vervollständigt eine mentale Übergabe. Du hörst auf, es zu verfolgen. Das System verfolgt es für dich.
+
+Die Regel für die Erfassung ist **Erfassen ohne Filterung**. Wenn du anfängst, Aufgaben während der Erfassung zu bewerten, wirst du entweder so langsam, dass du aufhörst zu erfassen, oder du fängst an, Commitment-Entscheidungen zu treffen, bevor du das vollständige Bild deines Tages hast. Erfasse zuerst. Filtere später. Der Backlog ist keine Verpflichtung; er ist ein Posteingang.
+
+In der Praxis bedeutet das, alles zu erfassen – vage Ideen, Aufgaben ohne Frist, Aufgaben, die wahrscheinlich nicht passieren, Aufgaben, die vielleicht jemand anderes Problem sind. Du kannst all das während deiner täglichen Planungssitzung sortieren. Was du nicht tun kannst, ist eine Aufgabe wiederherstellen, die du nicht erfasst hast, weil du vor Ort entschieden hast, dass sie es nicht wert ist aufzuschreiben.
+
+## Schritt 2 – Wähle deine Fokus-Aufgaben für heute
+
+Der Commitment-Schritt ist wo die meisten täglichen Planungssysteme erfolgreich sind oder scheitern. Erfassung ist einfach (fast jeder kann eine Erfassungsgewohnheit aufbauen), aber Auswahl ist schwieriger, weil es bedeutet zu entscheiden, was du nicht tun wirst.
+
+Öffne jeden Morgen dein Backlog und wähle die Aufgaben, auf die du dich heute verpflichtest. Nicht die Aufgaben, die du gerne tun möchtest, oder die Aufgaben, die sich vaguirgendwie wichtig anfühlen, oder die Aufgaben, die du so lange aufgeschoben hast, dass du dich verpflichtet fühlst sie einzubeziehen. Die Aufgaben, auf die du dich heute wirklich verpflichtest, gegeben deines tatsächlichen Energieniveaus und der realistischen Anzahl von verfügbaren Stunden.
+
+**Wie viele Aufgaben?** Die Forschung zu Entscheidungsfindung und kognitiver Belastung zeigt konsistent, dass Menschen schlecht abschätzen können, wie lange Aufgaben dauern und wie viele sie an einem Tag schaffen. Eine Studie über die Planning-Fallacy-Vorstellung fand heraus, dass Menschen die Abschlusszeiten systematisch unterschätzen. Die praktische Implikation ist, dass du für weniger Aufgaben plant, als du bewältigen kannst, nicht für mehr. Zusätzliche Ressourcen umfassen einen neutralen Überblick über Planning-Bias und einen produktivitätsfokussierten Artikel.
+
+Die meisten Produktivitätspraktiker, die seit Jahren mit Aufgabenplanung arbeiten, empfehlen irgendwo zwischen drei und fünf Aufgaben als deine tägliche Fokus-Liste. Drei reicht oft aus. Fünf ist normalerweise zu viel. Der Punkt ist, die Liste klein genug zu machen, dass alles abzuschließen ein realistisches Ergebnis ist, kein aspiratives. Eine Liste, die du abschließt, fühlt sich grundlegend anders an als eine Liste, bei der du zu kurz kommst, und dieses Gefühl bestimmt, ob du morgen zum System zurückkommst. Zusätzliche Ressourcen zur Drei-Aufgaben-Methode umfassen diesen Leitfaden zur Produktivitätsregel der drei Aufgaben und diesen praktischen Überblick für Selbstständige.
+
+Wenn du deine Fokus-Aufgaben auswählst, schreib sie auf eine separate Liste (physisch oder digital getrennt von deinem Backlog). Der Backlog bleibt intakt. Deine Daily-Focus-Liste ist das, womit du heute arbeitest. Am Ende des Tages wirst du zu dieser Unterscheidung zurückkehren.
+
+## Schritt 3 – Schütze deine Fokus-Zeit
+
+Deine Aufgaben auszuwählen ist nur die halbe Verpflichtung. Die andere Hälfte ist es, die Bedingungen zu schaffen, unter denen du sie tatsächlich tun kannst.
+
+Der effektivste Weg dazu ist, Zeit in deinem Kalender für deine wichtigste Aufgabe des Tages zu blockieren. Anstelle von „Ich kümmere mich darum, wenn ich einen Moment Zeit habe", erstelle einen tatsächlichen Kalender-Eintrag mit Startzeit und Dauer. Das schützt diese Zeit vor Meeting-Anfragen, Unterbrechungen und dem umgebenden Zug von weniger kritischen Aufgaben, die im Moment einfacher wirken.
+
+Du brauchst keinen vollständig zeitlich strukturierten Plan, um von diesem Vorteil zu profitieren. Ein einzelner geschützter Block (sagen wir, 9 bis 11 Uhr, reserviert für deine Top-Aufgabe) reicht aus, um deinen Tag zu verankern. Alles andere kann flexibel sein. Das Eine, das nicht flexibel ist, ist die Zeit, auf die du dich für deine tatsächliche Priorität verpflichtet hast.
+
+Wenn du deine kognitiven Spitzenzeiten identifizieren kannst (die Tageszeit, in der dein Fokus und deine Entscheidungsfindung am schärfsten sind), plane deine wichtigste Aufgabe dann ein. Für die meisten Menschen ist dies am Morgen, bevor der Tag's Context-Switching die exekutive Funktion erschöpft hat. Reserviere dieses Zeitfenster und behandle es als eine Verpflichtung dir selbst gegenüber, nicht als Vorschlag.
+
+## Schritt 4: Handhabe das Tagesende (Der Reset-Moment)
+
+Das ist der Schritt, den die meisten Tages-Planungsleitfäden überspringen oder als Nachgedanken behandeln. Es ist tatsächlich der Schritt, der bestimmt, ob dein System über die Zeit gesund bleibt.
+
+Am Ende jedes Tages (oder während einer kurzen Planungssitzung am nächsten Morgen) stellst du dir eine einfache Frage: Was machst du mit den Aufgaben auf deiner Daily-Focus-Liste, die du nicht beendet hast?
+
+Die meisten Task-Apps beantworten diese Frage automatisch – sie färben die Aufgabe rot und kennzeichnen sie als überfällig. Das ist psychologisch verheerend. Das Überfällig-Label unterscheidet nicht zwischen einer Aufgabe, die du absichtlich deprioritiert hast, weil etwas Wichtigeres kam, und einer Aufgabe, die du zu tun vergessen hast. Beide bekommen das gleiche rote Abzeichen. Beide fühlen sich wie Versäumnisse an. Mit der Zeit macht eine wachsende Ansammlung von roten, überfälligen Elementen, deine Task-App zu öffnen, wie ein Betreten eines Zimmers voller Anklagen. Menschen tun das freiwillig nicht lange. Das ist ein Hauptgrund, warum To-do-Listen scheitern – nicht weil die Aufgaben nicht echt sind, sondern weil die Rückmeldungsschleife des Systems Vermeidung statt Aktion erzeugt.
+
+Die Alternative ist ein Reset. Anstatt unvollständige Aufgaben als überfällig zu kennzeichnen, kehrst du sie in den Backlog zurück. Sie bleiben neutral und unbelastet, verfügbar um erneut gewählt zu werden, wenn sie noch wert sind gewählt zu werden. Der Tag endet sauber. Morgen startet sauber. Du hast nicht versagt; du hast Entscheidungen getroffen, und die Aufgaben, die du nicht gewählt hast, warten auf einen anderen Tag.
+
+Das ist die Kernmechanik in Dawny – unvollständige Daily-Focus-Aufgaben kehren am Ende jedes Tages automatisch in den Backlog zurück. Es gibt keinen Überfällig-Stapel. Es gibt keine wachsende Mauer aus Schuldgefühlen. Aufgaben, die immer wieder in den Backlog zurückkehren (die es nie auf die Daily-Focus-Liste schaffen), werden schließlich automatisch durch eine Mechanik namens „Make It Count" archiviert. Du musst dich nicht zwingen, eine manuelle Bereinigung durchzuführen. Das System bemerkt Muster und zeigt sie dir.
+
+> „Ich nutze Dawny tatsächlich jeden Morgen. Der tägliche Reset gibt mir den Spielraum, den ich brauche." – Dawny Beta-Tester
+
+> „Fast alle Aufgaben, die automatisch archiviert wurden, waren einfach nicht wichtig genug. Ich habe keine einzige zurückgebracht." – Dawny Beta-Tester
+
+Die Psychologie dahinter ist unkompliziert: Wenn eine Aufgabe immer wieder übersprungen wird, ist das Information. Es bedeutet, dass die Aufgabe entweder keine echte Priorität ist, zu einer zukünftigen Version deines Lebens gehört, die noch nicht angekommen ist, oder nicht wirklich deine Aufgabe zum Tun ist. Ein täglicher Reset lässt dich natürlich auf diese Information reagieren, ohne eine erzwungene Entscheidung. Du löschst die Aufgabe nicht. Du wählst sie einfach nicht wieder. Das System erkennt das Muster schließlich an.
+
+Der tägliche Reset und die Morgenroutine sind wert, als Ritual statt als administrative Pflicht behandelt zu werden. Selbst zwei Minuten (Überprüfen, was du beendet hast, unvollständige Aufgaben in den Backlog zurückbringen, morgens Fokus auswählen) erzeugen eine saubere psychologische Grenze zwischen heute und morgen.
+
+## Schritt 5: Wöchentliche Überprüfung (Fünf Minuten)
+
+Selbst mit einem täglichen Reset wird dein Backlog im Laufe der Zeit wachsen. Die Erfassung läuft kontinuierlich. Neue Elemente kommen ständig an. Ohne periodisches Beschneiden, wirst du schließlich deine täglichen Aufgaben aus einem Backlog von 200 Elementen auswählen, was den Sinn eines Backlogs negiert.
+
+Verbring einmal pro Woche (Freitag Nachmittag oder Sonntag Abend funktionieren beide gut) fünf Minuten damit, deinen Backlog zu überprüfen. Nicht um die Aufgaben zu tun, sondern nur um sie anzusehen. Stelle dir drei Fragen: Ist das noch relevant? Ist das etwas, das ich realistisch jemals tun werde? Ist das wirklich meine Verantwortung?
+
+Alles, das diese Fragen nicht erfüllt, sollte gelöscht oder archiviert werden. Du gibst diese Aufgaben nicht auf. Du machst eine ehrliche Einschätzung, dass sie nicht passieren werden, und räumst den Weg für die Aufgaben frei, die es werden. So verhinderst du, dass sich Aufgabenschulden ansammeln. Nicht durch eine heroische jährliche Säuberung, sondern durch fünf Minuten ehrliches Beschneiden jede Woche.
+
+Die wöchentliche Überprüfung gibt dir auch die Chance, Muster zu bemerken. Wenn die gleiche Aufgabe drei Wochen lang in deinem Backlog sitzt, ohne jemals auf deine Daily-Focus-Liste zu kommen, sagt dir diese Aufgabe etwas. Entweder ist sie nicht wirklich eine Priorität, oder es gibt ein Hindernis, das du nicht adressiert hast. In beiden Fällen musst du eine Entscheidung über sie treffen, statt sie weiter sitzen zu lassen und Platz einzunehmen.
+
+## Häufige Fehler bei der täglichen Planung
+
+Selbst mit einem guten System untergraben ein paar wiederkehrende Fehler tägliche Planungsroutinen. Hier ist worauf du achten solltest.
+
+**Zu viele Aufgaben auf der täglichen Liste.** Das ist der häufigste Fehler und der schädlichste. Wenn deine tägliche Liste zwölf Elemente hat und du fünf abschließt, beendest du den Tag in einem Gefühl, hinterherzuhinken, obwohl du fünf Dinge getan hast. Eine kürzere Liste, die du abschließt, ist motivational deutlich besser als eine längere Liste, bei der du unvollständig beendest. Beginne mit drei Aufgaben. Füge mehr hinzu, nur wenn du zuverlässig drei abgeschlossen hast.
+
+**Vermischung von Erfassung mit Commitment.** Wenn du Aufgaben bewertest, während du sie erfasst, wirst du entweder Erfassung zu einem Stopp verlangsamen oder premature Commitment-Entscheidungen treffen, ohne das vollständige Bild zu sehen. Halte die beiden Schritte getrennt. Erfasse zuerst, unterschiedslos. Wähle später aus dem erfassten Pool während eines dedizierten Planungsmomentes.
+
+**Den Backlog niemals überprüfen oder beschneiden.** Ein Backlog, das nur wächst, wird zu einer weiteren Quelle von Überwältigung – eine andere Art von Aufgabenschuld. Die wöchentliche Fünf-Minuten-Überprüfung ist das, was den Backlog funktional hält, statt nur eine längere Version des Problems, das du lösen wolltest.
+
+**Überfällig-Labels zu Schuldgefühl-Triggern werden lassen.** Wenn dein aktuelles System Überfällig-Indikatoren verwendet und du dich jedes Mal schlecht fühlst, wenn du deine Task-App öffnest, das ist kein Disziplin-Problem. Das ist ein Design-Problem. Das System erzeugt eine Rückmeldungsschleife, die Vermeidung antreibt. Die Lösung ist entweder Fälligkeitsdaten für Aufgaben ohne echte Fristen auszuschalten oder zu einem System zu wechseln, das ein Reset-Modell anstelle eines Überfällig-Modells nutzt.
+
+**Ein System aufbauen, das zu komplex ist um täglich gepflegt zu werden.** Komplexität ist der stille Killer von Planungsgewohnheiten. Ein System, das 30 Minuten Instandhaltung erfordert, wird an den Tagen übersprungen, an denen du es am meisten brauchst (die sind immer die geschäftigen, schwierigen Tage). Das System, das Kontakt mit deinen härtesten Wochen überlebt, ist fast immer das einfachste.
+
+## Einfache vs. aufwändige Systeme: Was die Forschung sagt
+
+Es gibt eine beständige Idee in der Produktivitätskultur, dass ein aufwändigeres System bessere Ergebnisse erzeugt. Mehr Features, mehr Kategorien, mehr Ansichten, mehr Integrationen und mehr Kontrolle. Die Forschung zu kognitiver Belastung deutet darauf hin, dass das genau umgekehrt ist.
+
+Roy Baumeisters Grundlagenwerk zum Entscheidungs-Stress zeigt, dass Entscheidungsfindung eine begrenzte kognitive Ressource ist. Je mehr Entscheidungen du triffst, desto schlechter werden nachfolgende Entscheidungen. Ein komplexes Planungssystem, das viele Micro-Entscheidungen erfordert, um einfach gepflegt zu werden (In welche Kategorie geht das? Welches Projekt? Welche Prioritätsstufe?), erschöpft genau die Ressource, die du für tatsächliche Arbeit brauchst.
+
+Die praktische Implikation für kognitive Belastung in Produktivität ist deutlich. Ein einfaches System, das du mühelos pflegst, ist fast immer effektiver als ein anspruchsvolles System, das du widerwillig pflegst. Die Frage, die man über jedes neue Planungs-Feature oder jeden Workflow stellen sollte, ist nicht „Würde das nützlich sein?" sondern „Würde ich das in drei Monaten noch tun?" Die meisten aufwändigen Systeme überstehen drei Monate echtes Leben nicht. Einfache Systeme tun es.
+
+Deshalb tendiert das Zwei-Listen-Modell (Backlog plus Daily Focus mit täglichem Reset) dazu, ausgefeiltere Alternativen in der Praxis zu übertreffen. Nicht weil es theoretisch optimal ist, sondern weil es einfach genug ist, um es jeden Tag zu tun, inklusive der Tage, an denen alles schiefgeht.
+
+## Welche Tages-Planungsmethode ist richtig für dich?
+
+Es gibt keine einzige Antwort. Unterschiedliche Systeme funktionieren für unterschiedliche Menschen, und die ehrliche Antwort ist, dass du wahrscheinlich experimentieren musst, bevor du den Ansatz findest, der zu deinem Hirn passt. Hier ist ein Framework zum Eingrenzen.
+
+**Wenn du mit Struktur florierst und vorhersehbare Zeitblöcke hast,** könnte Time Blocking gut für dich funktionieren. Weise spezifische Aufgaben spezifischen Zeitfenstern in deinem Kalender zu, behandle diese Blöcke als Termine und überprüfe und neuaufbaue deinen Plan jeden Morgen. Der Vorteil ist Klarheit und Commitment. Der Nachteil ist Zerbrechlichkeit, da ein ungeplantes Meeting in deinen ganzen Tag kaskadieren kann.
+
+**Wenn du minimale Reibung und ein verzeihendes System willst,** ist das Zwei-Listen-Modell mit täglichem Reset wahrscheinlich deine beste Wahl. Erfasse im Backlog, wähle jeden Morgen drei bis fünf Aufgaben, reset am Ende des Tages. Der gesamte Instandhaltungsaufwand beträgt etwa zehn Minuten täglich und fünf Minuten wöchentlich. Es erfordert keinen perfekten Tag um zu funktionieren.
+
+**Wenn du ADHD verwaltest oder Unterschiede bei der exekutiven Funktion hast,** fallen Standard-Planungsratschläge oft fehl, weil sie konsistentes Arbeitsgedächtnis, einfache Task-Initiierung und zuverlässige Zeitschätzung voraussetzen (keines davon kommt mit ADHD einfach). Die effektivsten Systeme für ADHD sind tendenziell solche mit sehr geringen Initiierungskosten, automatischen Resets, die die Schleife der Schande entfernen, und kurzen täglichen Listen, die keine ausgedehnte Selbstregulierung zum Navigieren erfordern. Es gibt einen dedizierten Leitfaden zu Produktivitäts-Apps und Systemen für ADHD, wenn das auf dich zutrifft.
+
+**Wenn du ein Team-Lead oder Knowledge Worker mit komplexen Projekten bist,** brauchst du möglicherweise eine Hybrid-Lösung. Ein persönliches tägliches Planungssystem für deine eigenen Aufgaben, kombiniert mit einem Projektmanagement-Tool zum Verfolgen von Team-Arbeit. Der Schlüssel ist, diese getrennt zu halten, anstatt beide in einem System zu verwalten.
+
+Der Gründer von Dawny baute sein eigenes System (und schließlich seine eigene App), weil er ADHD hat und nichts auf dem Markt matched wie sein Gehirn tatsächlich funktioniert. Nicht um in der Abstraktion produktiver zu sein, sondern um aufzuhören, sich vor seiner eigenen Task-Liste zu fürchten. Die Philosophie hinter Dawny ist, dass das richtige System nicht unbedingt das mächtigste ist. Es ist das, das Schande völlig aus der Gleichung entfernt.
+
+## Häufig gestellte Fragen
+
+### Was ist die beste Tages-Planungsmethode?
+
+Die beste Tages-Planungsmethode ist die, die du konsistent tatsächlich nutzen wirst, was bedeutet, die einfachste, die deine Kernbedürfnisse erfüllt. Für die meisten Menschen deckt ein Zwei-Listen-System (Backlog plus eine kleine Daily-Focus-Liste) mit täglichem Reset alles Notwendige ab, ohne genug Reibung hinzuzufügen um Aufgabe zu verursachen. Aufwändige Methoden wie volles GTD oder starre Time Blocking funktionieren gut für Menschen, die sie pflegen, aber die meisten Menschen pflegen sie nicht durch schwierige Phasen.
+
+### Wie viele Aufgaben sollte ich pro Tag planen?
+
+Die Forschung zu kognitiver Belastung und Task-Schätzung unterstützt konsistent, für weniger Aufgaben zu planen als du zu bewältigen denkst. Drei Aufgaben sind ein angemessener Ausgangspunkt. Die meisten Menschen finden, dass drei gut gewählte Aufgaben, vollständig abgeschlossen, einen produktiven und befriedigenden Tag darstellen. Fünf ist normalerweise die praktische Obergrenze bevor Abschluss unwahrscheinlich wird. Das Ziel ist, eine tägliche Liste zu setzen, die du realistisch beenden kannst, nicht eine, die alles erfasst, das du tun könntest.
+
+### Zu welcher Tageszeit sollte ich meine Aufgaben planen?
+
+Früher Morgen (bevor die Unterbrechungen des Tages beginnen) oder am Vorabend funktionieren beide gut. Morgen-Planung hat den Vorteil, dein Energieniveau zu kennen und neue Inputs vom Vorabend. Abend-Planung hat den Vorteil, den Tag mit einem klaren Gefühl für das Kommende abschließen zu können. Konsistenz zählt mehr als Timing. Wähle einen Moment, der in deinen Plan passt und schütze ihn.
+
+### Wie halte ich eine tägliche Planungsroutine bei?
+
+Reduziere Reibung zu dem Punkt, an dem die Routine sich fast automatisch anfühlt. Halte dein Planungs-Tool offen und sichtbar. Mache die tägliche Sitzung kurz genug (zehn Minuten oder weniger), dass sie sich nicht wie eine Investition anfühlt. Befestige sie an eine bestehende Gewohnheit (Kaffee, Pendelstrecke, Morgen-Spaziergang). Und kritisch: Evaluiere nicht, ob die Routine „funktioniert", bis du sie konsistent für mindestens drei Wochen getan hast. Ein übersprungener Tag ist kein Fehler. Es ist ein Datenpunkt. Die Routine überlebt übersprungene Tage.
+
+### Was sollte ich mit Aufgaben tun, die ich heute nicht beendet habe?
+
+Bring sie in deinen Backlog zurück, nicht in eine Überfällig-Liste. Die Unterscheidung zählt psychologisch. Eine Überfällig-Liste sagt dir, dass du versagt hast. Ein Backlog sagt, dass die Aufgabe wartet, dass du sie wieder wählst. Wenn du die Aufgabe morgen mit frischen Augen ansiehst, kannst du eine frische Entscheidung treffen: Ist das noch wert getan zu werden? Wenn die gleiche Aufgabe mehrmals in deinen Backlog zurückkehrt, ohne jemals auf deine tägliche Liste zu kommen, behandle das als Signal. Die Aufgabe könnte keine echte Priorität sein, und ein gutes System wird dir das schließlich klar zeigen.
+
+## Fazit
+
+Das effektivste tägliche Planungssystem ist nicht das sophistizierteste. Es ist das mit genug niedriger Reibung, dass du es jeden Tag pflegst, inklusive der schwierigen Tage. Es trennt deinen Backlog von deiner Daily-Focus-Liste. Lässt dich dich auf eine kleine Anzahl von Aufgaben statt auf einen aspirativen Stapel verpflichten. Und handhabe die unvermeidlichen Unvollständigkeiten ohne Strafe, weil Strafe Vermeidung züchtet und Vermeidung ist wo alle Planungssysteme sterben.
+
+Das Fünf-Schritte-Framework in diesem Leitfaden (Erfassung, Auswahl, Schutz, Reset, Überprüfung) gibt dir diese Grundlage. Du musst nicht alle fünf vom ersten Tag an perfekt implementieren. Beginne mit Erfassung und der Daily-Focus-Liste. Füge das Reset-Ritual nach einer Woche hinzu. Baue die wöchentliche Überprüfung ein, sobald sie sich natürlich anfühlt. Einfach schlägt aufwändig auf jeder Stufe.
+
+Die Beziehung zwischen dir und deiner Task-Liste sollte sich nicht wie ein Gegensatz anfühlen. Sie sollte sich wie ein Tool anfühlen, das dir hilft, gute Entscheidungen zu treffen – eines das sauber reset wenn der Tag vorbei ist und frisch startet wenn der nächste beginnt.
+
+Wenn du eine Task-App testen möchtest, die auf dieser Philosophie gebaut ist, ist Dawny kostenlos auf TestFlight verfügbar.
+    
+Der Entwickler hinter Dawny hat ADHD und baute die App nach Jahren des Versuchens – und Aufgebens – jeder Produktivitäts-App auf dem Markt.
+  
+Möchtest du eine Task-App testen, die auf dieser Philosophie gebaut ist?
+ 
+Dawny ist kostenlos auf TestFlight verfügbar – keine Verpflichtung notwendig.
+ 
+Testen Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/dawny-vs-todoist.md
+++ b/website/src/content/blog/de/dawny-vs-todoist.md
@@ -1,0 +1,137 @@
+---
+title: "Dawny vs. Todoist: Zwei unterschiedliche Philosophien zum Erledigen von Aufgaben"
+description: "Todoist vs Dawny: Ein ehrlicher Vergleich eines leistungsstarken Aufgabenmanagers und einer minimalistischen iOS-App, die auf tägliche Zurückstellungen aufgebaut ist."
+pubDate: 2026-05-10
+---
+
+> **Kurze Antwort:** Dawny vs Todoist kommt auf die Philosophie an. Todoist ist ein leistungsstarker Aufgabenmanager für Power User, die volle Kontrolle wollen — Projekte, Labels, Unteraufgaben, wiederkehrende Aufgaben, Integrationen und Teamzusammenarbeit. Dawny ist eine minimalistische iOS-App, die auf einem Prinzip basiert: Unvollendete tägliche Aufgaben werden automatisch zurückgesetzt, statt überfällig zu werden. Wenn dich deine Todoist-Aufgabenliste jemals überfordert hat, könnte Dawny einen Versuch wert sein.
+
+Du hast ein System. Du benutzt Todoist seit Monaten — vielleicht sogar Jahren. Du hast Projekte, Labels, Filter und Prioritäten hinzugefügt. Du hast sogar ein YouTube-Video über das beste Todoist-Setup angeschaut. Und doch kommt jedes Mal, wenn du die App öffnest, das mulmige Gefühl, bevor du auch nur eine einzige Aufgabe bearbeitet hast. Die Liste ist lang. Die überfälligen Einträge sind rot. Du fühlst dich irgendwie gestresster als vorher, als du noch kein System hattest.
+
+Wenn dir das bekannt vorkommt, bist du nicht allein — und du bist auch nicht schlecht in Produktivität. Du verwendest möglicherweise einfach ein Tool, das für eine andere Art von Gehirn entwickelt wurde. Dieser Artikel vergleicht Dawny und Todoist ehrlich: Was jede App gut macht, wo jede schwach ist und welcher Mensch in welches Lager gehört.
+
+## Schnellvergleich: Dawny vs Todoist auf einen Blick
+
+FunktionTodoistDawnyTägliches AufgabenlimitKeinAbsichtlich kleinÜberfällige AufgabenMit rotem Label angezeigenAutomatisch ins Backlog zurückgesetztPlattformenBrowseriOS, Android, Web, DesktopNur iOS (derzeit)UnteraufgabenJaNeinLabels und FilterJaNeinTeamzusammenarbeitJaNeinIntegrationen (Kalender, Slack, etc.)JaNeinKostenFree Tier + bezahlte PläneKostenlos (Beta)Am besten fürPower User, Teams, komplexe ProjektePersonen, die sich von ihrer Aufgaben-App überfordert fühlen
+
+Diese Tabelle könnte dir bereits alles Wichtige zeigen. Aber die Zahlen und Häkchen vermissen die wichtigere Frage: Wie *fühlt* sich jede App im täglichen Gebrauch an?
+
+## Was Todoist gut macht
+
+Todoist ist wirklich ausgezeichnete Software. Es hat seinen Platz als einer der beliebtesten Aufgabenmanager auf dem Markt verdient — aus gutem Grund.
+
+Das Projektsystem ermöglicht dir, Arbeiten auf jeder Komplexitätsstufe zu organisieren — persönlich, beruflich oder teamweit. Unteraufgaben, Abschnitte und verschachtelte Projekte bedeuten, dass du fast jeden Arbeitsablauf abbilden kannst. Labels und Filter ermöglichen Power Usern, ihre Aufgabenliste auf dutzende verschiedene Arten zu filtern und genau das anzuzeigen, das gerade Aufmerksamkeit braucht.
+
+Die Integrationsbibliothek ist umfangreich. Todoist verbindet sich mit Google Calendar, Outlook, Slack, Zapier und dutzenden anderen Tools über offizielle Integrationen. Wenn deine Arbeit bereits in anderen Apps stattfindet, kann sich Todoist einfügen, ohne dass du deine Gewohnheiten ändern musst. Für eine unabhängige Bewertung siehe diese Forbes-Rezension zu Todoist.
+
+Für Teams machen gemeinsame Projekte und Aufgabenzuweisung Todoist zu einem echten leichtgewichtigen Projektmanagement-Tool. Wenn du mehrere Personen managst oder Arbeiten regelmäßig weitergibst, zählt diese Fähigkeit.
+
+## Wo Todoist für manche Nutzer schwach wird
+
+Das ist keine Kritik an Todoist. Es ist eine Beobachtung über ein Muster, das bei bestimmten Nutzertypen immer wieder auftaucht.
+
+Wenn ein Aufgabenmanager keine natürliche Grenze für die Anzahl der Einträge hat, wachsen die Listen. Wenn Listen schneller wachsen, als du Aufgaben erledigst, sammeln sich überfällige Einträge an. Todoist markiert diese Einträge rot, weil es helfen möchte — aber für Nutzer mit ADHS, Angst oder einer Tendenz zur Überforderung wird diese rote Zahl zu etwas, das man vermeidet, statt es zu bearbeiten.
+
+Mehr Funktionen bedeuten auch mehr Entscheidungen. Bevor du einfach etwas *tun* kannst, musst du entscheiden: Zu welchem Projekt gehört das? Welche Priorität? Welches Label? Sollte ich ein Fälligkeitsdatum setzen? Der Aufwand für die Pflege eines perfekten Systems kann mehr kognitive Energie kosten als die Aufgaben selbst.
+
+Das ist das, was Forscher manchmal als Aufgabenschulden bezeichnen. Das sich ansammelnde Gewicht von Dingen, die du tun wolltest, aber nicht getan hast. Todoist markiert diese Schulden ständig sichtbar wie die meisten traditionellen Aufgabenmanager. Für manche Nutzer ist diese Sichtbarkeit motivierend. Für andere ist sie lähmend.
+
+## Was Dawny anders macht
+
+Dawny wurde von einem Indie-Entwickler gebaut, der sein ganzes Leben lang ADHS hat. Er hat jede Produktivitäts-App auf dem Markt ausprobiert, einschließlich Todoist. Und ist jedes Mal auf die gleiche Mauer gestoßen. Er hat Dawny für sein eigenes Gehirn gebaut, nicht um produktiver zu sein, sondern um aufzuhören, seine eigene Aufgabenliste zu fürchten.
+
+Die Kernmechanik ist einfach: Am Ende jeden Tages kehren alle Aufgaben, die du in deinem Daily Focus nicht abgeschlossen hast, automatisch in dein Backlog zurück. Sie werden nicht überfällig. Sie werden nicht rot. Sie warten einfach, ohne zu verurteilen, bis du sie wieder wählst.
+
+Dein Backlog ist alles, das du irgendwann vielleicht tun möchtest. Dein Daily Focus ist die kleine Menge an Aufgaben, auf die du dich *heute* konzentrierst. Bewusst klein gehalten. Jeden Morgen triffst du eine aktive, bewusste Entscheidung darüber, was wichtig ist. Aufgaben, die du immer wieder überspringst, werden automatisch durch die „Make It Count"-Mechanik archiviert. Keine Schuldgefühle erforderlich.
+
+Das ist das Gegenteil davon, warum die meisten To-Do-Listen scheitern: Dawny lässt deine Liste nicht zu einem Denkmal für deine vergangenen Absichten werden. Es erzwingt eine tägliche Neubewertung dessen, was jetzt tatsächlich wichtig ist.
+
+Beta-Tester beschreiben die Verschiebung deutlich:
+
+> „Ich dachte nie, dass der reduzierte Ansatz richtig für mich ist. Aber nach dem ersten Test habe ich einfach nicht aufgehört, Dawny zu benutzen. Meine alte To-Do-Listen-App liegt jetzt ungeöffnet mit all ihren unerledigen Aufgaben darin." *Dawny Beta-Tester*
+
+> „Seit ich Dawny benutze, habe ich keine Angst mehr, meine Aufgabenliste anzuschauen. Denn die Aufgaben, die ich ohnehin nicht erledige, werden einfach nicht mehr angezeigt." *Dawny Beta-Tester*
+
+**Ein Wort zur Transparenz:** Dawny ist derzeit eine iOS-App in öffentlicher Beta auf TestFlight. Sie hat deutlich weniger Funktionen als Todoist. Keine Unteraufgaben, keine Labels, keine Integrationen, kein Web-Zugriff, keine Team-Funktionen. Wenn dir diese Dinge wichtig sind, ist Todoist derzeit die bessere Wahl.
+
+## Wer sollte Todoist verwenden
+
+Todoist ist das richtige Tool, wenn:
+
+- Du komplexe Projekte mit mehreren beweglichen Teilen oder Stakeholdern managst
+
+- Du im Team arbeitest und gemeinsame Aufgabenlisten oder Aufgabenzuweisung brauchst
+
+- Du auf Integrationen mit Google Calendar, Slack oder anderen Tools angewiesen bist
+
+- Du ein hohes Aufgabenvolumen hast und wirklich Filtering und Suche brauchst, um es zu bewältigen
+
+- Du aufblühst, wenn du volle Sicht auf alles, das auf deinem Teller ist, hast
+
+Todoist belohnt Nutzer, die die Kapazität und Neigung haben, ein komplexes System zu pflegen. Wenn diese Beschreibung auf dich zutrifft, ist es eines der besten verfügbaren Tools.
+
+## Wer sollte Dawny ausprobieren
+
+Dawny ist einen Versuch wert, wenn:
+
+- Du mehrere To-Do-Apps aufgegeben hast, weil die Liste irgendwann zu überwältigend wurde
+
+- Du ein unterschwelliges Schuldgefühl empfindest, jedes Mal wenn du deine aktuelle Aufgaben-App öffnest
+
+- Du ADHS, Angststörung oder Konzentrationsprobleme hast und festgestellt hast, dass funktionsreiche Apps die Dinge schlimmer machten, nicht besser
+
+- Du bereits ein separates System für komplexe Projekte hast und etwas Leichteres für den täglichen persönlichen Fokus möchtest
+
+- Du ein iPhone-Benutzer bist und ein einfaches Daily-Focus-Tool ohne Lernkurve suchst
+
+Dawny versucht nicht, Todoist im Projektmanagement zu ersetzen. Es ist für die tägliche Frage ausgelegt: *Was mache ich tatsächlich heute?*
+
+## Der philosophische Unterschied
+
+Das ist der Kern davon. Todoist vertraut dem Nutzer, Komplexität zu bewältigen. Es gibt dir jedes Tool, das du brauchst, und tritt zur Seite. Wenn du die kognitive Last eines großen, detaillierten Systems verträgt, belohnt Todoist diese Investition.
+
+Dawny entfernt Komplexität aus der Gleichung. Es macht eine eigenwillige Wette: Für bestimmte Menschen ist das beste Aufgabenmanagement das, das deinen Schiefertafel jeden Morgen zurückgesetzt und sich weigert, die Fehler von gestern heute zu verfolgen. Die Grenzen sind keine Bugs, sie sind das Produkt.
+
+Keine dieser Philosophien ist falsch. Die Frage ist, welche zu dem passt, wie dein Gehirn tatsächlich funktioniert, nicht wie du möchtest, dass es funktioniert.
+
+## Häufig gestellte Fragen
+
+### Ist Dawny eine gute Todoist-Alternative?
+
+Dawny ist eine gute Alternative für Nutzer, die sich von Todoists Funktionsumfang überfordert fühlen oder die mit sich ansammelnden überfälligen Aufgaben kämpfen. Es ist kein direkter Ersatz. Es hat viel weniger Funktionen und ist derzeit nur auf iOS verfügbar. Wenn du Projektmanagement, Teamzusammenarbeit oder tiefe Integrationen möchtest, ist Todoist immer noch das bessere Tool. Dawny ist am besten für Menschen, die ein leichteres Daily-Focus-System brauchen.
+
+### Was ist der Unterschied zwischen Dawny und Todoist?
+
+Der Kerndiffel liegt darin, wie sie unvollendete Aufgaben handhaben. Todoist markiert sie als überfällig und hält sie sichtbar, bis sie erledigt sind. Dawny setzt unvollendete Daily-Focus-Aufgaben am Ende des Tages automatisch ins Backlog zurück, sodass du jeden Morgen ohne einen Berg von Schuldgefühlen startest. Todoist ist auch plattformübergreifend mit vielen Funktionen; Dawny ist nur auf iOS und bewusst minimal.
+
+### Welche Aufgaben-App ist besser für ADHS?
+
+Es gibt keine universelle Antwort, aber viele Nutzer mit ADHS finden, dass funktionsreiche Apps wie Todoist die Überforderung eher verstärken als zu verringern. Die ständige Sichtbarkeit von überfälligen Aufgaben und der Aufwand für die Pflege eines komplexen Systems können kontraproduktiv sein. Dawny wurde speziell mit diesem Muster im Hinterkopf entworfen. Der automatische Reset und die bewusst kleine Daily-Focus-Liste reduzieren die kognitive Belastung. Allerdings gedeihen manche Menschen mit ADHS mit strukturheavy Tools; das hängt vom Individuum ab.
+
+### Kann ich meine Todoist-Aufgaben zu Dawny importieren?
+
+Derzeit nicht. Dawny hat in seiner Beta kein Import-Feature. Du müsstest Aufgaben, die du mitnehmen möchtest, manuell hinzufügen. Angesichts von Dawnys Philosophie der bewussten täglichen Auswahl finden viele Nutzer, dass ein Neustart statt das Importieren eines existierenden Backlogs tatsächlich die bessere Erfahrung ist.
+
+### Ist Dawny kostenlos?
+
+Ja. Dawny ist derzeit kostenlos während seiner öffentlichen Beta auf TestFlight zu nutzen. Es ist kein Abonnement erforderlich, um an der Beta teilzunehmen.
+
+## Fazit
+
+Todoist ist eine großartige App. Wenn du ein Power User bist, der Projekte, Integrationen, Team-Funktionen und volle Kontrolle über ein komplexes Aufgabensystem braucht, verdient es seinen Ruf.
+
+Aber wenn du jemand bist, der Apps wie Todoist ausprobiert hat und sich danach schlechter fühlte. Wenn die roten Überfällig-Labels dich dazu gebracht haben, deinen Aufgabenmanager zu meiden, statt ihn zu nutzen. Das Problem war nie deine Arbeitsmoral. Es war die Diskrepanz zwischen dem Tool und der Art, wie dein Gehirn Druck und Auswahl verarbeitet.
+
+Dawny versucht nicht, Todoist in Features zu übertrumpfen. Es versucht, eine Sache anders zu machen: Deine Aufgabenliste zu einem Ort zu machen, den du morgens öffnen möchtest, nicht etwas, das du fürchtest. Es setzt zurück, statt sich anzusammeln. Es beschränkt, statt zu erweitern. Es archiviert Aufgaben, die du immer wieder überspringst, statt dich damit unbegrenzt zu verfolgen.
+
+Es ist eine Beta, es ist nur iOS verfügbar, und es hat weniger Funktionen als fast jede andere App in dieser Kategorie. Aber für die richtige Person ist das genau der Punkt.
+
+Wenn du eine Aufgaben-App ausprobieren möchtest, die auf dieser Philosophie aufgebaut ist, ist Dawny kostenlos auf TestFlight testbar.
+
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren des Ausprobierens — und Aufgebens — jeder Produktivitäts-App auf dem Markt gebaut.
+
+Möchtest du eine Aufgaben-App ausprobieren, die auf dieser Philosophie aufgebaut ist?
+
+Dawny ist kostenlos auf TestFlight testbar — ohne Verpflichtung.
+
+Probiere Dawny kostenlos auf TestFlight aus

--- a/website/src/content/blog/de/decision-fatigue-task-management.md
+++ b/website/src/content/blog/de/decision-fatigue-task-management.md
@@ -1,0 +1,131 @@
+---
+title: "Entscheidungsmüdigkeit und deine To-Do-Liste: Warum mehr Aufgaben dich weniger produktiv machen"
+description: "Entscheidungsmüdigkeit kostet dich Fokus, bevor du überhaupt anfängst. Erfahre, wie deine Aufgabenliste sie verursacht — und wie eine kleinere tägliche Liste sie verhindert."
+pubDate: 2026-05-10
+---
+
+> **Die kurze Antwort:** Entscheidungsmüdigkeit und Produktivitätsverlust sind real — eine To-Do-Liste mit 40 Einträgen zwingt dich, 40 Mikro-Entscheidungen zu treffen („Soll ich das jetzt machen?"), bevor du überhaupt mit echten Aufgaben anfängst. Diese mentale Belastung führt zu schlechteren Entscheidungen später am Tag und zu einem wachsenden Drang, die Liste zu ignorieren. Eine kleine, bewusst zusammengestellte tägliche Liste — getrennt von deinem kompletten Backlog — verhindert Entscheidungsmüdigkeit von Anfang an.
+
+Du hast es schon bemerkt: Je mehr du zu tun hast, desto weniger scheint es dich produktiv zu machen. Du öffnest deine Task-App mit guten Absichten, schaust die Liste durch und irgendwie endet es darin, dass du gar nichts daraus machst — oder nur die einfachste Aufgabe erledigst, um das Gefühl zu haben, etwas bewegt zu haben. Das ist keine Faulheit. Es ist nicht mangelnde Motivation. Es ist dein Gehirn, das genau das tut, was Gehirne tun, wenn man sie bittet, zu viele Entscheidungen auf einmal zu treffen.
+
+Jede Aufgabe auf deiner Liste ist eine ungelöste Frage. Und ungelöste Fragen kosten dich — noch bevor du eine davon beantwortest. Die Forschung ist hier eindeutig, und die Lösung ist strukturell, nicht motivational. Wenn dein Aufgabensystem dich erschöpft, bevor der Arbeitstag richtig beginnt, ist das Problem nicht du. Es ist das Design.
+
+## Was ist Entscheidungsmüdigkeit?
+
+Entscheidungsmüdigkeit ist die Verschlechterung der Entscheidungsqualität, nachdem eine Person lange Zeit Entscheidungen getroffen hat. Der Begriff wurde populär durch die grundlegende Forschung des Psychologen Roy Baumeister zur Ego-Depletion — der Erkenntnis, dass Selbstkontrolle und Entscheidungsfindung aus einer gemeinsamen, endlichen kognitiven Ressource schöpfen. Wenn diese Ressource schwächer wird, versagt dein Gehirn nicht völlig. Es nimmt Abkürzungen. Es wählt die einfachste Option, vermeidet es, sich festzulegen, oder trifft impulsive Entscheidungen, die es mit voller Batterie abgelehnt hätte.
+
+Eine der eindrucksvollsten Illustrationen stammt aus einer Studie israelischer Richter, die von Jonathan Levav und Shai Danziger untersucht wurde. Gefangene, die früh am Tag vor einer Bewährungskommission erschienen, bekamen etwa 65 % der Zeit eine Bewährung gewährt. Am Ende einer Sitzung fielen die Genehmigungen auf fast null — nicht wegen irgendetwas, das die Gefangenen getan hatten, sondern weil die Entscheidungskapazität der Richter aufgebraucht war. Der gleiche kognitive Mechanismus arbeitet, wenn du vor 9 Uhr morgens auf eine Liste mit 50 Aufgaben starrst.
+
+Das Konzept wurde seither in der Entscheidungsforschung intensiv untersucht — von Gesundheitswesen über Einzelhandel bis hin zu Knowledge Work und persönlicher Produktivität. Der Kernbefund bleibt: Mehr Entscheidungen führen zu schlechteren Entscheidungen später. Baumeister's ursprüngliche Studie zur Ego-Depletion bleibt eine grundlegende Referenz, und moderne Ratgeber bieten zusätzliche Perspektiven.
+
+## Wie deine Aufgabenliste Entscheidungsmüdigkeit verursacht
+
+Eine Aufgabenliste mit 40 Einträgen sind nicht 40 Aufgaben. Es sind 40 offene Fragen. Jedes Mal, wenn du deine App öffnest, stellt jeder Eintrag implizit die Frage: „Ist das heute relevant? Ist das dringend? Soll ich das jetzt oder nach dem Mittagessen machen? Muss ich das überhaupt noch tun?" Das ist nicht eine Frage pro Eintrag. Es ist ein Bündel kleiner Urteile, die dein Gehirn verarbeitet, bevor es dich loslässt.
+
+Das passiert schnell und größtenteils unterhalb der Bewusstseinsschwelle. Aber es kostet dich trotzdem. Nachdem du durch eine lange Liste gescrollt hast und etwas Bestimmtes gefunden hast, mit dem du arbeiten möchtest, hast du schon einen bedeutsamen Teil deines täglichen Entscheidungs-Budgets für Meta-Entscheidungen aufgebraucht. Entscheidungen über Entscheidungen. Du hast noch kein einziges Element von deiner Liste erledigt, und du bist bereits erschöpfter als zu Beginn.
+
+Deshalb ist „To-Do-Listen erzeugen Überforderung" nicht einfach eine vage Beschwerde. Es ist eine mechanistische Beschreibung dessen, was lange Aufgabenlisten wirklich mit kognitiven Funktionen machen. Die Überforderung ist nicht imaginär. Sie hat eine neurologische Grundlage.
+
+## Der verstärkende Effekt: Warum längere Listen sich schlimmer anfühlen als sie sollten
+
+Der Schaden durch eine aufgeblähte Aufgabenliste ist nicht proportional. Er ist verstärkend. Wenn die Listenlänge zunimmt, bekommt jeder einzelne Eintrag weniger Aufmerksamkeit während der Scan-Phase. Dein Gehirn kann 50 Einträge nicht so sorgfältig bewerten wie 5. Also fängt es an, Abkürzungen zu nehmen — es ignoriert Einträge, die schwierig zu bedenken sind, verschiebt alles, das echte Überlegung erfordert, und konzentriert sich auf das, was am einfachsten oder vertrautesten aussieht.
+
+Das Ergebnis ist ein vorhersehbares Muster: Die schnellen, unkomplizierten Aufgaben werden erledigt. Die wichtigen, aber schwierigen bleiben auf der Liste, unendlich. Und die Liste wächst weiter, weil du neue Aufgaben schneller hinzufügst, als du die erledigst, die wirklich zählen. Das System ernährt sich selbst.
+
+Es gibt auch einen Motivationskostenaspekt. Wenn du drei Aufgaben von einer Liste mit fünf Einträgen erledigst, hast du 60 % abgeräumt. Das fühlt sich wie echter Fortschritt an. Wenn du drei Aufgaben von einer Liste mit fünfzig erledigst, hast du die Nadel kaum bewegt. Die Feedback-Schleife, die dir das Gefühl geben sollte, etwas zu erreichen, ist unterbrochen. Du machst die gleiche Menge Arbeit und fühlst dich schlechter dabei.
+
+## Das Paradoxon der Wahl, angewendet auf Aufgabenverwaltung
+
+Psychologe Barry Schwartz dokumentierte in seinem Buch „The Paradox of Choice" (2004) etwas Kontraintuatives: Mehr Optionen machen Menschen nicht glücklicher oder produktiver. Sie machen sie ängstlicher und weniger zufrieden. Wenn man aus einem kleinen Satz von Optionen wählt, entscheiden sich Menschen schnell und fühlen sich gut über das Ergebnis. Wenn man aus einem großen Satz wählt, verbringt man mehr Zeit mit der Entscheidung, fühlt sich weniger sicher in der Wahl und erlebt mehr Bedauern danach — auch wenn man die gleiche Entscheidung getroffen hat.
+
+Angewendet auf Aufgabenverwaltung legt dieses Prinzip nahe, dass die Angst, die du empfindest, wenn du auf eine lange Aufgabenliste schaust, nicht nur darum geht, zu viel zu tun zu haben. Es geht darum, zu viele Optionen zur Auswahl zu haben. Jede uneingeschränkte Wahl hat verborgene Kosten: das Bewusstsein, dass du falsch wählen könntest. Mit 50 Aufgaben ist die Chance, dass du gerade die optimale machst, wirklich niedrig. Dein Gehirn weiß das, auch wenn du dir das nicht bewusst überlegst.
+
+Deine Optionen einzugrenzen — deine tägliche Liste bewusst auf eine Handvoll Aufgaben zu begrenzen — macht den Tag nicht nur verwaltbarer. Es beseitigt eine ganze Kategorie von Zweifeln. Wenn du bereits entschieden hast, was heute ansteht, musst du nicht weiter entscheiden.
+
+## Wie du Entscheidungsmüdigkeit in deinem Aufgabensystem reduzierst
+
+Die strukturelle Lösung für Entscheidungsmüdigkeit in der Aufgabenverwaltung kommt auf drei Veränderungen an — jede reduziert die Anzahl der Entscheidungen, die du in diesem Moment treffen musst.
+
+**1. Trenne dein Backlog von deiner täglichen Liste.**
+
+Dein Backlog ist der Ort, an dem alles lebt. Jede Idee, jede Aufgabe für irgendwann, jedes Projekt, das vielleicht mal wichtig wird. Es sollte umfassend und unproblematisch sein. Deine tägliche Liste ist eine völlig separate Fläche — die kleine Menge an Dingen, die du dich tatsächlich heute verpflichtest zu machen. Das Zwei-Listen-System macht diese Aufteilung explizit. Wenn du deine tägliche Liste öffnest, stöberst du nicht in deinem gesamten Task-Universum. Du schaust dir eine vorgefilterte Ansicht der heutigen Verpflichtungen an.
+
+**2. Begrenze deine tägliche aktive Liste auf drei bis fünf Aufgaben, im Voraus ausgewählt.**
+
+Die täglichen Aufgaben auf drei zu begrenzen, ist eine der am häufigsten empfohlenen Strategien in der Produktivitätsforschung. Nicht weil mehr schlecht wäre, sondern weil die explizite und realistische Verpflichtung die Qualität der Entscheidungen, die du triffst, verändert. Wenn deine tägliche Liste drei Einträge hat, bekommt jeder echte Überlegung. Wenn sie dreißig hat, bekommt jeder einen Scan.
+
+Der Teil „im Voraus ausgewählt" ist genauso wichtig wie das Limit. Wenn du morgens drei Aufgaben am Abend zuvor auswählst, hast du dich während eines Moments relativer Klarheit vorentschieden. Wenn du einen Überblick über den kommenden Tag hast und deine Energie weniger aufgebraucht ist als um 9 Uhr morgens. Das morgige Ich erbt die Entscheidungen, die das gestrige Ich getroffen hat. Das ist ein Geschenk.
+
+**3. Lass unvollendete Aufgaben automatisch zurücksetzen, lass sie nicht sich ansammeln.**
+
+Dies ist weniger offensichtlich, aber es ist wohl das mächtigste. Wenn Aufgaben nicht erledigt werden, werden sie überfällig. Überfällige Aufgaben verschwinden nicht. Sie sitzen oben auf deiner Liste, markiert in Rot, fordern Aufmerksamkeit jedes Mal, wenn du die App öffnest. Jede erfordert, dass du neu überlegst: Ist das noch relevant? Soll ich das heute machen? Warum habe ich das noch nicht getan?
+
+Ein System, das unvollendete Tagesaufgaben automatisch ins Backlog zurückversetzt, anstatt sie als überfällig zu markieren, eliminiert diese ganze Klasse wiederkehrender Mikro-Entscheidungen. Gesterns unvollendete Aufgabe kehrt ins Backlog zurück. Todays Liste startet sauber. Du wählst wieder, was der heutige Tag bringt.
+
+## Die Rolle des automatischen täglichen Zurücksets beim Reduzieren von Entscheidungen
+
+Das automatische tägliche Zurückset ist nicht nur eine gute Laune-Funktion. Es ist ein Entscheidungs-Reduzierungsmechanismus. Ohne ihn würde jede unvollendete Aufgabe von jedem vorherigen Tag deine tägliche Entscheidungslast verstärken. Du entscheidest nicht nur, was du heute tust. Du entscheidest erneut, ob gesterns unvollendete Aufgaben noch gültig sind, und vorgesterns, und vorletzte Woche's. Die Liste wird zu einem Palimpsest von vergangenen Verpflichtungen, die möglicherweise noch relevant sind oder auch nicht.
+
+Wenn Aufgaben automatisch zurücksetzen, verschwindet diese ganze Kategorie von „Ist das noch wert zu tun?" von der täglichen Oberfläche. Aufgaben, die zählen, werden wieder gewählt. Aufgaben, die nicht zählen, sitzen im Backlog, bis du bemerkst, dass du sie immer wieder nicht wählst. An dem Punkt hast du echte Informationen darüber, ob sie auf einer Liste gehören.
+
+Beta-Tester von Dawny haben diese Verschiebung direkt bemerkt:
+
+> „Seit ich Dawny nutze, habe ich keine Angst mehr, auf meine Aufgabenliste zu schauen." — Dawny Beta-Tester
+
+Die Angst, auf deine Liste zu schauen, ist ein Symptom von Entscheidungsmüdigkeit. Sie bedeutet, dass sich die Liste mit genug ungelösten Fragen angesammelt hat, dass das Öffnen sich wie eine unangenehme Verpflichtung anfühlt statt eines nützlichen Werkzeugs. Das Zurückset entfernt das angesammelte Gewicht.
+
+> „Ich nutze Dawny tatsächlich jeden Morgen. Das tägliche Zurückset gibt mir den Raum zum Atmen, den ich brauche." — Dawny Beta-Tester
+
+Raum zum Atmen bedeutet in diesem Zusammenhang das kognitive Äquivalent einer leichteren Entscheidungslast. Du öffnest die App und weißt, dass die Liste widerspiegelt, was du für heute gewählt hast, nicht was du letzten Dienstag vergessen hast zu tun.
+
+## Vorentscheide, um In-the-Moment-Entscheidungen zu reduzieren
+
+Über die strukturellen Veränderungen an der Liste selbst hinaus gibt es Taktiken, die die Anzahl der Entscheidungen reduzieren, die du in Echtzeit triffst.
+
+**Plane morgen am Abend davor.** Am Ende jedes Arbeitstags verbringst du fünf Minuten damit, zu entscheiden, was der nächste Tag bringt. Deine drei Aufgaben für morgen gehen auf die Liste, bevor du den Laptop zuklappt. Wenn du aufwachst, ist die Entscheidung bereits getroffen — du führest aus, nicht wählst.
+
+**Gruppiere ähnliche Aufgaben nach Tageszeit.** Verwaltungsaufgaben (Email, Planung, kurze Antworten) gruppieren sich natürlicherweise morgens oder nach dem Mittagessen. Deep-Work-Aufgaben gehören in das Fenster, in dem du am schärfsten bist. Wenn du den Tag so strukturierst, ist die Frage „Welche Art von Arbeit sollte ich jetzt tun?" bereits beantwortet. Du entscheidest nur innerhalb einer Kategorie, nicht über alle Kategorien gleichzeitig.
+
+**Nutze einfache Tageszeit-Etiketten.** Du brauchst keine komplexe Prioritätsmatrix. Ein einfaches Label — „morgens", „nachmittags", „wann auch immer". Grenzt das Feld ein, wenn du dich hinsetzt. Anstatt deine ganze Liste zu bewerten, schaust du dir nur die morgendliche Untermenge an. Kleine Einschränkungen, konsequent angewendet, verstärken sich in signifikant niedrigerer täglicher Entscheidungslast.
+
+Das Ziel über alle diese Taktiken hinweg ist das gleiche: Treffe mehr Entscheidungen im Voraus, in Momenten höherer kognitiver Klarheit, damit weniger Entscheidungen in den Momenten bleiben, wenn deine Kapazität aufgebraucht ist.
+
+## Häufig gestellte Fragen
+
+### Was ist Entscheidungsmüdigkeit am Arbeitsplatz?
+
+Entscheidungsmüdigkeit am Arbeitsplatz ist der Rückgang der Entscheidungsqualität, der auftritt, nachdem Mitarbeiter viele Wahlmöglichkeiten im Laufe des Tages getroffen haben. Sie betrifft alle — von Führungskräften bis zu einzelnen Mitarbeitern — und zeigt sich als Vermeidungsverhalten, impulsive Entscheidungen und Rückfallverhalten auf den Status quo. In Knowledge Work zeigt sich das besonders als Schwierigkeiten beim Priorisieren von Aufgaben, Probleme beim Starten komplexer Projekte und eine Tendenz, wenig wertvolle Beschäftigungsarbeit anstelle von bedeutungsvoller Aufgabe zu tun.
+
+### Wie verursacht eine To-Do-Liste Entscheidungsmüdigkeit?
+
+Jeder Eintrag auf einer To-Do-Liste ist eine offene Frage: „Soll ich das jetzt machen?" Mit einer Liste von 40 Einträgen beantwortest du diese Frage implizit 40 Mal, bevor du echte Arbeit geleistet hast. Dieses Scannen und Mikro-Evaluieren kostet kognitive Ressourcen. Die gleichen Ressourcen, die du später brauchst, um gute Entscheidungen zu treffen. Eine lange, undifferenzierte Aufgabenliste lädt eine große Anzahl von niedrigertigsten Entscheidungen vor, bevor dein Tag überhaupt begonnen hat.
+
+### Wie reduziere ich Entscheidungsmüdigkeit?
+
+Die effektivsten Herangehensweisen sind strukturell statt motivational. Trenne dein Backlog (alles, was du machen könntest) von deiner täglichen Liste (was du dich heute verpflichtest zu tun). Begrenze deine tägliche Liste auf drei bis fünf Aufgaben, am Abend zuvor gewählt, wenn dein Denken klarer ist. Nutze automatische Zurücksets, damit unvollendete Aufgaben ins Backlog zurückkehren statt sich als überfällige Einträge anzusammeln. Jedes davon reduziert die Anzahl der Entscheidungen, die du in dem Moment treffen musst.
+
+### Warum bin ich produktiver, wenn ich weniger Aufgaben habe?
+
+Weniger Aufgaben bedeutet weniger Wahlmöglichkeiten, was weniger kognitiven Belastung bedeutet, bevor du anfängst. Wenn deine tägliche Liste drei Einträge hat, bekommt jeder echte Aufmerksamkeit und du wirst sie wahrscheinlich tatsächlich erledigen. Das schafft positiven Schwung. Wenn die Liste dreißig Einträge hat, sind die Evaluierungskosten hoch, das Fertigstellen fühlt sich unmöglich an, und Motivation sinkt. Produktivität geht oft weniger um Anstrengung und mehr darum, die kognitiven Bedingungen zu verwalten, die Anstrengung möglich machen.
+
+### Zu welcher Tageszeit sollte ich wichtige Entscheidungen treffen?
+
+Früher ist allgemein besser. Die Entscheidungskapazität ist nach Ruhe am höchsten und sinkt im Laufe des Tages, während du mehr Entscheidungen triffst. Für die meisten Menschen stellen die ersten zwei bis drei Stunden des Arbeitstags das klarste Denk-Fenster dar. Wichtige Entscheidungen — einschließlich welche Aufgaben deinen Fokus verdienen — sind am besten in diesem Fenster getroffen oder ideal am Vorabend, so dass sie nicht die kognitiven Ressourcen am Morgen verbrauchen, die besser für echte Arbeit genutzt werden würden.
+
+## Fazit
+
+Entscheidungsmüdigkeit und Produktivitätsverlust sind ein strukturelles Problem, nicht ein persönliches. Die Forschung ist konsistent: Wir haben eine begrenzte Kapazität für Entscheidungen, sie sinkt im Laufe des Tages, und Systeme, die uns zwingen, hunderte von kleinen Entscheidungen zu treffen, bevor wir etwas Sinnvolles getan haben, werden immer unsere besten Absichten untergraben.
+
+Die Lösung ist architektonisch. Ein separates Backlog für alles. Eine kleine tägliche Liste für heutige Verpflichtungen, im Voraus gewählt. Und ein Zurückset-Mechanismus, der unvollendete Aufgaben davon abhält, sich in einen immer wachsenden Haufen ungelöster Fragen anzusammeln. Das sind keine Hacks oder Motivationstricks. Das sind Design-Entscheidungen, die mit der Struktur menschlicher Kognition arbeiten, nicht gegen sie.
+
+Wenn dein Aufgabensystem nicht mehr ständige Neubewertung verlangt und stattdessen bewusste Verpflichtungen widerspiegelt, wird die Liste aufgehört, etwas zu sein, das du vermeidest, und fängst an, etwas zu sein, das du wirklich nutzt. Das ist nicht nichts. Der Unterschied zwischen einer Liste, die du jeden Morgen öffnest, und einer, die du eine Woche lang nicht angefasst hast, ist oft ein Design-Problem mit einer strukturellen Lösung.
+
+Wenn du eine Task-App testen möchtest, die auf dieser Philosophie aufgebaut ist, ist Dawny kostenlos auf TestFlight verfügbar — ohne Verpflichtung.
+
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren gebaut, in denen er jede verfügbare Produktivitäts-App versucht — und aufgegeben — hat.
+
+Möchtest du eine Task-App testen, die auf dieser Philosophie aufgebaut ist?
+
+Dawny ist kostenlos auf TestFlight verfügbar — ohne Verpflichtung.
+
+Probiere Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/morning-routine-task-reset.md
+++ b/website/src/content/blog/de/morning-routine-task-reset.md
@@ -1,0 +1,137 @@
+---
+title: "Die 5-Minuten-Morgenroutine, die deine Aufgabenliste täglich zurücksetzt"
+description: "Eine tägliche Morgen-Aufgabenliste-Zurücksetzung braucht 5 Minuten und verhindert die Überforderung, die die Produktivität vor dem Mittag zerstört. Hier ist der genaue Prozess — und die Philosophie dahinter."
+pubDate: 2026-05-10
+---
+
+# Die 5-Minuten-Morgenroutine, die deine Aufgabenliste täglich zurücksetzt
+
+> **Kurzantwort:** Eine Morgenroutine für Produktivität muss nicht um 5 Uhr morgens beginnen. Sie braucht einen bewussten Schritt: eine Aufgabenlisten-Zurücksetzung. In 5 Minuten überprüfst du die gestrige unvollendete Arbeit, wählst 2–3 Aufgaben, die dir heute wirklich wichtig sind, und gibst dir selbst die Erlaubnis, alles andere zu ignorieren. Diese einzige Entscheidung — getroffen, bevor die erste E-Mail kommt — gibt der gesamten Welt die Richtung vor und reduziert die Entscheidungsmüdigkeit erheblich.
+
+Stell dir zwei Versionen deinen Morgen vor. In der ersten öffnest du deine Aufgaben-App und fühlst sofort das Gewicht von gestern — und dem Tag davor, und der Woche davor. Rote Einträge. Aufgaben, die vor zwei Wochen sinnvoll waren. Eine Liste, die schneller gewachsen ist, als du sie hätte umsetzen können. Du schließt die App, ohne etwas zu tun, und sagst dir selbst, dass du dich später darum kümmern wirst.
+
+In der zweiten Version öffnest du deine App und siehst eine saubere Liste. Die gestrigen unvollendeten Aufgaben sind nicht als Fehler übernommen worden — sie sind neutral ins Backlog zurückgekehrt. Du brauchst fünf Minuten, um auszuwählen, worum es heute wirklich geht, dann schließt du die App und fängst an zu arbeiten. Bis zu deinem ersten Termin weißt du bereits, was du heute tust und warum.
+
+Der Unterschied zwischen diesen zwei Morgen ist nicht Disziplin oder Willenskraft. Es ist ein System — konkret eine fünf Minuten lange Morgen-Aufgabenlisten-Zurücksetzung, die Planung als bewusste Handlung behandelt, nicht als automatische Reaktion auf angesammelte Schuldgefühle.
+
+## Warum dein Morgen den Ton für den ganzen Tag setzt
+
+Die erste Stunde nach dem Aufwachen ist der kognitiv wertvollste Teil deines Tages. Die Forschung zur Attention Restoration Theory (Aufmerksamkeitswiederherstellungstheorie), entwickelt von den Umweltpsychologen Rachel und Stephen Kaplan, beschreibt, wie gerichtete Aufmerksamkeit — die Art, die für konzentrierte Arbeit und Entscheidungsfindung erforderlich ist — eine erschöpfbare Ressource ist, die sich während der Ruhe erholt. Eine systematische Übersicht der Aufmerksamkeitswiederherstellungstheorie zeigt, dass Menschen, die den Tag mit intakter gerichteter Aufmerksamkeit beginnen, bei komplexen Aufgaben deutlich besser abschneiden als diejenigen, die bereits erschöpft beginnen.
+
+Übertrage das auf deinen Morgen: Jede Entscheidung, die du triffst, bevor du deine wichtigste Arbeit beginnst, verbraucht einen Teil dieser Ressource. E-Mails durchzuschauen, auf Slack-Benachrichtigungen zu reagieren oder auf eine 60-Punkt-Aufgabenliste zu starren und zu versuchen herauszufinden, wo man anfangen soll — alles zieht von demselben begrenzten Pool ab. Bis du dich tatsächlich hinsetzt, um die Arbeit zu tun, die zählt, hast du bereits einen großen Teil deiner besten kognitiven Kapazität aufgebraucht.
+
+Eine bewusste fünf Minuten lange Morgen-Planungsritual ändert die Gleichung. Anstatt den ganzen Morgen über mentale Energie damit zu verschwenden, auf deine Umgebung zu reagieren, triffst du früh eine klare Entscheidung: worum geht es heute. Und diese Entscheidung leitet alles andere. Du machst keine 60 Mikro-Entscheidungen jedes Mal, wenn du einen Blick auf deine Aufgaben-App wirfst. Du hast heute Morgen eine Makro-Entscheidung getroffen, und der Rest des Tages kann ihr folgen.
+
+## Was die meisten Menschen bei der Morgenplanung falsch machen
+
+Die meisten Menschen haben keine Morgenplanungsroutine. Sie haben eine Morgenreaktionsroutine. Sie wachen auf, greifen nach ihrem Telefon und fangen sofort an, die Prioritäten anderer Menschen zu verarbeiten — E-Mails, Benachrichtigungen, Nachrichten — bevor sie auch nur eine eigene Entscheidung getroffen haben.
+
+**E-Mail zuerst öffnen.** E-Mail ist eine Liste von Anfragen anderer Menschen. Wenn du deinen Morgen dort beginnst, gibst du die Kontrolle über deine Aufmerksamkeit sofort an jeden ab, der dir etwas über Nacht geschickt hat. Bis du deinen Posteingang geschlossen hast, bist du bereits hinter jemandem anders' Agenda zurück und hast noch kein Mal an deine eigene gedacht.
+
+**Mit der leichtesten Aufgabe beginnen.** Das fühlt sich produktiv an. Du machst Dinge. Aber die leichteste Aufgabe und die wichtigste Aufgabe sind selten das gleiche. Mit dem Einfachen zu beginnen schafft Schwung, aber es ist Schwung in die falsche Richtung. Die harte, wichtige Arbeit wird immer wieder auf später am Tag verschoben, wenn deine Energie niedriger und die Dringlichkeit höher ist.
+
+**Reagieren, anstatt zu planen.** Die meisten Morgen fühlen sich an, als gäbe es keine Zeit zu planen. Etwas kommt auf, eine Nachricht braucht eine Antwort, ein Termin beginnt früher. Aber den Planungsschritt zu überspringen spart keine Zeit. Es kostet sie. Ohne eine klare Entscheidung darüber, worum es heute geht, fühlt sich jede Aufgabe gleich dringend an, und du verbringst den Tag damit, den Kontext zu wechseln, anstatt bei etwas Wichtigem Fortschritte zu machen.
+
+**Gestern's Liste unverändert heute übernehmen.** Das ist vielleicht das häufigste Muster. Und das schädlichste. Gestrige unvollendete Aufgaben sind bereits in deiner App, normalerweise als verspätet gekennzeichnet. Du schaust auf die Liste, spürst einen Hauch von Schuldgefühl und entscheidest, dass du heute einfach mehr Anstrengung aufbringen wirst. Aber die Liste ist immer noch die falsche Liste. Sie spiegelt Gesterns Plan wider, nicht Heute's Realität. Und eine Liste, die auf Schuldgefühlen basiert, ist eine, die du lieber vermeiden möchtest.
+
+## Die 5-Minuten-Morgen-Aufgabenlisten-Zurücksetzung: Schritt für Schritt
+
+Das ist die gesamte Routine. Es dauert fünf Minuten. Du machst es, bevor du E-Mail öffnest, bevor du Slack checkst, bevor du etwas schaust, das zu jemand anderem's Agenda gehört.
+
+**Schritt 1: Öffne deine Aufgaben-App. Nicht deinen Posteingang.** Die Reihenfolge zählt. Deine Aufgaben-App ist der Ort, wo deine eigenen Prioritäten leben. Dein Posteingang ist der Ort, wo die von jedem anderen sind. Fang mit deinen an.
+
+**Schritt 2: Schau dir gestrige unvollendete Aufgaben an und stelle eine Frage.** Nicht „warum habe ich das nicht getan?". Diese Frage ist eine Schuldgefühl-Spirale, die nur darauf wartet zu passieren. Die einzige Frage, die es wert ist zu stellen, ist: „Ist das heute noch relevant?" Wenn ja, ist es ein Kandidat für heutige Liste. Wenn nein, schicke es zurück ins Backlog und mach weiter.
+
+**Schritt 3: Wähle 2–3 Aufgaben für heute's Daily Focus.** Nicht fünf. Nicht acht. Zwei oder drei. Diese Einschränkung ist der wichtigste Teil der ganzen Routine, weil sie eine echte Prioritätsentscheidung erzwingt. Wenn alles auf heute's Liste kommen kann, muss nichts priorisiert werden. Wenn du nur drei wählen kannst, musst du herausfinden, was wirklich wichtig ist. Wähle aus deinem Backlog, wenn gestern nichts Relevantes übrig gelassen hat; diese Liste existiert, um dir Optionen zu geben, nicht Verpflichtungen.
+
+**Schritt 4: Lege diese als deinen Fokus für heute fest.** Nenn sie dein Daily Focus, dein Big Three, deine unverrückbaren Dinge. Das Label spielt keine Rolle. Wichtig ist, dass du eine klare Zusage gemacht hast: das sind die Dinge, die einen erfolgreichen Tag ausmachen. Alles andere ist sekundär.
+
+**Schritt 5: Schließ die App und fang mit der schwierigsten an.** Die schwierigste Aufgabe auf deiner Liste ist fast immer die wichtigste. Damit zu beginnen ist keine Strafe. Es ist Respekt vor deinen eigenen Prioritäten. Und deine kognitiven Ressourcen sind jetzt am höchsten, was bedeutet, dass dies der beste Moment ist, den du den ganzen Tag über haben wirst, um sie anzupacken.
+
+Die gesamte Sequenz, vom Öffnen der App bis zum erneuten Schließen, dauert etwa fünf Minuten, sobald es zur Gewohnheit geworden ist. Die ersten paar Male könnten länger dauern, während du dich an die Entschlossenheit gewöhnst, die der Prozess erfordert. Dieses Unbehagen ist Teil der Rücksetzung, die funktioniert — du triffst tatsächlich eine Entscheidung, nicht nur Elemente herumgeschoben.
+
+Wenn du einen tieferen Blick auf die Prinzipien hinter dieser Art von intentionaler täglicher Struktur werfen möchtest, deckt das tägliche Planungssystem-Framework die vollständige Architektur dahinter ab.
+
+## Die Kraft der automatischen Nacht-Zurücksetzung
+
+Es gibt eine Version der Morgen-Zurücksetzung, die fast keine Anstrengung erfordert, weil der schwierigste Teil — gestrige unvollendete Aufgaben aus deiner aktiven Liste zu löschen — automatisch passiert, während du schläfst.
+
+Das Konzept ist einfach: Anstatt unvollendete Aufgaben als überfällig zu behandeln (ein Fehler, der Abrechnung erfordert), behandelt das System sie als unentschieden. Wenn der Tag endet und eine Aufgabe nicht gemacht wurde, wird sie nicht rot und tritt einem jemals wachsenden Haufen verpasster Zusagen bei. Sie kehrt neutral und unverurteilt ins Backlog zurück, wartet darauf, morgen wieder gewählt zu werden, wenn es immer noch die Wahl wert ist.
+
+Das ist die Designphilosophie hinter Dawny. Die App hat zwei Listen: ein Backlog, das alles hält, das du irgendwann machen möchtest, und ein Daily Focus, das nur das hält, das du aktiv für heute ausgewählt hast. Um 3 Uhr morgens, bevor du aufwachst, kehren alle unvollendeten Daily-Focus-Aufgaben automatisch ins Backlog zurück. Dein Morgen beginnt mit einer leeren aktiven Liste. Du wählst frisch, ohne das Gewicht von gestern.
+
+> „Ich benutze Dawny eigentlich jeden Morgen. Das tägliche Reset gibt mir den Luft zum Atmen, den ich brauche." — Dawny-Beta-Tester
+
+Der praktische Effekt dieses Designs ist beeindruckend. Wenn deine Morgen-Zurücksetzung von einem sauberen Blatt beginnt, wird der Planungsschritt wirklich zukunftsorientiert. Du entscheidest nicht, welche von gestrigen Fehlern du retten sollst. Du entscheidest, welche von Heute's Gelegenheiten es sind. Das ist völlig anders mentale Rahmen, und es ändert, wie sich der ganze Tag anfühlt.
+
+> „Seit ich Dawny benutze, habe ich keine Angst mehr, auf meine Aufgabenliste zu schauen." — Dawny-Beta-Tester
+
+Es gibt auch eine subtile Intelligenz, die in die Rücksetzung im Laufe der Zeit eingebaut ist. Aufgaben, die immer wieder ins Backlog zurückkehren, ohne jemals in dein Daily Focus zu schaffen, erzählen dir etwas. Wenn du eine Aufgabe fünf Morgen hintereinander übersprungen hast, ist es fast sicher nicht so wichtig, wie du dachtest, als du sie hinzufügtest. Ein gutes System bemerkt dieses Muster und bringt es schließlich an die Oberfläche. Damit du eine ehrliche Entscheidung treffen kannst, ob es überhaupt auf deine Liste gehört.
+
+## Wie man die Morgen-Zurücksetzung zu einer Gewohnheit macht (wenn man kein Morgenmensch ist)
+
+Du musst kein Morgenmensch sein, damit das funktioniert. Du musst konsistent sein, und das erfordert, die Gewohnheit so friktionsfrei wie möglich zu machen.
+
+**Knüpfe sie an einen bestehenden Trigger an.** Der zuverlässigste Weg, eine neue Gewohnheit zu bauen, ist, sie mit etwas zu verbinden, das du bereits zuverlässig machst. Kaffee ist der klassische Anker; die Routine wird „Kaffee machen, dann die Aufgabenlisten-Zurücksetzung machen." Das erste Telefon-Entsperren funktioniert genauso gut. Du brauchst keine zusätzliche Zeit zu finden. Du brauchst einen Übergang zu nutzen, den du bereits jeden Morgen machst.
+
+**Lege die App dorthin, wo du sie nicht übersehen kannst.** Eine Aufgabenlisten-Zurücksetzung dauert fünf Minuten. Zu vergessen, dies zu tun, dauert null. Stelle sicher, dass deine Aufgaben-App auf deinem Startbildschirm ist, idealerweise das erste, das du siehst, wenn du dein Telefon morgens entsperrst. Reibungsabbau ist nicht Faulheit; es ist Verhaltensdesign.
+
+**Nutze einen Fünf-Minuten-Timer.** Paradoxerweise macht ein hartes Zeitlimit die Zurücksetzung einfacher, nicht schwieriger. Wenn du weißt, dass du nur fünf Minuten hast, hörst du auf, deine Wahlen in Frage zu stellen, und fängst an, sie zu treffen. Der Timer schafft einen Behälter, der Entscheidungen niedrig schwierig fühlen lässt. Wenn du die falsche Wahl getroffen hast, setzt du dich morgen zurück.
+
+**Gleiche Zeit, gleicher Prozess, jeden Tag.** Gewohnheiten bilden sich durch Wiederholung und Konsistenz, nicht durch Intensität. Eine fünf Minuten lange Zurücksetzung, die jeden Morgen gemacht wird, ist unendlich wertvoller als eine dreißig Minuten lange tiefe Planungssitzung, die zweimal die Woche gemacht wird. Strebe nach Konsistenz über Gründlichkeit.
+
+**Verfolge den Streak, aber verzeihe die Pausen.** Zu wissen, dass du die Gewohnheit für zwei Wochen am Laufen gehalten hast, fügt positiven Druck hinzu, um sie am Laufen zu halten. Aber ein verpasster Morgen ist kein Grund, aufzugeben; es ist nur ein verpasster Morgen. Die Zurücksetzung beginnt morgen erneut.
+
+## Was zu tun ist, wenn der Morgen falsch läuft
+
+Einige Morgen laufen nicht wie geplant. Du läufst spät, etwas Dringendes landet in deinem Posteingang, bevor du Zeit zum Denken hattest, ein Kind braucht etwas, ein Termin wurde früher verlegt. Die fünf Minuten lange Routine hat plötzlich keine fünf Minuten, um darin zu leben.
+
+Das ist echtes Leben, und ein gutes System muss im echten Leben funktionieren, nicht nur an den idealen Tagen.
+
+Die Ausweichroute ist eine 60-Sekunden-Version: App öffnen, eine Aufgabe wählen. Nicht drei. Eine. Die Aufgabe, die, wenn es die einzige Sache wäre, die du heute vollendest, den Tag lebenswert anfühlen ließe. App schließen.
+
+Das ist es. Eine Entscheidung in 60 Sekunden ist unendlich besser als keine Entscheidung und einen Tag verbracht, um zu reagieren. Es hält die Gewohnheit an schwierigen Tagen am Leben und gibt dir mindestens einen Ankerpunkt für den Rest des Tages zum Umkreisen. Die meiste Zeit schafft das Vollenden dieses einen Dinges genug Schwung zum Weitermachen. Aber selbst wenn nicht, hast du das eine Ding gemacht, das zählte.
+
+Die Morgen-Aufgabenlisten-Zurücksetzung ist nicht ein starres Ritual, das fehlschlägt, sobald Bedingungen nicht perfekt sind. Es ist eine Denkweise: Bevor du auf irgendjemand anderes' Prioritäten reagierst, triff mindestens eine Entscheidung über deine eigenen. Diese Entscheidung kann in fünf Minuten oder in 60 Sekunden passieren. Entweder Weg ändert es den Tag.
+
+An Tagen, wo auch die 60-Sekunden-Ausweichroute nicht möglich ist, komme um die Mittagszeit zurück. Führe die Zurücksetzung dann durch. „Morgen" ist eine Metapher für „bevor du anfängst", und es ist nie zu spät, mit Absicht zu beginnen.
+
+## Häufig gestellte Fragen
+
+### Was ist eine Morgenplanungsroutine?
+
+Eine Morgenplanungsroutine ist ein kurzer, absichtlicher Prozess, den du am Anfang jeden Tages durchführst, um zu entscheiden, worauf du dich konzentrierst. Es beinhaltet normalerweise das Überprüfen deiner Aufgabenliste, das Auswählen von 2–3 Prioritäten für den Tag und das Beiseitelegen dieser als dein aktiver Fokus. Das Schlüsselwort ist absichtlich. Eine Planungsroutine unterscheidet sich vom einfachen Öffnen deiner E-Mail und Reagieren auf das, was über Nacht angekommen ist.
+
+### Wie lange sollte die Morgenplanung dauern?
+
+Fünf Minuten sind für die meisten Menschen genug. Das Ziel ist keine umfassende Analyse. Es ist eine einzelne klare Entscheidung: Was sind die zwei oder drei Dinge, die heute zu einem Erfolg machen? Längere Planungssitzungen können tatsächlich gegen dich arbeiten, indem sie Überdenken fördern und eine übereifrige Liste produzieren. Wenn deine Morgenplanung länger als zehn Minuten dauert, ist der Prozess zur Arbeit geworden, anstatt ein Gateway dazu zu sein.
+
+### Sollte ich Aufgaben am Vorabend oder am Morgen planen?
+
+Beide Ansätze funktionieren, und das Kombinieren ist oft am besten. Eine Abend-Übersicht, die kurz festnotiert, was unvollendete ist und wie morgen aussehen könnte, lässt dein Gehirn über Nacht trainieren und macht die Morgen-Zurücksetzung schneller. Aber die abschließende Zusage zu Heute's spezifischen Aufgaben ist am besten am Morgen zu treffen, wenn du weißt, was frisch, was dringend und wie du dich wirklich fühlst. Nacht-Planung setzt die Bühne; Morgen-Planung setzt die Absichten.
+
+### Was ist die beste Morgenroutine für Produktivität?
+
+Die beste Morgenroutine für Produktivität ist diejenige, die du tatsächlich konsistent machst. Für Aufgaben-Management speziell, zeigt die Evidenz auf Richtung, deine aktive tägliche Liste klein zu halten (2–5 Elemente), die Planungsentscheidung zu treffen, bevor du E-Mail oder reaktive Apps öffnest, und mit der kognitiv anspruchsvollsten Aufgabe zu beginnen, wenn deine Energie am höchsten ist. Die spezifische Reihenfolge anderer Gewohnheiten — Bewegung, Meditation, Journaling. Zählt weitaus weniger als die konsistente Handlung, deine Prioritäten zu wählen, bevor du auf andere's reagierst.
+
+### Wie halte ich mich an eine Morgenroutine?
+
+Konsistenz über Perfektion ist die Regel, die am wichtigsten ist. Verknüpfe die Routine mit einer bestehenden Morgengewohnheit (Kaffee, erstes Entsperren, Dusche), reduziere Reibung, indem du deine App in den Vordergrund stellst, und setze ein Zeitlimit, damit der Prozess nicht expandiert. Wenn du einen Morgen verpasst — und du wirst es. Behandle es als einen verpassten Tag, nicht ein fehlgeschlagenes System. Die Routine setzt am nächsten Tag fort. Gewohnheiten werden in Monaten gebaut, nicht durch eine einzelne Ausnahme kaputt gemacht.
+
+## Fazit
+
+Eine Morgen-Aufgabenlisten-Zurücksetzung geht nicht um früher aufwachen, meditieren oder deine erste Stunde in eine Produktivitäts-Performance optimieren. Es geht um eine Entscheidung, die getroffen wird, bevor du anfängst, auf jeden anderen zu reagieren, die eine einzelne Frage antwortet: Worum geht es heute wirklich?
+
+Diese Entscheidung dauert fünf Minuten. Es erfordert das Wählen von 2–3 Aufgaben aus einer klaren, überschaubaren Liste, das Setzen dieser als dein Daily Focus, und dann das Herauskommen aus dem Planungsmodus und in den Handlungsmodus. Die Forschung zu morgigen kognitiven Ressourcen, Entscheidungsmüdigkeit und Aufmerksamkeitswiederherstellung alle deuten in die gleiche Richtung: Menschen, die früh klare tägliche Prioritätsentscheidungen treffen, schneiden besser ab und erleben weniger Stress über den Rest des Tages.
+
+Die Reset-Philosophie — wo unvollendete Aufgaben über Nacht ins Backlog zurückkehren, anstatt als überfällige Elemente zu akkumulieren — macht die Morgen-Entscheidung wirklich sauber. Du wählst nicht, welche Fehler zu retten. Du wählst, welche von Heute's Gelegenheiten. Diese Verschiebung des Rahmens ist klein aber tiefgreifend. Wenn du erleben möchtest, wie sich das in der Praxis anfühlt, ist der Artikel über das Wählen deiner drei wichtigsten Aufgaben ein nützlicher nächster Schritt.
+
+Wenn du eine Aufgaben-App ausprobieren möchtest, die um diese Philosophie herum gebaut ist, ist Dawny frei zu testen auf TestFlight.
+
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren des Versuchens — und des Aufgebens — aller Produktivitäts-Apps auf dem Markt gebaut.
+
+Möchtest du eine Aufgaben-App ausprobieren, die um diese Philosophie herum gebaut ist?
+
+Dawny ist frei zu testen auf TestFlight — keine Verpflichtung erforderlich.
+
+Probiere Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/productivity-apps-adhd.md
+++ b/website/src/content/blog/de/productivity-apps-adhd.md
@@ -1,0 +1,136 @@
+---
+title: "Produktivitäts-Apps für ADHS: Was die meisten falsch machen"
+description: "Die meisten Produktivitäts-Apps scheitern bei ADHS-Gehirnen, weil sie Funktionen hinzufügen. Die eigentliche Lösung ist, die zu entfernen, die Schuldgefühle, Überbelastung und Vermeidung auslösen."
+pubDate: 2026-05-10
+---
+
+# Produktivitäts-Apps für ADHS: Was die meisten falsch machen
+
+> **Kurz gesagt:** Die meisten Produktivitäts-Apps scheitern bei Menschen mit ADHS aus dem gleichen Grund: Sie fügen Funktionen hinzu, um Probleme zu lösen, die durch Funktionen gar nicht zu lösen sind. Überfällige Markierungen, Erinnerungsstapel, Projekthierarchien und Streak-Tracker erhöhen die kognitive Belastung, ohne die eigentliche Herausforderung anzugehen — sich heute auf etwas konzentrieren, es zu Ende bringen und sich nicht schuldig fühlen über das, was man nicht geschafft hat.
+
+Du hast einen Ordner auf deinem Telefon. Vielleicht hast du ihn irgendwo auf dem zweiten oder dritten Bildschirm versteckt. Er ist voll mit Apps — Task Manager, Planer, Gewohnheits-Tracker — die alle gleich anfangen und gleich enden: mit hoffnungsvollem Tippen und stiller Aufgabe. Jede sah vielversprechend aus. Jede fühlte sich an, als könnte es dieses Mal funktionieren. Keine hat es getan.
+
+Das ist keine Geschichte über mangelnde Willenskraft oder Disziplin. Es ist eine nahezu universelle Erfahrung für Menschen, deren Gehirne anders funktionieren — und der Grund dafür, dass es immer wieder passiert, ist es wert, verstanden zu werden, denn es ist nicht deine Schuld. Es ist ein Designproblem. Der Entwickler hinter Dawny hatte diesen gleichen Ordner, hat jede große Task-App auf dem Markt ausprobiert und ist jedes Mal auf die gleiche Mauer gestoßen. Also hat er etwas anderes gebaut — für sein eigenes Gehirn, nicht für ein Produktivitätsideal, bei dem er sich niemals heimisch gefühlt hat.
+
+## Warum Standard-To-Do-Apps mit ADHS-Gehirnen kämpfen
+
+Standard-To-Do-Apps wurden um eine Reihe von Annahmen über die menschliche Planung und Ausführung herum designt. Diese Annahmen funktionieren für eine bestimmte Art von Gehirn. Für ADHS-Gehirne wirken sie sich aktiv negativ aus.
+
+**Zeitblindheit.** Eine der konsistentesten Erfahrungen von Menschen mit ADHS ist eine fundamental andere Beziehung zur Zeit. Nicht Faulheit, sondern eine neurologische Schwierigkeit, wahrzunehmen, wie weit entfernt zukünftige Fristen wirklich sind. Apps, die Fristen als ihr primäres Organisationsprinzip nutzen, erzeugen einen konstanten Strom von „Überfällig"-Benachrichtigungen für Aufgaben, die tatsächlich als entfernt wahrgenommen wurden, bis sie plötzlich nicht mehr entfernt waren. Der überfällige Stapel wächst schnell, und das ist kein moralisches Versagen.
+
+**Interessen-gesteuerte Motivation.** Forschungen, die im *Neuropsychology Review* veröffentlicht wurden, beschreiben ADHS nicht als generellen Aufmerksamkeitsmangel, sondern als Defizit in der Regulierung von Aufmerksamkeit. Speziell darin, Anstrengung bei Aufgaben aufzubringen, die nicht intrinsisch motivierend oder unmittelbar verstärkend sind. Eine Aufgabe, die nächste Dienstag fällig ist, erzeugt nicht für jedes Gehirn die gleiche Dringlichkeit. Langfristige Fristen wirken oft nicht als handlungsfähig.
+
+**Aus den Augen, aus dem Sinn.** Dieser Satz wird oft abfällig verwendet, aber für viele Menschen mit ADHS beschreibt er ein echtes kognitives Muster: Was physisch sichtbar und unmittelbar ist, konkurriert um Aufmerksamkeit mit allem anderen; Was drei Bildschirme tief in einer Projekthierarchie begraben ist, existiert einfach nicht. Ein großer Backlog ist unsichtbar. Was gerade auf dem Bildschirm ist, wird erledigt.
+
+**Entscheidungslähmung.** Öffne eine Aufgabenliste mit 60 Einträgen und du musst eine Entscheidung treffen, bevor du etwas angefangen hast: Welcher? Für ein Gehirn, das bereits mit der Aufgabeninitiierung kämpft, ist diese erste Entscheidung ein enormes Hindernis. Je größer die Liste, desto höher die Hürde zum Anfangen.
+
+## Was die meisten „ADHS-freundlichen" Apps machen — und warum das nach hinten losgeht
+
+Suche nach „beste App für ADHS-Produktivität" und du findest eine bekannte Kategorie von Empfehlungen. Apps mit Farbcodierung, Streaks, Gamification, Punktsystemen und mehrstufigen Erinnerungsplänen. Die Logik ist intuitiv: ADHS-Gehirne reagieren auf Neuheit und Belohnung, also baue Neuheit und Belohnung in die App ein.
+
+Das Problem ist, dass dieser Ansatz eine Taktik für kurzfristige Engagement als langfristiges System behandelt. Und in der Praxis erzeugt jede dieser Funktionen ihre eigene Art von Reibung.
+
+**Streaks** sind besonders destruktiv. Ein Streak-System belohnt Konsistenz, indem es jeden Fehler katastrophal fühlen lässt. Du verlierst deinen Streak, du hast ihn „gebrochen", du bist wieder bei Null. Für jemanden, der bereits mit einem inneren Kritiker kämpft, der jede verpasste Aufgabe als persönliches Versagen darstellt, ist ein Streak-Counter, der rot wird, nicht motivierend. Es ist das Gegenteil. Es fügt eine weitere Sache hinzu, sich schlecht über zu fühlen, und einen weiteren Grund, die App zu meiden.
+
+**Mehr Erinnerungen** erzeugen Benachrichtigungsmüdigkeit. Nach der dritten oder vierten Warnung für die gleiche unerledigt Aufgabe werden die Benachrichtigungen zur Hintergrundmusik. Sie werden automatisch weggeklappt und lösen keine Aktion mehr aus. Das beabsichtigte Signal ertrinkt in seiner eigenen Wiederholung.
+
+**Funktionskomplexität** erzeugt Entscheidungslähmung auf App-Ebene. Wenn das Hinzufügen einer Aufgabe die Wahl eines Projekts, einer Priorität, eines Fälligkeitsdatums, eines Tags und einer geschätzten Dauer erfordert, ist die Reibung beim Erfassen einer Idee hoch genug, dass viele Menschen es einfach nicht tun. Das System, das helfen sollte, wird zur Sache, für die du Energie brauchst.
+
+## Was wirklich hilft — und warum es das Gegenteil von dem ist, was du erwarten würdest
+
+Das Muster, das die Reibung für viele ADHS-Gehirne tatsächlich reduziert, ist nicht Addition. Es ist Subtraktion.
+
+**Weniger gleichzeitig sichtbare Aufgaben** bedeutet weniger Entscheidungen, bevor du anfängst. Wenn du drei Dinge auf deiner Liste heute siehst, ist die Wahl zwischen ihnen handhabbar. Wenn du vierzig siehst, ist die erste Aufgabe, diese vierzig auf drei zu reduzieren, und viele Menschen kommen über diesen Schritt nie hinaus.
+
+**Keine Überfällig-Markierungen** bedeuten keinen Schuldauslöser. Wenn eine Aufgabe, die du gestern nicht erledigt hast, heute morgens nicht als „fehlgeschlagen" markiert ist, wenn du die App öffnest, sinken die emotionalen Kosten des App-Öffnens erheblich. Die Aufgabe ist immer noch da, falls sie wichtig ist, aber sie bestraft dich nicht dafür, menschlich zu sein.
+
+**Ein täglicher Reset** bedeutet, jeden Morgen eine frische Entscheidung zu treffen, nicht einen erbten Stapel. Statt gestrige unvollendete Aufgaben als Schuld voranzutragen, schaust du auf deinen Backlog und wählst, was heute wichtig ist. Das ist eine fundamental andere Beziehung zu deiner Aufgabenliste, es ist eine tägliche Entscheidung, keine wachsende Verpflichtung.
+
+**Ein kleiner täglicher Fokus** schafft ein klares Erfolgssignal. „Habe ich meine drei Dinge gemacht?" ist eine Frage mit einer echten Antwort. „Habe ich Fortschritt auf meiner 47-Einträge-Liste gemacht?" ist das nicht.
+
+Dies sind keine Funktionen, die für ADHS designt sind. Es sind Design-Entscheidungen, die die Elemente entfernen, die die meiste kognitive und emotionale Reibung erzeugen. Für jeden, aber besonders für Gehirne, die mit genau den Schmerzpunkten kämpfen, auf die diese Elemente abzielen.
+
+## Die wichtigste Funktion jeder ADHS-Task-App — und sie ist gar keine Funktion
+
+Hier ist die Frage, die am meisten zählt, wenn man eine Task-App bewertet: Was macht sie mit Aufgaben, die du nicht erledigt hast?
+
+Wenn unerledigte Aufgaben zu roten Überfällig-Einträgen werden, bestraft die App genau das Muster. Aufgabeninitiierungsversagen, unterschätztes Zeitbudget, Ablenkung. Das, was ADHS häufig macht. Jeden Tag, wenn du nach einem harten Tag die App öffnest, triffst du auf eine Liste von Dingen, bei denen du „versagt" hast.
+
+Das ist, warum Standard-To-Do-Listen so viele Menschen scheitern lässt: Das Design geht davon aus, dass Versagen zu flaggen motivierend ist, während es für die meisten Menschen einfach Vermeidung auslöst. Die App wird zur Sache, vor der du dich versteckst, was genau das Gegenteil ihres Zwecks ist.
+
+Eine App, die unerledigte Aufgaben ohne Verurteilung zurückzusetzt, keine roten Markierungen, keine gebrochenen Streaks, keine Umplanungs-Anforderungen, ist verständnisvoller für die Art, wie ADHS tatsächlich funktioniert. Task-Schulden sammeln sich nicht an, weil das System so designt ist, dass es das nicht zulässt.
+
+Zwei Personen, die Dawny getestet haben, drücken es deutlich aus:
+
+> „Ich nutze Dawny wirklich jeden Morgen. Der tägliche Reset gibt mir den Freiraum, den ich brauche."
+, Dawny Beta-Tester
+
+> „Seit ich Dawny nutze, habe ich keine Angst mehr, meine Aufgabenliste anzusehen. Weil die Aufgaben, die ich ohnehin nicht erledige, einfach nicht mehr angezeigt werden."
+, Dawny Beta-Tester
+
+Dieses zweite Zitat ist bedeutsam. Keine Angst, deine Aufgabenliste anzusehen. Das sollte die Basiserwartuung für jedes Produktivitätswerkzeug sein, und für viele Menschen ist es das nicht.
+
+## Was du in einer Task-App suchst (wenn dein Gehirn so funktioniert)
+
+Das ist keine Ranking-Liste von Apps. Es ist eine Reihe von Fragen, die es wert ist, zu stellen, bevor du dich für ein System entscheidest. Weil die richtige Antwort davon abhängt, wie dein Gehirn tatsächlich funktioniert, nicht davon, welche App die besten Bewertungen hat.
+
+**1. Wie geht sie mit Aufgaben um, die du nicht erledigt hast?**
+Markiert sie diese als überfällig, oder lässt sie dich jaden Tag eine frische Entscheidung treffen? Die Antwort sagt viel über die zugrundeliegende Philosophie.
+
+**2. Wie viele Einträge sind auf einmal in der Standard-Ansicht sichtbar?**
+Eine Standard-Ansicht, die dein gesamte Task-Verlauf zeigt, ist eine andere Design-Entscheidung als eine, die zeigt, was du für heute gewählt hast. Keine ist grundsätzlich falsch, aber eine wird besser für bestimmte Gehirne funktionieren.
+
+**3. Bestraft sie „Fehlschläge"?**
+Verpasste Fristen, gebrochene Streaks, unvollständige tägliche Ziele. Registriert die App diese als Fehlschläge und signalisiert sie visuell? Für manche Menschen ist dieses Signal nützlich. Für andere ist es der Grund, warum sie die App nicht mehr öffnen.
+
+**4. Kannst du schnell erfassen, ohne komplexe Metadaten?**
+Je niedriger die Reibung beim Hinzufügen einer Aufgabe, desto wahrscheinlicher ist es, dass du sie tatsächlich hinzufügst, wenn die Idee dir kommt. Eine App, die ein Projekt, einen Tag und ein Fälligkeitsdatum für jeden neuen Eintrag erfordert, erzeugt eine Hürde, die den Zweck der Erfassung aufhebt.
+
+**5. Fühlt sich das Öffnen der App besser oder schlechter an?**
+Das ist der ehrlichste Test. Bevor du etwas anderes überprüfst, bemerke deine erste Reaktion, wenn du deinen Task Manager öffnest. Wenn es Erleichterung ist, funktioniert das System für dich. Wenn es Beklemmung ist, funktioniert das System gegen dich, unabhängig davon, wie viele Funktionen es hat.
+
+## Eine Anmerkung zu dem, was Apps nicht können
+
+Das ist es wert, klar zu sagen: Keine Task-App löst ADHS. Nicht Dawny, nicht irgendeine andere App, nicht die, die du noch nicht ausprobiert hast.
+
+ADHS ist eine neurodevelopmentale Störung, die die exekutiven Funktionen auf Weise beeinflusst, die über Task Management hinausgehen. Externe Verantwortlichkeit, ein Freund, ein Coach, ein Body-Doubling-Partner helfen oft mehr als irgendeine App. Therapie, besonders Verhaltenstherapie, die für ADHS angepasst ist, adressiert Muster, die keine Benutzeroberfläche berühren kann. Für viele Menschen ist Medikation ein bedeutsamer Teil dessen, was tägliches Funktionieren möglich macht. Dies sind keine Alternativen zu einer guten App; sie sind die Dinge, die wirklich am meisten zählen.
+
+Eine App ist ein Werkzeug. Ein gutes entfernt Reibung. Ein schlechtes fügt sie hinzu. Aber selbst das beste Werkzeug ersetzt nicht die Unterstützungsstrukturen, die Menschen mit ADHS tatsächlich dabei helfen, zu gedeihen. Wenn du erheblich kämpfst, sprich bitte mit jemandem, der dir wirklich helfen kann, nicht nur eine weitere App herunterladen.
+
+## FAQ
+
+### Was ist die beste To-Do-Liste-App für ADHS?
+
+Es gibt keine einzelne beste App, weil ADHS sich bei verschiedenen Menschen unterschiedlich manifestiert. Der wichtigste Faktor ist nicht Funktionen. Es ist, wie die App Aufgaben handhabt, die du nicht erledigt hast. Eine App, die unerledigte Aufgaben zurücksetzt, ohne sie als Fehlschläge zu markieren, reduziert den Schuldgefühls- und Vermeidungs-Zyklus, der viele Standard-Apps für ADHS-Gehirne unhaltbar macht. Suche nach Einfachheit, einer begrenzten täglichen Ansicht und keinen bestrafenden Streak-Systemen.
+
+### Warum funktionieren To-Do-Listen nicht für ADHS?
+
+Die meisten To-Do-Listen wurden als Erfassungswerkzeuge designt — Orte zum Speichern von allem — nicht als Entscheidungssysteme. Für ADHS-Gehirne löst eine lange Liste Entscheidungslähmung aus, bevor auch nur eine Aufgabe begonnen wird. Die Überfällig-Markierungen und angesammelter Backlog erzeugen eine Schuldreaktion, die zu Vermeidung führt. Die Liste wird zum Problem statt zur Lösung. Der Zeigarnik-Effekt — die Tendenz des Gehirns, bei unvollendeten Aufgaben zu verweilen — bedeutet, dass ein großer Backlog mentale Bandbreite beansprucht, selbst wenn du nicht darauf schaust.
+
+### Sind Produktivitäts-Apps hilfreich für ADHS?
+
+Sie können es sein, wenn sie die richtige Passung sind. Der Schlüssel ist, eine App zu wählen, deren Design dazu passt, wie dein Gehirn tatsächlich funktioniert, statt wie du denkst, dass es funktionieren sollte. Apps, die mehr Funktionen, mehr Erinnerungen und mehr Komplexität hinzufügen, erhöhen oft die kognitive Belastung statt sie zu reduzieren. Eine einfachere App, die begrenzt, was sie zeigt, täglich zurücksetzt und Schuldauslöser entfernt, kann nachhaltiger sein als eine mächtige, die schnell überwältigend wird.
+
+### Wie sollte jemand mit ADHS seine Aufgaben organisieren?
+
+Der praktischste Ansatz ist die Trennung von Erfassung und täglichem Fokus. Behalte einen Backlog für alles, das du eines Tages vielleicht machen möchtest. Filtere ihn nicht zu hart beim Punkt der Erfassung. Jeden Tag wählst du eine kleine Anzahl von Dingen (drei ist eine häufige Empfehlung), auf die du dich tatsächlich konzentrieren wirst. Versuche nicht, direkt vom ganzen Backlog zu arbeiten. Überprüfe ihn gelegentlich, um irrelevante Einträge zu entfernen. Das Ziel ist ein System, bei dem deine tägliche Ansicht so klein ist, dass das Öffnen sie keine große Entscheidung erfordert, bevor du etwas angefangen hast.
+
+### Welche Funktionen sollte eine ADHS-Produktivitäts-App haben?
+
+Die nützlichere Frage ist: Welche Funktionen sollte sie nicht haben? Verzichte auf Streaks, komplexe Projekthierarchien, Überfällig-Markierungen, die sich häufen, und Erinnerungssysteme, die nicht leicht stummgeschaltet werden können. Was tatsächlich nützlich ist: schnelle Aufgabenerfassung mit minimalen erforderlichen Feldern, eine begrenzte tägliche Fokus-Ansicht getrennt vom ganzen Backlog, und eine Möglichkeit, unerledigte Aufgaben zu handeln, die keine Schuldgefühle erzeugt. Wie Dawny mit funktionsreichen Alternativen vergleicht, zeigt, wie viel davon auf Design-Philosophie statt auf Feature-Anzahl ankommt.
+
+## Fazit
+
+Der häufigste Fehler im Produktivitäts-App-Design für ADHS-Gehirne ist nicht ein fehlende Funktion. Es ist die Anwesenheit von Funktionen, die genau die kognitive und emotionale Reibung erzeugen, die sie beheben sollten. Mehr Erinnerungen erzeugen Vermeidung. Streaks erzeugen Angst. Überfällig-Markierungen erzeugen Schuldgefühle. Komplexe Strukturen erzeugen Lähmung. Das Muster verstärkt sich, bis die App in jenem Ordner landet neben jeder anderen, die du je versucht hast.
+
+Der Entwickler hinter Dawny hat die App gebaut, weil er ADHS hat und immer wieder auf diese gleiche Mauer stößt. Nicht um ein Produktivitätsprodukt zu bauen. Um aufzuhören, seine eigene Aufgabenliste zu fürchten. Das Resultat ist nicht eine App mit ADHS-Funktionen. Es ist eine App, bei der die üblichen Quellen von Reibung entfernt wurden. Aufgaben setzen sich zurück, statt überfällig zu werden. Die tägliche Ansicht ist bewusst klein. Nichts bestraft dich dafür, menschlich zu sein.
+
+Wenn du eine Task-App probieren möchtest, die um diese Philosophie gebaut ist, ist Dawny kostenlos auf TestFlight zu testen.
+    
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren des Ausprobierens — und Aufgebens — jeder Produktivitäts-App auf dem Markt gebaut.
+  
+Möchtest du eine Task-App probieren, die um diese Philosophie gebaut ist?
+ 
+Dawny ist kostenlos auf TestFlight zu testen — keine Verpflichtung notwendig.
+ 
+Probiere Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/three-most-important-tasks.md
+++ b/website/src/content/blog/de/three-most-important-tasks.md
@@ -1,0 +1,123 @@
+---
+title: "Die 3 wichtigsten Aufgaben: Wie du entscheidest, woran du heute arbeiten möchtest"
+description: "Die MIT-Methode (Most Important Tasks) beschränkt deinen täglichen Fokus auf 3 Aufgaben. Lerne, warum sie funktioniert, wie du deine MITs jeden Morgen wählst und was du tust, wenn du sie nicht schaffst."
+pubDate: 2026-05-10
+---
+
+> **Kurz gesagt:** Die Methode der 3 wichtigsten Aufgaben (MIT, Most Important Tasks) fordert dich auf, jeden Morgen drei Aufgaben auszuwählen, zu deren Erledigung du dich verpflichtest — und nur drei. Diese Beschränkung zwingt zur Priorisierung, reduziert Entscheidungsfatigue während des Tages und schafft ein klares Erfolgssignal: Wenn du deine drei Aufgaben schaffst, war der Tag produktiv. Alles andere ist ein Bonus.
+
+Du setzt dich zum Arbeiten hin, öffnest deine Aufgaben-App und siehst 47 Einträge. Du verbringst 20 Minuten damit, herauszufinden, wo du anfangen sollst. Du wählst etwas Einfaches. Den ganzen Tag über fühlst du dich irgendwie unproduktiv — obwohl du technisch gesehen einiges erledigt hast. Kommt dir bekannt vor?
+
+Das ist kein Zeitmanagement-Fehler. Das ist ein Prioritätsproblem. Die meisten Aufgaben-Systeme sind dafür ausgelegt, alles zu erfassen, was du je tun möchtest, aber sie bieten fast keine Hilfe bei der Entscheidung, worauf deine Aufmerksamkeit heute wirklich abzielen sollte. Das Ergebnis ist ein tägliches Gefühl von Überwältigung, Vermeidung und das naggende Gefühl, hart zu arbeiten, ohne voranzukommen. Die MIT-Methode ist eine direkte Antwort genau auf dieses Problem — und warum sie funktioniert, hat weniger mit Willenskraft zu tun als damit, wie das menschliche Gehirn Entscheidungen verarbeitet.
+
+## Was ist die MIT-Methode?
+
+Die MIT-Methode — Kurzform für Most Important Tasks (Wichtigste Aufgaben) — ist eine tägliche Planungspraxis, die dich auffordert, jeden Morgen die drei Aufgaben zu identifizieren, die dir heute am wichtigsten sind. Nicht die zehn Dinge, die du hoffentlich schaffst. Nicht dein komplettes Backlog. Drei. Du verpflichtest dich zu diesen drei Aufgaben, bevor du deinen Posteingang öffnest, bevor du Slack checkst, bevor der Tag dich woanders hin trägt.
+
+Die Methode wird meist Leo Babauta zugeschrieben, der sie durch seinen Zen Habits-Artikel über die Beschränkung deiner täglichen Aufgaben seit Ende der 2000er Jahre populär machte. Die Grundregel ist einfach: Wähle drei MITs aus, bevor du mit der Arbeit beginnst, notiere sie separat von deiner größeren Aufgabenliste und behandle sie als deine nicht verhandelbaren Verpflichtungen für den Tag. Alles andere ist optional. Weitere Perspektiven zur Drei-Aufgaben-Methode findest du in diesem Artikel über die Regel der Drei und in diesem Leitfaden zu den 3 wichtigsten Aufgaben.
+
+## Warum Drei — Nicht Fünf, Nicht Eine?
+
+Die Zahl Drei ist nicht willkürlich. Sie ist ein kognitives Sweet Spot. Und das Verstehen, warum, hilft dir, dich an die Methode zu halten, auch an Tagen, an denen du denkst, du solltest mehr schaffen.
+
+**Warum „eine" zu viel Druck aufbaut.** Eine einzelne tägliche Priorität ist ein würdiges Ideal für bestimmte Rahmenwerke, aber in der Praxis schafft sie ein binäres Ergebnis: Entweder hattest du einen guten Tag oder nicht — es gibt kein Mittelding. Eine Aufgabe ist auch eher zu groß (und wird nie erledigt) oder zu klein (und fühlt sich nicht bedeutungsvoll an). Der Druck einer einzelnen Make-or-Break-Verpflichtung kann selbst Vermeidung verursachen.
+
+**Warum „fünf" oft zu „einige von fünf" wird.** Die Forschung über Entscheidungsfatigue — das dokumentierte Phänomen, dass die Qualität von Entscheidungen nach einer langen Reihe von Entscheidungen abnimmt — deutet darauf hin, dass längere Listen nicht nur nicht helfen: Sie schaden aktiv. Studien haben gezeigt, dass Menschen später am Tag schlechtere Entscheidungen treffen, wenn ihre kognitiven Ressourcen aufgebraucht sind. Dasselbe Prinzip gilt für Aufgabenlisten: Je länger die Liste, desto mehr Entscheidungen verschiebst du, und desto unwahrscheinlicher ist es, dass du etwas davon umsetzt. Fünf Punkte reichen aus, um die Vermeidung auszulösen, die mit Entscheidungsfatigue verbunden ist.
+
+**Warum Drei die Goldilocks-Zahl ist.** Drei ist klein genug, um tatsächlich im Kopf zu behalten, groß genug, um einen produktiven Tag darzustellen, und strukturiert genug, um echte Triage zu erzwingen. Wenn du nur drei Slots hast, kannst du nicht alles einschließen, was sich vaguely wichtig anfühlt. Du musst entscheiden, was wirklich zählt. Diese Beschränkung ist der ganze Punkt.
+
+## Wie du deine drei MITs wählst
+
+Der Auswahlprozess ist genauso wichtig wie die Zahl. Schlecht gemacht, wird die MIT-Auswahl zu einer anderen Form der Vermeidung. Du verbringst 30 Minuten damit, deine Liste zu optimieren, statt zu arbeiten. Richtig gemacht, dauert es unter fünf Minuten und gibt dir eine klare Richtung für den ganzen Tag.
+
+**Schritt 1: Überprüfe dein Backlog kurz. Aber verliere dich nicht darin.** Scanne dein tägliches Planungssystem oder deine Aufgabenliste, um dich an das zu erinnern, das auf dich wartet. Das ist eine Übersicht, keine tiefe Analyse. Gib dir ein Zeitlimit, maximal zwei Minuten.
+
+**Schritt 2: Stelle dir eine Klärungsfrage.** „Wenn ich heute sonst nichts tue, welche drei Dinge würden diesen Tag lohnenswert machen?" Diese Frage filtert das Rauschen heraus. Dringlichkeit, Schuldgefühle und Gewohnheit sind starke Kräfte, die dich zu Beschäftigungsarbeit ziehen. Die Frage zieht dich zurück zu dem, was wirklich zählt.
+
+**Schritt 3: Schreibe deine MITs separat von deinem Backlog auf.** Markiere oder kennzeichne sie nicht einfach in deiner bestehenden Aufgaben-App. Die physische oder visuelle Trennung ist wichtig. Sie schafft eine saubere, kleine Liste, die die heutigen Verpflichtungen darstellt, getrennt von allem anderen, das du eines Tages tun könntest.
+
+**Schritt 4: Beginne mit der schwierigsten MIT zuerst.** Brian Tracys Prinzip „Iss den Frosch zuerst" gilt direkt hier: Wenn du deine schwierigste oder am meisten gefürchtete Aufgabe zuerst erledigst, fühlt sich alles danach leichter an, und du hast schon das wichtigste Ergebnis des Tages gesichert, bevor deine Energie und Konzentration zu sinken beginnen. Mit der einfachen MIT zu beginnen fühlt sich produktiv an, führt aber oft dazu, dass die schwierigste nie erledigt wird.
+
+## Was du mit Allem anderen tust
+
+Alles, das nicht auf deiner MIT-Liste steht, geht ins Backlog. Ein separater Wartebereich für Aufgaben, die real und gültig sind, aber nicht Verpflichtung von heute. Das Backlog ist keine Fehlerzone. Es ist nicht eine Liste von Dingen, die du vernachlässigst. Es ist ein Parkplatz, ein sicherer Ort für Aufgaben, bis sie auf deiner Prioritätsliste nach oben rücken oder relevant werden.
+
+Diese Trennung ist die strukturelle Lösung, die die MIT-Methode langfristig funktionieren lässt. Wenn dein Backlog klar von deinen täglichen Verpflichtungen getrennt ist, hörst du auf, dich schuldig zu fühlen, wann immer du eine unvollendete Aufgabe siehst. Das Backlog sagt „irgendwann". Deine MIT-Liste sagt „heute". Das sind sehr unterschiedliche Gespräche, und sie sollten nicht am gleichen Ort stattfinden.
+
+Die Aufgaben, die du nie als MITs wählst, werden sich schließlich von selbst offenbaren — sie sind nicht wichtig genug, um etwas zu tun. Das ist nützliche Information, keine Niederlage.
+
+## Was passiert, wenn du deine drei MITs nicht schaffst?
+
+Das ist der Punkt, an dem die meisten Produktivitätsratschläge zusammenbrechen. Die MIT-Methode sagt dir, drei Aufgaben auszuwählen. Aber fast nichts befasst sich damit, was passiert, wenn eine von ihnen nicht erledigt wird. Die Standardantwort ist implizit: Du fühlst dich schlecht, du verschleppst sie, du fügst sie zur morgigen Liste mit einer mentalen Notiz der Enttäuschung hinzu.
+
+Genau diese Ansammlung ist der Grund, warum deine To-Do-Liste sich überwältigend anfühlt. Unvollendete Verpflichtungen sitzen nicht einfach in deiner App. Sie sitzen hinten in deinem Kopf. Der Zeigarnik-Effekt, ein gut erforschtes psychologisches Phänomen, beschreibt, wie ungelöste Aufgaben das Arbeitsgedächtnis belegen und eine persistente niedriggradige kognitive Last erzeugen. Addiere genug von ihnen, und die Liste selbst wird etwas, das du vermeidest.
+
+Ein anderes Modell: Was, wenn eine unvollendete MIT einfach zu deinem Backlog zurückkehrt. Ohne eine „Überfällig"-Bezeichnung, ohne ein rotes Badge, ohne Schuldgefühle? Es ist keine fehlgeschlagene Verpflichtung. Es ist eine unentschiedene Aufgabe, die auf den richtigen Tag wartet. Du wählst morgen neu, ob sie auf die MIT-Liste gehört. Wenn sie immer wieder übersprungen wird, sagt dir das etwas Wichtiges über das, ob du sie wirklich tun musst.
+
+Ein Dawny-Beta-Tester beschrieb es so:
+
+> „Dawny nutzt die gleiche Logik, die ich mit verpassten Anrufen verwende: 'Wenn es wirklich wichtig wäre, würden sie zurückrufen.'" — Dawny-Beta-Tester
+
+Diese Ausdrucksweise erfasst etwas Reales. Nicht jede Aufgabe, die sich um 9 Uhr morgens wichtig anfühlte, ist es wirklich. Der Reset löscht die Aufgabe nicht. Er gibt dir eine weitere Chance zu entscheiden, ob sie auf die MIT-Liste von morgen gehört oder ob sie ins Archiv gehört.
+
+## Die MIT-Methode in der Praxis — Ein echtes Beispiel
+
+Es ist Dienstagmorgen. Du hast ein Backlog von 34 Aufgaben, das sich über Arbeitsprojekte, persönliche Besorgungen und eine halbfertige Idee erstreckt, die du vor drei Wochen hinzugefügt hast. Du verbringst zwei Minuten damit, es zu scannen. Dann stellst du dir die Frage.
+
+Deine drei MITs für den Tag:
+
+- Den überarbeiteten Vertrag an den Kunden senden (wichtigste, am meisten gefürchtete)
+
+- Den Gliederung für die Team-Präsentation schreiben
+
+- Den Zahnarzttermin vereinbaren, den du seit zwei Monaten aufschiebst
+
+Du schreibst diese irgendwo separat auf. Ein Klebezettel, eine fokussierte Tagesansicht in deiner App, ein kleines Notizbuch. Dein Backlog existiert immer noch. Du hast die anderen 31 Aufgaben nicht gelöscht. Du hast nur erklärt, dass diese drei das Spiel von heute sind.
+
+Du fängst mit dem Vertrag an. Es dauert länger als erwartet. 90 Minuten statt 45. Bis du es fertigstellt, fühlst du dich wirklich stolz. Du arbeitest die Präsentationsgliederung nach dem Mittagessen durch. Um 16 Uhr merkst du, dass du den Zahnarzttermin nicht vereinbart hast. Du wirst abgelenkt, der Tag endet, und du hast es nicht geschafft.
+
+In einem traditionellen System ist „Zahnarzt vereinbaren" jetzt überfällig. Es trägt ein rotes Label. Morgen sitzt es neben neuen Aufgaben und konkurriert um Aufmerksamkeit, die es wahrscheinlich nicht verdient.
+
+Im MIT-Modell kehrt „Zahnarzt vereinbaren" zu deinem Backlog zurück. Morgenfrüh wählst du deine drei MITs erneut. Ist die Vereinbarung eines Zahnarzttermins eines der drei Dinge, die morgen lohnenswert machen würden? Wahrscheinlich nicht. Aber du wirst es dann entscheiden. Wenn du es sechs weitere Male übersprungen hast, weißt du, dass es entweder nicht wichtig ist oder wichtig genug, um es endlich an erste Stelle zu setzen.
+
+Zwei von drei MITs erledigt ist nach den meisten Maßstäben ein produktiver Tag. Die MIT-Methode gibt dir diese Lesung klar. Eine Liste von 34 Aufgaben nicht.
+
+## Häufig gestellte Fragen
+
+### Was sind die wichtigsten Aufgaben (MITs) in der Produktivität?
+
+MITs — Most Important Tasks (Wichtigste Aufgaben) — sind die spezifischen Aufgaben, zu deren Erledigung du dich an einem bestimmten Tag verpflichtest, die du bewusst jeden Morgen vor Arbeitsbeginn wählst. Das Konzept, populär gemacht von Leo Babauta von Zen Habits, begrenzt deine täglichen Verpflichtungen auf drei Punkte. Die Beschränkung zwingt zur Priorisierung und schafft ein klares, ehrliches Maß dafür, ob der Tag produktiv war.
+
+### Wie wähle ich meine Top 3 Aufgaben für den Tag?
+
+Beginne mit einem kurzen Scan deines Backlogs, dann stelle dir die Frage: „Wenn ich heute sonst nichts tue, welche drei Dinge würden diesen Tag lohnenswert machen?" Schreibe deine drei Antworten separat von deiner vollständigen Aufgabenliste auf. Widerstehe dem Drang, nur nach Dringlichkeit zu ordnen. Dringend ist nicht dasselbe wie wichtig. Und fange immer mit der schwierigsten der drei zuerst an.
+
+### Was, wenn ich meine 3 MITs früh fertig mache?
+
+Das ist ein gutes Problem zu haben. Und es passiert öfter, als die meisten Menschen erwarten, sobald sie realistisch MITs wählen. Wenn du früh fertig wirst, gehe zurück zu deinem Backlog und wähle, woran du als nächstes arbeiten möchtest. Du könntest eine vierte Aufgabe wählen, oder du könntest aufhören. In jedem Fall ist der Tag bereits ein Erfolg. Die verbleibende Zeit ist ein Bonus.
+
+### Sollte ich meine MITs morgens machen?
+
+Die Auswahl deiner MITs am Morgen wird fast universell empfohlen. Bevor dein Posteingang, bevor Besprechungen, bevor der Tag seine eigene Agenda setzt. Ob du sie morgens bearbeitest, hängt davon ab, wann deine Peak-Focus-Stunden fallen. Wenn du deine beste intensive Arbeit am Nachmittag machst, wähle deine MITs morgens und plane sie für den Nachmittag. Die Auswahl und die Ausführung sind separate Schritte.
+
+### Wie unterscheidet sich die MIT-Methode vom Time Blocking?
+
+Time Blocking weist bestimmten Arbeiten spezifische Stunden zu. Die MIT-Methode weist Priorität bestimmten Aufgaben zu, ohne notwendigerweise vorzuschreiben, wann du sie tust. Die beiden Ansätze sind kompatibel und oft komplementär: Du kannst deine MITs als Time Blocking planen. Aber die MIT-Methode ist einfacher zum Anfangen und erfordert keine Kalenderkontrolle, was sie an Tagen, an denen sich Pläne ändern, widerstandsfähiger macht.
+
+## Fazit
+
+Die Methode der 3 wichtigsten Aufgaben funktioniert nicht, weil sie mehr von dir verlangt, sondern weil sie weniger verlangt. Weniger Scannen, weniger entscheiden, weniger Schuld. Indem du deine tägliche Verpflichtung auf drei Aufgaben beschränkst, zwingst du dich zur ehrlichen Priorisierung, reduzierst die Entscheidungsfatigue, die deine Energie erschöpft, bevor du überhaupt angefangen hast, und schaffst ein System, das dir klar sagt, wann der Tag lohnenswert war.
+
+Die Forschung über Entscheidungsfatigue und die Psychologie unvollendeter Aufgaben weisen beide in die gleiche Richtung: Kleinere, durchdachte Listen übertreffen große, umfassende. Nicht weil ehrgeizige Menschen lange Listen nicht bewältigen können, sondern weil kein Gehirn es kann. Die MIT-Methode funktioniert mit der Art und Weise, wie Aufmerksamkeit und Motivation tatsächlich funktionieren, anstatt zu verlangen, dass du sie mit Disziplin überwindest.
+
+Das letzte Stück ist das, was mit den Aufgaben passiert, die du nicht fertigmachst. Ein System, das sie rot macht und sie überfällig nennt, funktioniert gegen dich. Ein System, das sie leise in dein Backlog zurückbringt, ohne Anklage. Das dir erlaubt, morgen mit frischen Augen erneut zu wählen. Das heißt nicht, die Latte senken. Das ist ehrlich gegenüber der Tatsache, dass sich Prioritäten ändern und Tage endlich sind.
+
+Wenn du eine Aufgaben-App testen möchtest, die um diese Philosophie herum gebaut ist, ist Dawny kostenlos auf TestFlight verfügbar.
+
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren des Versuchens — und Aufgebens — jeder Produktivitäts-App auf dem Markt entwickelt.
+
+Möchtest du eine Aufgaben-App testen, die um diese Philosophie herum gebaut ist?
+
+Dawny ist kostenlos auf TestFlight verfügbar — keine Verpflichtung nötig.
+
+Probiere Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/two-list-system-backlog.md
+++ b/website/src/content/blog/de/two-list-system-backlog.md
@@ -1,0 +1,123 @@
+---
+title: "Das Zwei-Listen-System: Wie du einen Backlog verwaltest, ohne darin unterzugehen"
+description: "Das Zwei-Listen-System trennt alles, was du vielleicht tun könntest, von dem, was du heute machst. Erfahre, wie es Aufgabenschulden vermeidet und wie du es einrichtest."
+pubDate: 2026-05-10
+---
+
+# Das Zwei-Listen-System: Wie du einen Backlog verwaltest, ohne darin unterzugehen
+
+> **Kurz beantwortet:** Das Zwei-Listen-System teilt deine Aufgaben in zwei deutliche Listen: einen Backlog (alles, was du irgendwann tun könntest) und eine Daily-Focus-Liste (die kleine Menge, auf die du dich heute konzentrierst). Aufgaben wechseln nur durch eine bewusste tägliche Entscheidung vom Backlog zur Daily Focus — nicht durch eine Deadline, nicht automatisch. Diese Trennung verhindert Überwältigung und beseitigt Aufgabenschulden, bevor sie sich ansammeln können.
+
+Du hast eine Liste. Alles ist darauf — die Präsentation, die bis Freitag fällig ist, der Zahnarzttermin, den du immer wieder aufschiebst, das Buch, das du lesen möchtest, die Rechnung, die du versenden musst, das Geburtstagsgeschenk, das du noch nicht gekauft hast. Sie alle sitzen zusammen, unterschiedslos, fordern alle gleichzeitig deine Aufmerksamkeit. Du scrollst durch die Liste. Du fühlst dich überfordert. Du schließt die App, ohne irgendetwas zu tun. Das Problem ist nicht, dass du zu viele Aufgaben hast. Das Problem ist, dass du „Dinge, die ich irgendwann tun könnte" mit „Dinge, die ich heute tue" vermischst — und genau diese Vermischung verwandelt ein sinnvolles Werkzeug in eine Quelle von Angst.
+
+## Der Ursprung: Warren Buffetts Zwei-Listen-Methode
+
+Das Zwei-Listen-Konzept wird oft auf eine Geschichte mit Warren Buffett und seinem persönlichen Piloten Mike Flint zurückgeführt. Der Geschichte nach bat Buffett Flint, seine 25 wichtigsten Karriereziele aufzulisten, und dann die fünf wichtigsten zu markieren. Die zwei entstandenen Gruppen — die Top Five und die restlichen zwanzig — wurden zu zwei separaten Listen. Die zweite Liste war keine Backup-Prioritätswarteschlange. Buffett soll Flint gesagt haben, alles darauf aktiv zu vermeiden, bis die Top Five erledigt seien.
+
+Der Ursprung dieser Geschichte ist umstritten und möglicherweise erfunden, aber das Prinzip, das sie veranschaulicht, ist echt und gut belegt: Der Akt der Trennung von „alles, was ich tun könnte" von „worauf ich mich konzentriere" ist selbst produktiv. Nicht weil die zweite Liste verschwindet, sondern weil sie aus deinem unmittelbaren Entscheidungsfeld entfernt wird. Angewendet auf die tägliche Aufgabenverwaltung wird dies zu einer mächtigen strukturellen Gewohnheit. Für eine zusätzliche Perspektive, siehe diesen TIME-Artikel über Warren Buffetts Zwei-Listen-Strategie.
+
+Das Zwei-Listen-System für Aufgaben funktioniert nach der gleichen Logik: Eine Liste enthält alles, was du tun könntest. Die andere enthält nur das, was du heute machst. Die Disziplin liegt nicht im Tun, sondern darin, die beiden Listen getrennt zu halten.
+
+## Liste 1: Der Backlog
+
+Dein Backlog ist ein neutraler Ablageplatz für jede Aufgabe, Idee oder Verpflichtung, die irgendwann wichtig sein könnte. Er hat keine Größenbeschränkung. Nichts darauf ist überfällig. Nichts darauf trägt von Natur aus Dringlichkeit. Es ist einfach ein Erfassungspunkt. Ein Platz, wo Aufgaben warten, bis du dich entscheidest, sie in deinen Daily Focus zu befördern.
+
+Das ist eine wichtige mentale Verschiebung: Der Backlog ist kein Fehlerstapel. Eine Aufgabe, die drei Wochen in deinem Backlog sitzt, ist nicht ein Zeichen, dass du sie vermieden hast. Es ist ein Zeichen, dass du an jedem der letzten einundzwanzig Morgen deine Optionen angeschaut und dich entschieden hast, etwas anderes ist wichtiger. Das ist keine Prokrastination, das ist Prioritätsmanagement.
+
+Der Backlog funktioniert am besten, wenn du ihm genug vertraust, um frei zu erfassen. Wenn dir etwas in den Sinn kommt, füge es hinzu. Filtere nicht voraus, ob es „würdig" ist, dort zu sein. Das Filtern erfolgt, wenn du dein Daily Focus wählst, nicht wenn du Aufgaben hinzufügst. Eine wöchentliche fünfminütige Überprüfung hilft dabei, Aufgaben auszusortieren, die irrelevant geworden sind. Nicht um die Liste zu kontrollieren, sondern um sie als Quelle von Optionen nützlich zu halten.
+
+## Liste 2: Daily Focus
+
+Deine Daily-Focus-Liste ist, wo echte Verpflichtung stattfindet. Sie enthält nur die Aufgaben, die du dir selbst verpflichtet hast, heute zu bearbeiten. Nicht Aufgaben, die du bearbeiten musst, nicht Aufgaben, die technisch noch offen sind, nicht alles, das du gerne erreichen würdest, wenn der Tag perfekt lief. Die meisten Praktizierenden des Zwei-Listen-Systems empfehlen drei bis fünf Aufgaben als strikte Obergrenze.
+
+Die Anzahl ist wichtiger, als sie zunächst erscheinen mag. Forschung zu Entscheidungsmüdigkeit zeigt, dass je mehr Wahlmöglichkeiten wir haben, desto schlechter wird jede einzelne Entscheidung. Eine Daily-Focus-Liste mit fünfzehn Aufgaben ist überhaupt keine fokussierte Liste. Sie ist ein zweiter Backlog — kleiner, aber genauso lähmend. Drei bis fünf Aufgaben sind eine Beschränkung, die die echte Prioritätsfrage erzwingt: Wenn ich heute nur eine Handvoll Dinge erledigen könnte, welche spielen wirklich eine Rolle?
+
+Der Ansatz der drei wichtigsten Aufgaben für heute ist ein enger Verwandter dieser Idee, und die Überschneidung ist beabsichtigt. Ob deine tägliche Liste drei oder fünf Aufgaben hat, das Prinzip ist dasselbe: klein genug, dass jedes Element darauf eine echte Verpflichtung ist, keine Hoffnung.
+
+## Das tägliche Übertragungs-Ritual
+
+Das Zwei-Listen-System funktioniert nur, wenn es einen echten Prozess für das Verschieben von Aufgaben zwischen Listen gibt. Ohne ihn wird der Backlog vergessen und die Daily-Focus-Liste bleibt entweder leer oder wird im letzten Moment mit dem gefüllt, das sich gerade dringend anfühlte.
+
+Der Morgen ist der natürliche Moment für diese Übertragung. Bevor du deine E-Mails öffnest, bevor du deine Nachrichten checkst, verbring ein paar Minuten mit deinem Backlog und frage dich: Was ist heute wirklich wert, sich darauf zu verpflichten? Nicht „Was muss ich tun?", sondern „Was wähle ich zu tun?" Die Unterscheidung ist wichtig. Verpflichtung und Wahl fühlen sich unterschiedlich an, und die Daily-Focus-Liste sollte sich wie eine Wahl anfühlen.
+
+Ein paar Fragen helfen bei der Auswahl:
+
+- Welches Element auf dieser Backlog-Liste würde, wenn es heute erledigt wird, den Tag erfolgreich fühlen lassen?
+
+- Gibt es etwas mit einer echten Zeitbeschränkung, das ich nicht verschieben kann?
+
+- Was wollte ich schon lange tun, aber überspringe immer wieder, und ist heute der Tag, mich wirklich darauf zu verpflichten?
+
+Die abendliche Übertragung ist die andere Hälfte des Rituals. Am Ende des Tages räumst du die Daily-Focus-Liste auf. Abgeschlossene Aufgaben werden als erledigt markiert. Unvollendete Aufgaben kehren zum Backlog zurück. Nicht als Fehlschläge, sondern als unentschiedene Aufgaben. Sie treten dem Pool von Dingen bei, die du morgen vielleicht wählst. Das ist der Moment, der verhindert, dass sich Aufgabenschulden ansammeln.
+
+## Warum das Aufgabenschulden verhindert
+
+Aufgabenschulden entstehen, wenn unvollendete Aufgaben nicht in einen neutralen Zustand zurückkehren. Sie bleiben in deiner aktiven Liste, markiert als überfällig, färben sich rot, sammeln Gewicht an. Die meisten Task-Management-Apps basieren auf der Annahme, dass wenn du etwas nicht getan hast, du es immer noch tun musst, und die App sollte dich prominent und ausdauernd an diesen Fehlschlag erinnern.
+
+Das Zwei-Listen-System funktioniert nach einer anderen Annahme: Wenn du heute etwas nicht getan hast, hast du eine Entscheidung getroffen, bewusst oder unbewusst. Dass etwas anderes wichtiger war. Diese Entscheidung verdient Respekt, nicht Bestrafung. Die unvollendete Aufgabe geht als neutrale Option zurück zum Backlog. Morgen könntest du sie wählen. Oder auch nicht. Wenn du sie nie wählst, sagt dir dieses Muster schließlich etwas Wichtiges darüber, ob die Aufgabe überhaupt wichtig ist.
+
+> „Ich nutze Dawny tatsächlich jeden Morgen. Der tägliche Reset gibt mir den Raum, den ich brauche." — Dawny-Beta-Tester
+
+> „Fast alle Aufgaben, die automatisch archiviert wurden, waren einfach nicht wichtig genug. Ich habe keine einzige zurückgeholt." — Dawny-Beta-Tester
+
+Der emotionale Unterschied zwischen diesen beiden Ansätzen — Überfälligkeitsliste versus neutraler Backlog — ist erheblich. Eine Überfälligkeitsliste ist ein Protokoll deiner Mängel. Ein Backlog ist eine Bibliothek von Optionen. Du gehst mit den beiden völlig unterschiedlich um. Das Tagesplanungssystem, das aus dem Zwei-Listen-Ansatz entsteht, ist eines, das du tatsächlich beibehalten kannst, weil es dich nicht dafür bestraft, menschlich zu sein.
+
+## Wie du das heute einrichtest (ohne eine App)
+
+Das Zwei-Listen-System braucht kein bestimmtes Werkzeug. Ein Notizbuch mit zwei Abschnitten funktioniert perfekt. Die linke Seite ist dein Backlog. Die rechte Seite ist der heutige Focus. Du schreibst deine tägliche Liste jeden Morgen neu, indem du aus dem Backlog wählst. Am Ende des Tages streichst du durch, was fertig ist, und verschiebst unvollendete Aufgaben zurück auf die linke Seite.
+
+Das Format ist weniger wichtig als die Disziplin. Wichtig ist, dass die beiden Listen wirklich getrennt bleiben. Dass Aufgaben nicht automatisch vom Backlog zum Daily Focus übergehen, nur weil Zeit vergangen ist, und dass deine Daily-Focus-Liste nicht wächst, bis sie funktional ein drittes, kleineres Backlog ist.
+
+Wenn du digitale Werkzeuge bevorzugst, such nach Apps, die diese Architektur explizit widerspiegeln: ein Erfassungsbereich ohne Zeitdruck und eine fokussierte tägliche Liste, die sich zurücksetzt. Das Prinzip funktioniert vom Taschennotizblock bis zu jeder Softwarelösung, die die gleiche Trennung respektiert.
+
+## Häufige Fehler
+
+**Die Daily-Focus-Liste wird zu einem zweiten Backlog.** Das ist das häufigste Versagensszenario. Du fängst mit fünf Aufgaben an, fügst dann zwei weitere hinzu, weil sie „schnell" sind, dann drei weitere, weil der Tag gut läuft, und um Mittag hast du zwölf Aufgaben und der Focus ist weg. Die Größenbeschränkung ist strukturell, es ist kein Vorschlag.
+
+**Der Backlog wird nie überprüft.** Wenn du deinen Backlog nie durchsiehst, wird er zu einem Friedhof. Aufgaben sammeln sich an, verfallen in Irrelevanz, und der Backlog verliert seinen Wert als Quelle echter Optionen. Eine fünfminütige wöchentliche Überprüfung reicht aus, um ihn lebendig zu halten.
+
+**Aufgaben wechseln automatisch statt bewusst.** Das Zwei-Listen-System bricht zusammen, wenn Aufgaben nach Fälligkeit statt nach Wahl migrieren. „Das ist bis Freitag fällig" ist ein Grund, über einen Wechsel nachzudenken. Nicht ein Grund, es automatisch zu verschieben. Die tägliche Auswahl sollte sich immer wie eine aktive Entscheidung anfühlen.
+
+**Die tägliche Liste wird nie geleert.** Wenn du deine Daily-Focus-Liste am Ende des Tages nicht abschließt, bleiben unvollendete Aufgaben stillschweigend dort und fangen an, sich anzusammeln. Das Reset ist der ganze Mechanismus. Ihn zu überspringen ist, was eine gesunde tägliche Liste in den Überfälligkeitsstapel verwandelt, den du vermeiden wolltest.
+
+**Schuldgefühle über den Backlog.** Manche Menschen fühlen sich verpflichtet, den Backlog systematisch durchzugehen. Um ihn schließlich „zu beenden". Der Backlog ist keine Warteschlange. Es ist eine Sammlung. Nicht alles darin wird jemals ein Daily-Focus-Element, und das ist in Ordnung. Der Job des Backlogs ist, Dinge sicher zu halten, nicht zu garantieren, dass sie erledigt werden.
+
+## Häufig gestellte Fragen
+
+### Was ist das Zwei-Listen-System?
+
+Das Zwei-Listen-System ist ein Aufgabenverwaltungsansatz, der alle deine potenziellen Aufgaben (der Backlog) von der kleine Menge trennt, auf die du dich heute verpflichtest (der Daily Focus). Aufgaben wechseln nur durch eine bewusste tägliche Entscheidung vom Backlog zur Daily-Liste. Diese Trennung verhindert den Überfälligkeitsstapel, der die meisten Menschen dazu bringt, ihre Aufgabensysteme aufzugeben. Das Konzept basiert auf Warren Buffetts Rat zur Zielaufteilung und wird auf die tägliche Aufgabenverwaltung angewendet.
+
+### Wie viele Aufgaben sollte auf einer täglichen To-Do-Liste sein?
+
+Die meiste Forschung und Praktiker schlagen drei bis fünf Aufgaben als strikte Obergrenze für eine Daily-Focus-Liste vor. Weniger als drei risikiert Unterengagement an produktiven Tagen; mehr als fünf neigt dazu, die Überwältigung einer vollständigen Aufgabenliste zu reproduzieren. Die Beschränkung ist beabsichtigt. Sie zwingt dich, zu identifizieren, was heute wirklich wichtig ist, anstatt alles aufzulisten, das du gerne erreichen würdest.
+
+### Was ist der Unterschied zwischen einem Backlog und einer To-Do-Liste?
+
+Eine To-Do-Liste ist typischerweise eine einzige flache Liste aktiver Aufgaben, oft gemischt mit langfristigen Zielen und unmittelbaren Aktionen. Ein Backlog ist ein bewusster Ablageplatz ohne eingebaute Dringlichkeit. Aufgaben sitzen dort, bis du dich aktiv entscheidest, sie auf deine tägliche Liste zu befördern. Der Schlüsselunterschied ist psychologisch: Eine To-Do-Liste erzeugt Druck auf alles, was sie enthält, während ein gut gepflegter Backlog ein neutraler Pool von Optionen ist.
+
+### Wie verhindere ich, dass meine To-Do-Liste zu lang wird?
+
+Die strukturelle Lösung besteht darin, deine Liste in Backlog und Daily Focus zu unterteilen. Dein Backlog kann so lange sein, wie es sein muss. Länge ist dort keine Rolle, weil es keine Dringlichkeit mit sich trägt. Deine tägliche Liste bleibt kurz, wie beabsichtigt (drei bis fünf Aufgaben). Kombiniert mit einer wöchentlichen Backlog-Überprüfung, um irrelevante Aufgaben zu entfernen, verschwindet die überwältigende Erfahrung einer einzelnen Liste.
+
+### Was hat Warren Buffett über To-Do-Listen gesagt?
+
+Die weit verbreitete Geschichte schreibt Buffett eine Zwei-Listen-Methode für die Zielplanung zu: schreib deine 25 wichtigsten Ziele auf, markiere die fünf wichtigsten, und behandle die restlichen zwanzig als Vermeidungsliste, bis die Top Five erledigt sind. Der genaue Ursprung dieser Geschichte ist umstritten, und sie könnte erfunden sein. Aber das zugrundeliegende Prinzip — dass die Trennung von „alles" von „den wenigen wichtigsten Dingen" selbst der produktive Akt ist — ist sowohl in Forschung als auch in der Praxis gut belegt.
+
+## Fazit
+
+Das Zwei-Listen-System funktioniert, weil es das richtige Problem löst. Das Problem mit den meisten Task-Management-Ansätzen ist nicht, dass Menschen Disziplin oder Motivation fehlt. Es ist, dass ihre Werkzeuge sie zwingen, alles auf einmal anzuschauen — das Dringende und das Irgendwann, das Wichtige und das Irrelevante. Mit gleichem optischen Gewicht. Das Ergebnis ist Überwältigung, Vermeidung und schließlich Aufgabe.
+
+Das Trennen deiner Aufgaben in einen Backlog und eine Daily-Focus-Liste ändert die emotionale Erfahrung der Aufgabenverwaltung völlig. Der Backlog hält deine Optionen. Der Daily Focus hält deine Verpflichtungen. Nichts sammelt sich als überfällig an. Nichts bestraft dich dafür, eine Aufgabe einer anderen vorzuziehen. Das System setzt sich jeden Abend zurück, und jeder Morgen beginnt mit einer echten Entscheidung, nicht mit einer Abrechnung.
+
+Das Zwei-Listen-System ist keine neue Idee. Aber es bleibt eine der effektivsten verfügbaren Strukturen, genau weil sie passt, wie Menschen tatsächlich Entscheidungen treffen: einen Tag nach dem anderen, mit einer vernünftigen Anzahl von Wahlmöglichkeiten, in einem Kontext, in dem sie sich nicht schuldig über das fühlen, was sie gestern nicht getan haben.
+
+Wenn du eine Task-App ausprobieren möchtest, die auf dieser Philosophie basiert, kannst du Dawny kostenlos auf TestFlight testen.
+
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren gebaut, in denen er alle Produktivitäts-Apps auf dem Markt ausprobiert und aufgegeben hat.
+
+Möchtest du eine Task-App ausprobieren, die auf dieser Philosophie basiert?
+
+Dawny ist kostenlos auf TestFlight zum Testen verfügbar — keine Verpflichtung erforderlich.
+
+Dawny kostenlos auf TestFlight ausprobieren

--- a/website/src/content/blog/de/what-is-task-debt.md
+++ b/website/src/content/blog/de/what-is-task-debt.md
@@ -1,0 +1,117 @@
+---
+title: "Was ist Aufgaben-Schuld?"
+description: "Aufgaben-Schuld ist das wachsende Chaos aus überfälligen und aufgegebenen Aufgaben, das deine To-Do-Liste unmöglich wirken lässt. Erfahre, was es verursacht und wie du es überwindest."
+pubDate: 2026-05-10
+---
+
+# Was ist Aufgaben-Schuld — und warum wird deine To-Do-Liste immer schlimmer?
+
+> **Kurz gesagt:** Aufgaben-Schuld ist die Ansammlung von überfälligen, verpassten oder aufgegebenen Aufgaben, die sich in deiner To-Do-Liste im Laufe der Zeit aufbauen. Wie finanzielle Schulden wächst sie exponentiell: Je länger du sie ignorierst, desto schlimmer fühlt sie sich an. Die meisten Produktivitäts-Apps machen Aufgaben-Schuld schlimmer, indem sie alles anzeigen, das nicht erledigt wurde. Die Lösung ist nicht mehr Disziplin — es ist ein System, das verhindert, dass sich Schuld überhaupt erst aufbaut.
+
+Du öffnest deine Task-App und fühlst dich sofort schlechter als zuvor. Rote Einträge. Verpasste Fristen von vor zwei Wochen. Aufgaben, die du im Januar hinzugefügt hast und die damals sinnvoll waren, aber jetzt bedeutungslos sind. Du scrollst durch die Liste, empfindest eine Welle von Schuldgefühlen und schließt die App, ohne etwas zu tun. Du warst schon mal hier. Dieses Gefühl hat einen Namen: Aufgaben-Schuld — und du bist damit nicht allein. Dieser Artikel erklärt, was Aufgaben-Schuld ist, warum sie sich aufbaut und was du wirklich dagegen tun kannst.
+
+## Was ist Aufgaben-Schuld?
+
+Aufgaben-Schuld ist das angesammelte Gewicht von unerledigten, überfälligen oder nicht mehr relevanten Aufgaben, die sich in deiner To-Do-Liste ansammeln. Genau wie finanzielle Schulden bleibt sie nicht stehen — sie wächst. Jeden Tag, an dem du dich nicht damit auseinandersetzt, wird die Liste länger, das Schuldgefühl größer und die Vorstellung, deinen Task Manager zu öffnen, immer abschreckender.
+
+Der Begriff lehnt sich an das Konzept der technischen Schuld in der Softwareentwicklung an, wo Abkürzungen heute morgen größere Probleme schaffen. Aufgaben-Schuld funktioniert genauso: Jede Aufgabe, die du aufschiebst, ohne eine Entscheidung zu treffen, trägt zu einem Backlog bei, das irgendwann unhandhabbar wird.
+
+Was Aufgaben-Schuld besonders heimtückisch macht, ist ihre psychologische Wirkung. Die Forschung zum Zeigarnik-Effekt — erstmals von der sowjetischen Psychologin Bluma Zeigarnik in den 1920er Jahren beschrieben — zeigt, dass unvollendete Aufgaben zu anhaltenden kognitiven Intrusionen führen. Dein Gehirn kehrt immer wieder zu unvollendeten Angelegenheiten zurück, selbst wenn du dich auf etwas anderes konzentrieren möchtest. Eine lange Liste von überfälligen Aufgaben ist nicht nur visuell überwältigend; sie beansprucht rund um die Uhr mentale Kapazität. Weitere Ressourcen umfassen Artikel darüber, wie unvollendete Aufgaben mentale Energie rauben und einen modernen Blick auf den Zeigarnik-Effekt.
+
+## Wie baut sich Aufgaben-Schuld auf?
+
+Aufgaben-Schuld entsteht selten auf einmal. Sie sammelt sich schrittweise an, durch Muster, die im Moment völlig normal wirken.
+
+**Optimistische Fristen.** Du fügst eine Aufgabe hinzu und setzt eine Frist, basierend darauf, wie lange du hoffst, dass sie dauert, nicht wie lange sie wirklich dauern wird. Wenn die Frist verstreicht und die Aufgabe nicht erledigt ist, wird sie rot und fügt sich der Schuldhaufen ein.
+
+**Aufgaben, die irrelevant werden.** Du hast „Marcus über den Q3-Vorschlag anschreiben" vor drei Wochen hinzugefügt. Q3 ist vorbei. Marcus hat einen anderen Job. Die Aufgabe ist jetzt bedeutungslos — aber sie sitzt immer noch dort, nimmt Platz und Aufmerksamkeit in Anspruch.
+
+**Wiederkehrende Low-Priority-Aufgaben.** Manche Aufgaben fühlen sich nie dringend genug an, um sie wirklich zu erledigen, aber auch nicht sicher genug, um sie zu löschen. Sie verbleiben auf der Liste, halb vergessen und tragen jedes Mal, wenn du vorbeiscrollst, leise zur kognitiven Belastung bei.
+
+**Die Vermeidungsschleife.** Hier wird Task Debt selbstverstärkend. Du öffnest deine App, siehst die überwältigende Liste, empfindest Angst und schließt die App, ohne etwas zu tun. Die Schuld wächst. Das nächste Mal, wenn du sie öffnest, ist die Liste noch länger. Die Angst ist noch stärker. Du schließt sie schneller. Mit der Zeit öffnest du sie gar nicht mehr.
+
+## Warum machen die meisten To-Do-Apps Aufgaben-Schuld schlimmer?
+
+Die meisten Task-Management-Apps basieren auf einer einzigen Annahme: Wenn du es nicht erledigt hast, musst du es noch erledigen. Diese Annahme treibt jede Designentscheidung voran — Überfällig-Labels, rote Indikatoren, Umplanungs-Aufforderungen, Streaks, die unterbrochen werden, wenn du einen Tag verpasst. Die App signalisiert dir ständig, dass du versagt hast.
+
+Das Problem ist, dass dieses Design nicht zwischen zwei sehr unterschiedlichen Situationen unterscheidet: „Ich habe das noch nicht erledigt" und „Ich habe mich entschieden, das heute nicht zu tun." Das sind völlig unterschiedliche mentale Zustände. Einer ist eine Verzögerung. Der andere ist ein Urteilsspruch. Aber deine App behandelt sie identisch, und das Ergebnis ist eine Liste, die unerbittlich wächst, unabhängig davon, ob deine Entscheidungen eigentlich sinnvoll sind.
+
+Florian, der Entwickler hinter Dawny, hat das selbst erlebt. Er hat jede große Produktivitäts-App probiert — Todoist, Any.do, Microsoft To-Do, Apple Reminders. Und ist jedes Mal auf die gleiche Mauer gestoßen. Aufgaben vervielfachten sich. Fristen verstrichen. Manche Aufgaben hatten sich bereits erledigt, bevor er sie erreichte. Er starrte immer wieder auf eine wachsende Wand von roten, überfälligen Einträgen. Aufgaben, die er erledigen wollte, Aufgaben, die nicht mehr wichtig waren, Aufgaben, die ihm Schuldgefühle verursachten. Und er schließt einfach die App. Die Apps waren nicht kaputt. Sie funktionierten genau so, wie sie konzipiert waren. Aber das Design passte nicht zu seiner, und vielen anderen, Gehirnen.
+
+Das ist einer der Hauptgründe, warum To-Do-Listen von Grund auf scheitern: Sie basieren auf der Annahme, dass mehr Sichtbarkeit gleich mehr Verantwortlichkeit ist. In der Praxis führt mehr Sichtbarkeit von Dingen, die du nicht erledigt hast, hauptsächlich zu mehr Angst.
+
+## Was kostet dich Aufgaben-Schuld wirklich?
+
+Die Kosten für das Tragen von Aufgaben-Schuld sind nicht nur das vage Schuldgefühl, das du empfindest, wenn du diese rote Nummer auf deinem App-Icon siehst. Es gibt konkrete, messbare Auswirkungen darauf, wie gut du denkst und arbeitest.
+
+**Entscheidungsmüdigkeit.** Jeder Eintrag in deinem Backlog ist eine Micro-Entscheidung, die du noch nicht getroffen hast: Erledige ich das jetzt, verschiebe ich es oder lösche ich es? Wenn deine Liste 80 Einträge hat, beginnst du jeden Tag damit, 80 ungelöste Entscheidungen durchzuscrollen, bevor du noch Kaffee getrunken hast. Das verbraucht kognitive Ressourcen, bevor die eigentliche Arbeit beginnt.
+
+**Angst, die die Motivation reduziert.** Der Zeigarnik-Effekt beeinflusst nicht nur die Konzentration. Er beeinflusst die Stimmung. Das Tragen einer mentalen Last von unvollendeten Aufgaben erzeugt ein Hintergrund-Summen von Stress, das es schwerer macht, die Arbeit zu genießen, die du gerade machst.
+
+**Unfähigkeit, echte Prioritäten zu sehen.** Wenn alles gleichberechtigt auf der Liste ist, fällt nichts ins Auge. Die Aufgabe, die du heute wirklich erledigen musst, ist begraben unter 60 Dingen, die theoretisch noch relevant, aber praktisch untätig sind.
+
+**Komplette Aufgabe.** Das ist das häufigste Ergebnis. Keine dramatische Entscheidung aufzugeben, sondern ein graduelles Abdriften. Du öffnest die App immer seltener, bis du eines Tages merkst, dass du sie seit drei Wochen nicht mehr angeschaut hast. Die Aufgaben sind immer noch da. Du schaust einfach nicht mehr hin.
+
+## Wie eliminiert ein täglicher Reset Aufgaben-Schuld?
+
+Die architektonische Lösung für Aufgaben-Schuld ist eine Verschiebung dessen, was „nicht erledigt" bedeutet. Anstatt eine unerledigte Aufgabe als überfällig zu behandeln — ein Fehlschlag, der Rechenschaft erfordert — behandelt ein Reset-basiertes System sie als unentschieden. Die Aufgabe kehrt in einen neutralen Zustand zurück und wartet darauf, dass du sie morgen wieder wählst, falls sie immer noch wert ist, gewählt zu werden.
+
+Dies ist die Philosophie hinter dem Zwei-Listen-System: Behalte ein Backlog für alles, das irgendwann wichtig werden könnte, und eine Daily-Focus-Liste für die kleine Anzahl von Aufgaben, zu denen du dich heute wirklich verpflichtest. Am Ende des Tages kehren Aufgaben, die nicht erledigt wurden, ins Backlog zurück, nicht in einen Überfällig-Haufen. Jeden Morgen beginnt man mit einer sauberen Latte.
+
+Es gibt einen sekundären Mechanismus, der diesen Ansatz noch mächtiger macht: Aufgaben, die immer wieder übersprungen werden, offenbaren sich selbst. Wenn du eine Aufgabe fünf Mal ins Backlog verschoben hast, ohne sie je für deinen Daily Focus zu wählen, sind das Daten. Diese Aufgabe sagt dir etwas. Wahrscheinlich, dass sie keine echte Priorität ist. In Dawny werden Aufgaben, die wiederholt übersprungen werden, automatisch archiviert, durch einen Mechanismus namens Make It Count. Du musst dich nicht dazu entschließen, sie zu löschen. Das System bemerkt das Muster für dich.
+
+> „Seit ich Dawny verwende, habe ich keine Angst mehr, meine Aufgabenliste anzuschauen. Die Aufgaben, die ich ohnehin nicht erledigen würde, erscheinen einfach gar nicht mehr." — Dawny Beta-Tester
+
+Diese Umrahmung ist bedeutsam. Anstatt dass deine Aufgabenliste ein Verzeichnis von allem ist, das du nicht erledigt hast, wird sie eine kuratierte Sammlung von Dingen, die du wirklich wählen könntest. Die Liste bleibt überschaubar, weil sie durch Design aktiv gepflegt wird, nicht durch periodische manuelle Reinigungen, die du dich selbst zu machen zwingst.
+
+## Was kannst du heute tun, wenn du Aufgaben-Schuld hast?
+
+Wenn deine aktuelle Aufgabenliste bereits tief in Schuld ist, sind hier fünf konkrete Schritte, um sie abzubauen.
+
+**1. Mache einen Schuld-Audit.** Gehe deine Liste durch und markiere jede Aufgabe als eines von drei Dingen: noch relevant, nicht mehr relevant oder unsicher. Versuche nicht, noch nichts zu erledigen, kategorisiere einfach.
+
+**2. Archiviere alles Irrelevante. Rücksichtslos.** Jede Aufgabe, die nicht mehr gilt, sich bereits selbst erledigt hat oder zu einer Version deines Lebens gehört, die nicht mehr existiert — archiviere oder lösche sie. Du gibst diese Aufgaben nicht auf. Du erkennst die Realität an.
+
+**3. Verschiebe unsichere Elemente aus deiner täglichen Ansicht.** Alles, wovon du dir nicht sicher bist, sollte nicht auf deiner aktiven Liste sein. Verschiebe es in eine „Irgendwann"- oder „Vielleicht"-Kategorie. Es ist immer noch zugänglich, wenn es relevant wird, konkurriert aber nicht um deine Aufmerksamkeit heute.
+
+**4. Begrenze deine aktive tägliche Liste auf 3–5 Aufgaben.** Die Forschung zu Entscheidungsmüdigkeit ist klar: Mehr Wahlmöglichkeiten führen zu schlechteren Entscheidungen. Eine kürzere Liste ist keine Faulheit. Es ist Klarheit. Wähle die Aufgaben, die heute wirklich wichtig sind, und lass den Rest warten.
+
+**5. Verpflichte dich zu einem täglichen Reset-Ritual.** Am Ende eines jeden Tages (oder am Anfang des nächsten) nimm dir fünf Minuten Zeit, um zu überprüfen, was erledigt wurde und was nicht. Triff eine bewusste Entscheidung für jedes Element: Kommt es in die Liste von morgen, oder geht es ins Backlog zurück, um zu warten? Dies ist die Gewohnheit, die verhindert, dass sich neue Schuld aufbaut.
+
+## Häufig gestellte Fragen
+
+### Was ist Aufgaben-Schuld in der Produktivität?
+
+Aufgaben-Schuld ist die wachsende Ansammlung von überfälligen, übersprungenen oder nicht mehr relevanten Aufgaben in deiner To-Do-Liste. Wie finanzielle Schulden wächst sie mit der Zeit. Je länger sie ignoriert wird, desto überwältigender wird sie. Sie erzeugt kognitive Belastung durch den Zeigarnik-Effekt, was bedeutet, dass dein Gehirn immer wieder zu unvollendeten Aufgaben zurückkehrt, selbst wenn du dich auf etwas anderes konzentrieren möchtest.
+
+### Warum wächst meine To-Do-Liste immer?
+
+To-Do-Listen wachsen aus drei Hauptgründen: optimistische Fristen, die überfällige Einträge erzeugen, Aufgaben, die irrelevant werden, aber nie entfernt werden, und Vermeidungsverhalten, das durch zu viele unvollendete Einträge ausgelöst wird. Die meisten Task-Apps machen das schlimmer, indem sie jede unerledigt Aufgabe als aktive Obligation behandeln, unabhängig davon, ob sie noch relevant ist.
+
+### Wie räume ich eine überwältigende To-Do-Liste auf?
+
+Beginne mit einem Schuld-Audit: Kategorisiere jede Aufgabe als noch relevant, nicht mehr relevant oder unsicher. Lösche oder archiviere alles in der zweiten Kategorie. Verschiebe unsichere Einträge in eine „Irgendwann"-Liste aus deiner täglichen Ansicht. Begrenze dann deine aktive tägliche Liste auf 3–5 Aufgaben. Entwickle ab sofort eine tägliche Reset-Gewohnheit, die verhindert, dass sich neue Schuld aufbaut.
+
+### Was ist der Unterschied zwischen einem Backlog und einer Überfällig-Liste?
+
+Eine Überfällig-Liste ist ein Verzeichnis deiner Fehlschläge. Aufgaben, die Fristen hatten und diese nicht erfüllt haben. Ein Backlog ist ein neutraler Behälter für Aufgaben, die noch nicht priorisiert wurden. Die Unterscheidung ist psychologisch wichtig: Eine Überfällig-Liste erzeugt Schuldgefühle und Vermeidung, während ein gut gepflegtes Backlog einfach ein Pool von Optionen ist, aus dem man wählt. Gute Task-Management-Systeme nutzen Backlogs, keine Überfällig-Listen.
+
+### Ist Aufgaben-Schuld das gleiche wie Aufschub?
+
+Sie sind verwandt, aber unterschiedlich. Aufschub ist ein Verhalten. Das Verschieben einer Aufgabe, die du erledigen möchtest. Aufgaben-Schuld ist das systemische Ergebnis von Aufschub (und anderen Faktoren wie schlechtem Werkzeug, zu optimistischer Planung und sich ändernden Umständen). Du kannst erhebliche Aufgaben-Schuld haben, ohne ein Aufschub-Typ zu sein, einfach weil du zu viele Aufgaben mit Fristen hinzugefügt hast, die nicht zu deiner tatsächlichen Kapazität passten.
+
+## Fazit
+
+Aufgaben-Schuld ist real, sie ist häufig und sie ist kein Charakterfehler. Sie ist das, was passiert, wenn das Design deiner Werkzeuge nicht dem entspricht, wie Menschen tatsächlich Entscheidungen treffen. Die meisten Task-Apps gehen davon aus, dass Sichtbarkeit Verantwortlichkeit schafft. In der Praxis erzeugt überwältigende Sichtbarkeit hauptsächlich Vermeidung, und Vermeidung ist das, was Schuld exponentiell wachsen lässt.
+
+Die Lösung ist nicht ein aggressiveres System mit härteren Fristen und mehr roten Indikatoren. Es ist ein System, das unvollendete Aufgaben nicht als Fehlschläge behandelt, sondern als unentschiedene Wahlmöglichkeiten. Eines, das täglich zurückgesetzt wird, deine aktive Liste klein hält und Muster über die Zeit hinweg für dich offenbaren lässt, anstatt dich zu zwingen, alles manuell zu verwalten. Diese Verschiebung, von Schuld zu Reset, ändert die ganze Beziehung zu deiner Aufgabenliste.
+
+Wenn du eine Task-App testen möchtest, die auf dieser Philosophie aufbaut, ist Dawny kostenlos auf TestFlight verfügbar.
+    
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren des Ausprobierens — und Aufgebens — jeder Produktivitäts-App auf dem Markt entwickelt.
+  
+Möchtest du eine Task-App testen, die auf dieser Philosophie aufbaut?
+ 
+Dawny ist kostenlos auf TestFlight verfügbar — ohne Bindung.
+ 
+Probiere Dawny kostenlos auf TestFlight

--- a/website/src/content/blog/de/why-to-do-lists-fail.md
+++ b/website/src/content/blog/de/why-to-do-lists-fail.md
@@ -1,0 +1,111 @@
+---
+title: "Warum Aufgabenlisten nicht funktionieren (und was die Forschung stattdessen sagt)"
+description: "Aufgabenlisten scheitern nicht, weil dir Disziplin fehlt, sondern weil sie dafür entwickelt wurden, alles zu erfassen — ohne beim Priorisieren zu helfen."
+pubDate: 2026-05-10
+---
+
+> **Kurze Antwort:** Aufgabenlisten scheitern, weil sie dafür entwickelt wurden, alles zu erfassen — nicht zum Priorisieren. Eine Liste, die unbegrenzt wächst, führt zu Entscheidungsmüdigkeit, erzeugt Schuldgefühle durch unerledigte Aufgaben und schafft eine mentale Belastung, die dich dazu bringt, die Liste ganz zu ignorieren. Das Problem ist nicht deine Disziplin. Das Problem ist, dass die meisten Task-Systeme Menge mit Wert verwechseln.
+
+Du kennst das Szenario. Du öffnest deine Task-App mit guten Absichten, füigst ein paar Aufgaben hinzu und sagst dir, dass heute anders sein wird. Dann kommt der Tag. Einige Aufgaben werden erledigt, die meisten nicht, und am Abend ist die Liste länger als am Morgen. Eine Woche später öffnest du die App gar nicht mehr.
+
+Das ist kein Charakterfehler. Es ist keine Faulheit, kein schlechtes Zeitmanagement und auch keine mangelnde Disziplin. Es ist ein Design-Problem — und es ist fast universal. Die Art, wie die meisten Task-Apps aufgebaut sind, läuft direkt gegen die Funktionsweise der menschlichen Kognition. Bevor du dir selbst wieder Vorwürfe machst, lohnt es sich zu verstehen, warum Aufgabenlisten so häufig scheitern — und wie ein besseres System aussieht.
+
+## Was war der ursprüngliche Zweck einer Aufgabenliste?
+
+Aufgabenlisten wurden als Erfassungswerkzeuge erfunden, nicht als Entscheidungssysteme. Die ursprüngliche Idee war einfach: schreib Dinge auf, damit dein Gehirn sie nicht behalten muss. Das ist genuinely nützlich. Unser Arbeitsgedächtnis ist begrenzt, und wenn wir Gedanken auf Papier (oder in einer App) auslagern, schaffen wir mentalen Freiraum.
+
+Das Problem entsteht, wenn wir ein Erfassungswerkzeug als Priorisierungsmaschine nutzen. Eine Liste, die alles fassen soll, wird zum Werkzeug, das wir nutzen, um zu entscheiden, was als nächstes ansteht. Das ist eine riesige Aufgabe für etwas, das dafür nie entwickelt wurde. Und die meisten Task-Apps haben diesen Widerspruch nie gelöst — sie haben nur den Erfassungsprozess schneller und bequemer gemacht.
+
+## Grund 1: Jede unerledigte Aufgabe ist eine Entscheidung, die du noch treffen musst
+
+Entscheidungsmüdigkeit ist real und wissenschaftlich gut dokumentiert. Der Psychologe Roy Baumeister forschte zur Ego-Depletion — später erweitert zur breiteren Forschung zur Entscheidungsmüdigkeit. Seine Ergebnisse zeigten, dass je mehr Entscheidungen eine Person trifft, desto schlechter werden ihre nächsten Entscheidungen. Die mentale Ressource, die du zum Entscheiden brauchst, ist endlich und wird über den Tag verteilt aufgebraucht.
+
+Stell dir vor, was passiert, wenn du eine Aufgabenliste mit 40 Einträgen öffnest. Bevor du eine einzige Sache getan hast, muss dein Gehirn 40 Optionen scannen und 40 kleine Entscheidungen treffen: Ist das heute relevant? Ist das dringend? Sollte ich das jetzt tun oder später? Das ist eine riesige kognitive Belastung, bevor du ein einziges Wort geschrieben oder einen einzigen Anruf gemacht hast. Die meisten Menschen reagieren auf diese Belastung auf die einzige rationale Weise, die ihnen bleibt: Sie schließen die App.
+
+Eine schlanke Tagesliste, begrenzt auf deine drei wichtigsten Aufgaben, umgeht das ganz. Weniger Einträge bedeuten weniger Entscheidungen, was bedeutet mehr Energie für das Erledigen von Dingen.
+
+## Grund 2: Unerledigte Aufgaben schaffen eine Schuldgefühl-Spirale
+
+Es gibt ein psychologisches Phänomen namens Zeigarnik-Effekt: Dein Gehirn haftet an unvollendeten Aufgaben und kehrt immer wieder zu ihnen zurück. Ursprünglich wurde es als Gedächtniseffekt beobachtet. Wir erinnern uns besser an unvollendete Dinge als an vollendete. Im Kontext einer modernen Aufgabenliste hat das eine unglückliche Nebenfolge: Jeder überfällige Eintrag trägt eine kleine, aber reale emotionale Last.
+
+Ein überfälliger Eintrag ist ein leises Nagging-Gefühl. Fünf überfällige Aufgaben fühlen sich wie ein schlechter Tag an. Dreißig davon, rot, fett, sich anhäufend, fühlen sich wie ein Versagen an. An diesem Punkt löst die App selbst Angst aus, bevor du etwas falsch gemacht hast. Du öffnest sie nicht mehr, nicht weil du faul bist, sondern weil dein Nervensystem richtig gelernt hat, dass die App sich schlecht anfühlt.
+
+Das ist, was Task-Schulden dir tatsächlich kosten. Es ist nicht nur die unerledigte Arbeit. Es ist das psychologische Gewicht, das du mit dir herumträgst, jedes Mal wenn du an die Liste denkst.
+
+## Grund 3: Digitale Listen haben kein natürliches Verfallsdatum
+
+Es gibt etwas, das Papier-Aufgabenlisten versehentlich richtig gemacht haben: Sie verfallen. Du fülltest eine Seite, verliertest das Notizbuch, wirfst die Notiz weg. Die alte Liste war weg, und du fängst neu an. Das erzwang einen natürlichen Reset, der Aufgaben entfernte, die nicht mehr relevant waren.
+
+Digitale Listen sind permanent. Eine Aufgabe, die du im Januar hinzugefügt hast, sitzt direkt neben einer, die du heute Morgen hinzugefügt hast, mit gleichem visuellem Gewicht und gleicher anklagender Präsenz. Die „Geburtstagskarte kaufen" von vor vier Monaten, für einen Geburtstag, der längst vorbei ist, starrt dich noch immer von der Liste an. Nichts fordert dich auf zu überdenken, ob eine alte Aufgabe noch wichtig ist. Alles sammelt sich an, für immer, bis du es manuell löschst.
+
+Die meisten Menschen gehen nicht regelmäßig zurück und räumen auf. Das ist kein Versagen der Disziplin. Es ist einfach nicht die Art, wie Aufmerksamkeit funktioniert. Ein System, das laufende manuelle Wartung erfordert, wird immer verfallen.
+
+## Grund 4: Menge wird mit Priorität verwechselt
+
+Öffne irgendeine Standard-Task-App und schau dir die Liste an. „Geburtstagskarte kaufen" sitzt neben „Quartalsreview vorbereiten" mit identischer Formatierung, identischem visuellen Gewicht, identischer Dringlichkeit. Es gibt keine Hierarchie, kein Signal. Deine Aufmerksamkeit muss die ganze Arbeit des Sortierens, Rangierens und Entscheidens machen, jedes Mal wenn du die App öffnest.
+
+So funktioniert menschliche Aufmerksamkeit nicht. Wir sind verdrahtet, um Kontrast und Unterschied wahrzunehmen, nicht um einheitliche Listen zu rangieren. Wenn alles gleich wichtig aussieht, fühlt sich nichts wichtig an. Und das Ergebnis ist, dass du dich für die leichteste Aufgabe entscheidest, nicht die sinnvollste. „Geburtstagskarte kaufen" wird erledigt. Das Quartalsreview wird bis morgen verschoben. Und dann noch einen Tag länger.
+
+Das Produktivitätssystem funktioniert nicht, weil es alle Aufgaben als gleichwertig behandelt, obwohl sie es nicht sind.
+
+## Was funktioniert tatsächlich: Erfassung von Verpflichtung trennen
+
+Die Forschung deutet auf eine einfache strukturelle Lösung hin: Trenne den Ort, an dem du alles erfasst, vom Ort, an dem du dich für heute verpflichtest. Ein großer Backlog, alles, das du vielleicht tun möchtest, ohne Zeitdruck. Das ist okay und nützlich. Was nicht okay ist, ist die gleiche Liste als deine tägliche Arbeitsfläche zu nutzen.
+
+Was funktioniert, ist eine kleine Tagesliste, die du bewusst jeden Morgen wählst. Nicht alles. Nur die Dinge, zu denen du dich heute wirklich verpflichtest. Wenn du fünf Einträge statt fünfzig siehst, triffst du bessere Entscheidungen. Du arbeitest mit deiner kognitiven Kapazität, nicht gegen sie.
+
+Ein Beta-Tester beschrieb es so:
+
+> „Ich nutze Dawny wirklich jeden Morgen. Der tägliche Reset gibt mir den Raum zum Atmen, den ich brauche." — Dawny Beta-Tester
+
+Das Konzept des „täglichen Reset" ist zentral für diesen Ansatz. Was wäre, wenn die Aufgaben, die du heute nicht erledigt hast, automatisch in deinen Backlog zurückkehrten? Keine „überfällig"-Markierung, kein rotes Abzeichen, keine Schuldgefühle? Du würdest morgen mit einer sauberen Liste starten. Du würdest wieder wählen, was deinen Fokus verdient. Und die Aufgaben, die ständig übersprungen werden, würden sich eventually selbst als Dinge offenbaren, die nicht wirklich wichtig genug sind, um zu handeln.
+
+Ein anderer Tester drückte es deutlich aus:
+
+> „Fast alle Aufgaben, die automatisch archiviert wurden, waren, wenn ich darüber nachdachte, einfach nicht wichtig genug in dem Moment." — Dawny Beta-Tester
+
+## Wie sieht eine Aufgabenliste aus, die es wert ist, geöffnet zu werden?
+
+Ein Task-System, das für die Art wie Kognition tatsächlich funktioniert, hat ein paar definierende Eigenschaften. Erstens: eine kleine Tagesoberfläche. Forschung und Praxis unterstützen beide, deine aktive Tagesliste auf ein paar Einträge zu beschränken. Die meisten Experten empfehlen drei bis fünf. Zweitens: klare Trennung zwischen „irgendwann" und „heute". Dein Backlog ist ein sicherer Ablageort, nicht eine Quelle von Schuldgefühlen. Drittens: automatisches Verfallen. Aufgaben, auf die nicht reagiert wird, sollten automatisch in den Ablageort zurückkehren, nicht als überfällige Einträge sich anhäufen.
+
+Das geht nicht um weniger tun. Es geht darum, ehrlich zu sein, was heute wirklich enthält. Und das System so zu gestalten, dass es mit der natürlichen Realität umgeht, dass sich Pläne ändern, Energie schwankt und Prioritäten sich verschieben. Ein gutes System passt sich menschlichem Verhalten an. Ein schlechtes fordert dich auf, dein Verhalten dem System anzupassen.
+
+## Häufig gestellte Fragen
+
+### Warum scheitere ich immer beim Führen einer Aufgabenliste?
+
+Du scheitern wahrscheinlich nicht. Die Liste tut es. Die meisten Task-Apps sind dafür ausgelegt, alles zu erfassen, ohne beim Priorisieren zu helfen. Das Ergebnis ist eine Liste, die schneller wächst, als du sie erledigen kannst, was Entscheidungsmüdigkeit und Vermeidung auslöst. Die Lösung ist strukturell: Trennte deinen Backlog von deiner Tagesliste, und halte deine Tagesliste klein genug, um umsetzbar zu sein.
+
+### Sind Aufgabenlisten schlecht für ADHS?
+
+Traditionelle Aufgabenlisten sind besonders schwierig für ADHS-Gehirne. Lange Listen ohne Hierarchie erfordern anhaltende Aufmerksamkeit, Arbeitsgedächtnis und Impulskontrolle — alles Bereiche, in denen ADHS Herausforderungen schafft. Die Schuldgefühle von unerledigten Aufgaben summieren sich auch schnell auf und können die Liste aversiv wirken lassen. Kürzere Tageslisten mit automatischen Resets passen viel besser zu der Art, wie ADHS-Aufmerksamkeit tatsächlich funktioniert.
+
+### Was sollte ich statt einer Aufgabenliste verwenden?
+
+Die beste Alternative ist nicht, Listen komplett aufzugeben. Es ist, sie neu zu gestalten. Nutze ein zwei-schichtiges System: ein Backlog, das alles hält (ohne Zeitdruck), und eine kleine Tagesliste, die du jeden Morgen aktiv wählst. Der kritische Unterschied ist, dass unvollendete Tagesaufgaben automatisch zurückgesetzt werden, anstatt überfällig zu werden. Das entfernt die angesammelte Schuldgefühl, die traditionelle Listen mit der Zeit unbrauchbar macht.
+
+### Wie viele Aufgaben sollten auf einer täglichen Aufgabenliste sein?
+
+Die meisten Produktivitätsforschungen und Praktiker einigen sich auf drei bis fünf Aufgaben als effektive tägliche Grenze. Das geht nicht um weniger tun. Es geht darum, echte Verpflichtungen zu machen, anstatt aspirationalen. Wenn du deine Tagesliste auf drei Aufgaben begrenzt, wirst du gezwungen, echte Prioritätsentscheidungen zu treffen. Das Ergebnis ist, dass du das erledigt, was du planst, was Momentum aufbaut, anstatt Schuldgefühle.
+
+### Warum macht meine Aufgabenliste mich angespannt?
+
+Die Angespanntheit kommt von angesammelter Task-Schuld. Jeder überfällige Eintrag ist ein kleines psychologisches Signal dafür, dass du eine Verpflichtung gegenüber dir selbst nicht erfüllt hast. Selbst wenn die ursprüngliche Verpflichtung unrealistisch war. Mit der Zeit wird die Liste mit diesem Gefühl assoziiert, und sie zu öffnen löst Angst aus, bevor du etwas falsch gemacht hast. Die Lösung ist ein System, das von Anfang an keine überfälligen Einträge anhäuft — eines, bei dem unvollendete Aufgaben in einen Backlog zurückkehren, anstatt rot zu werden.
+
+## Fazit
+
+Aufgabenlisten scheitern nicht, weil du nicht diszipliniert genug bist, um sie zu nutzen. Sie scheitern, weil sie auf einer fehlerhaften Annahme aufgebaut sind: dass das Erfassen von allem und das Handeln danach das gleiche Problem sind. Das sind sie nicht.
+
+Entscheidungsmüdigkeit, die Schuldgefühl-Spirale des Zeigarnik-Effekts, unendliche Anhäufung und die Nivellierung aller Aufgaben zu visuellen Gleichberechtigten. Das sind keine persönlichen Schwächen. Das sind Design-Fehler in den Systemen, die den meisten von uns übergeben wurden. Die Forschung macht klar, dass Willenskraft und gute Absichten nicht der Engpass sind. Die Architektur ist es.
+
+Ein System, das es wert ist zu nutzen, sieht anders aus: ein sicherer Backlog für alles, eine kleine Tagesliste, die du bewusst wählst, und automatische Resets, die verhindern, dass sich Schuldgefühle aufbauen. Es geht nicht darum, produktiver zu sein. Es geht darum, die Reibung zu entfernen, die dich dazu bringt, die Liste komplett zu ignorieren.
+
+Wenn du eine Task-App testen möchtest, die auf dieser Philosophie aufgebaut ist, ist Dawny kostenlos auf TestFlight verfügbar.
+
+Der Entwickler hinter Dawny hat ADHS und hat die App nach Jahren des Versuchens — und Aufgebens — von jeder Produktivitäts-App auf dem Markt entwickelt.
+
+Möchtest du eine Task-App testen, die auf dieser Philosophie aufgebaut ist?
+
+Dawny ist kostenlos auf TestFlight verfügbar — keine Verpflichtung erforderlich.
+
+Dawny kostenlos auf TestFlight testen

--- a/website/src/content/blog/en/cognitive-load-productivity.md
+++ b/website/src/content/blog/en/cognitive-load-productivity.md
@@ -1,0 +1,125 @@
+---
+title: "Cognitive Load and Productivity: Why Simpler Systems Work Better"
+description: "Complex task apps drain mental energy before you start working. Learn how cognitive load theory explains why simpler productivity systems consistently outperform feature-rich ones."
+pubDate: 2026-05-10
+---
+
+# Cognitive Load and Productivity: Why Simpler Systems Work Better
+
+> **Quick Answer:** Cognitive load productivity refers to how the mental effort required to manage your task system directly affects your capacity for real work. A complex to-do app with 47 tasks, multiple projects, labels, and subtasks creates high cognitive load before you’ve done any actual work. Simpler systems — with fewer visible tasks and a clear daily focus — reduce this overhead and leave more mental bandwidth for the work itself.
+
+You’ve probably had this experience: you open a feature-rich task app, spend 15 minutes reorganizing projects and adding tags, and then close it — somehow more tired than when you started, without having done a single piece of actual work. It’s not laziness. It’s not poor time management. It’s cognitive load, and your productivity tools are supposed to reduce it, not create it. The tools that look most powerful on paper are sometimes the most draining to use — and there’s decades of research that explains exactly why.
+
+## What Is Cognitive Load?
+
+Cognitive load is the total mental effort required to process information and make decisions at any given moment. The concept was formalized by educational psychologist John Sweller in his 1988 paper on cognitive load theory, originally developed to explain why some instructional designs help students learn and others overwhelm them. The theory has since become foundational in interface design, software engineering, and — increasingly — productivity system design. For a more academic overview, see this systematic review of cognitive load theory.
+
+Sweller identified three types of cognitive load. **Intrinsic load** is the inherent complexity of the task itself — writing a difficult email, solving a technical problem, making a strategic decision. You can’t eliminate intrinsic load; it’s the actual work. **Extraneous load** is the overhead imposed by the system you’re working within — confusing interfaces, unnecessary decisions, unclear structure. This is the type you want to minimize. **Germane load** is the mental effort devoted to building understanding and skill, the load that actually helps you improve over time.
+
+For productivity apps, extraneous load is the enemy. When you spend mental energy navigating your task system. Scanning long lists, interpreting metadata, deciding what to prioritize from dozens of visible options. That’s extraneous load. It doesn’t contribute to your work. It just depletes the mental resources you need to do it.
+
+## How Your Task App Increases Cognitive Load
+
+Most task apps are optimized for capturing tasks, not for minimizing the mental overhead of using them. The result is a design that feels powerful at first glance but generates significant extraneous load every time you open it.
+
+**Scanning a large list of tasks** is itself cognitively expensive. Your brain doesn’t just see a list. It reads each item, evaluates it for relevance, and processes it before moving to the next one. A list of 50 tasks doesn’t cost one unit of attention; it costs fifty separate micro-evaluations, each of which draws on your limited working memory.
+
+**Reading metadata** multiplies this cost. Due dates, priority labels, project tags, subtask indicators, assignees, recurring-task markers. Each piece of metadata is an additional data point your brain has to process and integrate into its model of what needs to happen. The more metadata per task, the higher the extraneous load per item.
+
+**Making prioritization decisions across many items** is perhaps the most expensive cognitive operation your task app demands. Every time you open your list and must decide what to do next, you’re running a complex evaluation across every visible item. With three tasks, that’s manageable. With thirty, you’re spending significant cognitive resources just to figure out where to start.
+
+**Remembering context** adds yet another layer. A task you added two weeks ago, “follow up on the proposal draft”. Requires mental reconstruction: which proposal? Which draft? What was the status? What does “follow up” actually mean here? Every decontextualized task is a small puzzle you have to solve before you can even decide whether to do it.
+
+## The Cognitive Cost of Overdue Items
+
+There’s a specific type of cognitive burden that overdue tasks create, beyond the general overhead described above. Psychologists call it the Zeigarnik effect: incomplete tasks create persistent mental intrusion. Your brain keeps returning to unfinished business, even when you’re nominally doing something else entirely.
+
+An overdue task doesn’t just appear on your list once. It reappears in your thoughts during meetings, during conversations, in the moments before you fall asleep. Each recurrence is a small cognitive tax. An interruption to whatever you were actually trying to think about. Scale that across ten or twenty overdue items, and you’re carrying a substantial background load of mental intrusion throughout your entire day.
+
+This is what task debt actually costs, not just the guilt of looking at the red items, but the persistent cognitive drain of unresolved open loops. Every overdue task is a micro-decision your brain keeps re-opening. Did I forget something? Should I feel bad about this? Do I still need to do this? Is it too late? Each of these questions consumes mental capacity that could be going toward your actual work.
+
+## Why Simpler Systems Reduce Cognitive Load
+
+The cognitive load argument for simpler productivity systems isn’t about aesthetics or minimalism as a value. It’s about mental resource allocation. Every unit of cognitive capacity you spend navigating your task system is a unit you’re not spending on the work itself.
+
+A shorter daily task list reduces cognitive load in a concrete, measurable way, fewer visible items means fewer evaluations, fewer decisions, and less working memory consumed by the list itself. If your daily view shows five tasks instead of fifty, you’ve reduced the scanning cost by a factor of ten before you’ve made any other changes.
+
+The daily focus list functions as what cognitive scientists would call a **cognitive container**. A boundary that limits the scope of what your brain needs to actively process. If a task isn’t on today’s list, your brain doesn’t need to hold it in working memory right now. It exists in the backlog, accessible when you need it, but outside the active processing scope of your current day. This is the same principle behind progressive disclosure in interface design, show people only what they need right now, and let them access more when they ask for it.
+
+A good daily planning system builds this boundary deliberately. The decision about what enters today’s list is made once, at the start of the day. And then you don’t have to keep re-evaluating the full backlog while you’re trying to work.
+
+## Feature Complexity vs. Productivity
+
+There’s a well-documented paradox in productivity software, the apps with the most features are often the ones that produce the least actual productivity. This isn’t because features are bad. It’s because every feature adds cognitive overhead to the tool itself.
+
+Each additional feature in a task app creates new decisions. Do I use tags or projects for this? Should this be a subtask or a standalone task? Does this belong in the personal space or the work space? Should I set a priority level, or just a due date, or both? These decisions feel like small choices, but they accumulate. The act of using the tool becomes a cognitive task in its own right.
+
+This is feature creep as a design problem. Not just a software problem. When tool designers add features to serve power users, they inadvertently shift cognitive burden to every user, including those who will never use the advanced features. The result is an app that demands more from you just to operate it, leaving you less capacity for the work the app is supposed to support.
+
+Choosing between features is itself a decision, and decision fatigue is real. The more small decisions you make about your system, the less decision-making capacity you have for your actual work. Simpler tools win not because simplicity is inherently virtuous, but because they conserve the cognitive resources that matter.
+
+## The Design Principle Behind Low-Cognitive-Load Apps
+
+The design choices that reduce cognitive load in a productivity app share a common logic, minimize the decisions users need to make about the system so they can focus on the work instead.
+
+**Progressive disclosure** means showing only what’s needed right now, keeping the rest accessible but not visible. A backlog that’s separate from your daily view embodies this principle. Everything is there if you need it, but it’s not demanding processing power when you don’t.
+
+**Defaults that work** eliminate the need to configure the system to get value from it. If the default behavior is sensible, most users never need to touch the settings. Which means they never spend cognitive energy making those configuration decisions.
+
+**Automatic cleanup** is perhaps the most powerful cognitive load reducer. When a system removes irrelevant tasks for you, or resets daily, returning incomplete tasks to a neutral state. It eliminates an entire category of decisions, the ongoing triage of what to do with things you didn’t do. In Dawny, incomplete Daily Focus tasks automatically return to the Backlog at 3 AM. There are no overdue labels. There’s no red counter. Every morning starts with a clean slate, and the system handles the cleanup so you don’t have to.
+
+> “I never thought the reduced approach was right for me. But after the first test, I simply didn’t stop using Dawny.”, Dawny beta tester
+
+The Make It Count mechanic takes this further, tasks that keep getting skipped over multiple resets are automatically archived. Your brain doesn’t have to keep evaluating whether this task still matters. The system notices the pattern and removes it from view. The insight is that a task you’ve bypassed five times in a row has already told you it’s not a priority. The system just makes that reality visible.
+
+## How to Reduce Cognitive Load in Your Current Setup
+
+You don’t need a new app to start reducing cognitive load in your workflow. These steps work within whatever system you’re already using.
+
+**Archive anything you haven’t touched in two weeks.** If a task has been on your list for two weeks without being selected for action, it’s generating cognitive overhead without providing value. Move it out of your active view. To a someday list, an archive, or delete it entirely. You’re not abandoning the task. You’re making an honest assessment of its current priority.
+
+**Reduce your visible daily tasks to 3–5.** This is the single highest-leverage change most people can make. Not because 5 tasks is the maximum you can accomplish in a day, but because limiting your daily list forces a real prioritization decision upfront, and then frees you from re-prioritizing continuously throughout the day.
+
+**Remove labels and projects that don’t drive decisions.** Metadata is only valuable if it actually changes what you do. If you have tags or project categories that exist but never influence which task you pick next, they’re generating cognitive load for no benefit. Audit your labels ruthlessly, if you can’t describe how a particular tag affects your prioritization, delete it.
+
+**Create a “someday” list completely separated from your daily view.** The goal is a hard cognitive boundary between “what I’m considering for today” and “everything else.” This separation means your brain can genuinely stop processing the “everything else” list during working hours, because there’s no visual reminder of it competing for attention.
+
+**Make one prioritization decision per day, not one per task.** Instead of evaluating each task every time you look at your list, spend five minutes each morning deciding what goes on today’s list. And then stop evaluating. The list is set. Work from it. This moves the cognitive cost to a single, dedicated moment rather than spreading it across the entire day.
+
+## Frequently Asked Questions
+
+### What is cognitive load in productivity?
+
+Cognitive load in productivity refers to the mental effort required to manage and navigate your task system. As distinct from the mental effort of doing the actual work. High cognitive load from your task app means less mental capacity available for the work that matters. Low-cognitive-load systems are designed to minimize the overhead of system operation so that more mental resources go toward actual output.
+
+### How does cognitive load affect work performance?
+
+Cognitive load directly reduces working memory capacity, which in turn impairs decision-making, attention, and creative problem-solving. When your task system generates high extraneous cognitive load. Through complex interfaces, large visible task lists, or ongoing prioritization decisions. You’re starting the actual work with a depleted cognitive budget. Research on working memory consistently shows that overloaded systems produce lower quality output and more errors.
+
+### How do I reduce mental overhead in my workflow?
+
+The most effective steps are, limit your visible daily tasks to 3–5, move everything else out of your daily view, eliminate metadata that doesn’t drive real decisions, and adopt a single daily prioritization moment instead of continuous re-evaluation. Automatic cleanup systems, apps or habits that handle the triage of undone tasks. Remove an entire category of ongoing decisions that otherwise accumulate as cognitive overhead.
+
+### Why do simpler to-do lists work better?
+
+Simpler to-do lists work better because they reduce the number of cognitive operations required to use them. Fewer visible items means less scanning, fewer prioritization decisions, and less working memory consumed by the list itself. The goal of a task list is to support your work, not to become a cognitive task in its own right. When the list is short enough to hold in your head, you can focus on doing the tasks instead of managing the system.
+
+### What is the relationship between cognitive load and decision fatigue?
+
+Cognitive load and decision fatigue are closely related but distinct concepts. Cognitive load describes the mental effort required to process information at any given moment. Decision fatigue describes the degradation of decision quality that occurs after making many decisions in sequence. A high-cognitive-load task system contributes to decision fatigue because it forces many small decisions, about prioritization, metadata, and task relevance. That consume the same mental resources used for real work. Reducing cognitive load in your system is one of the most effective ways to preserve decision quality throughout the day.
+
+## Conclusion
+
+The productivity tools that feel most powerful. The ones with the most features, the most customization, the most visible information. Often make you less productive, not more. This isn’t a paradox once you understand cognitive load theory. Complex systems demand cognitive resources just to operate. Every unit of attention spent scanning a long task list, interpreting metadata, or deciding what to prioritize is a unit not spent on actual work.
+
+The alternative isn’t about being minimalist for aesthetic reasons. It’s about designing your system so that it demands as little as possible from you, and gives you back the mental bandwidth to do your best work. That means shorter daily lists, automatic cleanup of undone tasks, and a clean separation between your daily focus and everything else waiting in the wings. Simpler systems win not because they’re simpler, but because they respect the limits of human attention.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/daily-planning-system.md
+++ b/website/src/content/blog/en/daily-planning-system.md
@@ -1,0 +1,169 @@
+---
+title: "How to Build a Daily Planning System That You'll Actually Use"
+description: "Learn how to build a daily planning system that sticks by covering capture, focus lists, daily resets, and why simplicity beats complexity."
+pubDate: 2026-05-10
+---
+
+# How to Build a Daily Planning System That You’ll Actually Use
+
+> **Quick Answer:** A daily planning system is a consistent method for deciding each morning which tasks to focus on that day. The most effective systems share three properties: they are simple enough to maintain daily, they separate your backlog from your active focus list, and they don’t penalize you when a day goes wrong. The best system is the one you actually use, not the most sophisticated one.
+
+You’ve probably tried time blocking. Maybe you built an elaborate bullet journal spread on a Sunday night, color-coded and beautiful, and abandoned it by Wednesday. Maybe you read about GTD, set up a whole project hierarchy, and never trusted the system enough to actually stop worrying. The problem isn’t the methods but the friction. A daily planning routine only works when maintaining it costs almost nothing. The moment it becomes a chore, it becomes optional. And optional habits don’t survive contact with a difficult week.
+
+This guide covers everything you need to build a daily planning system that you’ll actually stick with. It moves from the fundamentals of what makes planning work, through the five concrete steps of an effective daily routine, to the common mistakes that quietly kill even good systems. This is the complete picture, not a shortcut.
+
+## What Is a Daily Planning System?
+
+A daily planning system is any consistent method for deciding, each day, which tasks deserve your attention and which can wait. It has two functions: **capture** (getting tasks out of your head and into a trusted place) and **commitment** (choosing the small set of tasks you’ll focus on today). Every effective planning system serves both functions. The failure modes usually trace back to one being broken or missing.
+
+A system without good capture means you’re constantly trying to remember what exists. A system without a real commitment step means your daily list is just your full backlog, an undifferentiated pile with no signal about what actually matters today.
+
+## The Core Principle: Separate Your Backlog From Your Daily List
+
+The single highest-leverage change you can make to your daily planning is to stop using one unified list for everything. Most people start with a single to-do list. Tasks go in, tasks (sometimes) come out, and over time the list grows into something that feels more like a ledger of guilt than a useful planning tool.
+
+The problem with a single unified list is that it mixes two completely different kinds of items: things you might want to do someday, and things you are genuinely committing to do today. These require different mental stances. When they live in the same place, you can’t tell them apart at a glance, and you end up re-evaluating the entire list every time you try to plan your day.
+
+The solution is a two-list system with a proper backlog. Your Backlog holds everything that might matter — ideas, future tasks, low-priority items, someday-maybe projects. Your Daily Focus list holds only what you’re genuinely committing to today. Nothing migrates from the Backlog to your Daily Focus list automatically. You choose it, deliberately, each morning. That act of choosing is itself planning.
+
+This separation does something psychologically important, it makes your daily list manageable by definition. You’re not trying to extract signal from noise every time you glance at your tasks. The noise lives in the Backlog. Your daily view shows only what you’ve decided matters today.
+
+## Step 1: Capture Everything (Without Commitment)
+
+The first step in any effective daily planning system is building a reliable capture habit. When a task, idea, or obligation comes to mind, write it down immediately. Don’t evaluate it, don’t prioritize it, don’t ask whether it’s worth doing. Just capture it.
+
+The purpose of this step is to get things out of your head and into a trusted external system. Your brain is excellent at generating ideas and terrible at storing them reliably. Every task you try to hold in working memory is taking up cognitive resources that could be doing useful work. The act of writing something down (in a Backlog, a notes app, or a physical notebook) completes a mental handoff. You stop tracking it. The system tracks it for you.
+
+The rule for capture is, **capture without filtering**. If you start evaluating tasks during capture, you’ll either slow down so much that you stop capturing, or you’ll start making commitment decisions before you have the full picture of your day. Capture first. Filter later. The Backlog is not a commitment; it’s an inbox.
+
+In practice, this means capturing everything, vague ideas, tasks with no deadline, tasks that probably won’t happen, tasks that might be someone else’s problem. You can sort all of that out during your daily planning session. What you cannot do is recover a task you didn’t capture because you decided on the spot it wasn’t worth writing down.
+
+## Step 2 — Choose Your Focus Tasks for Today
+
+The commitment step is where most daily planning systems succeed or fail. Capture is easy (almost everyone can build a capture habit), but choosing is harder because it means deciding what not to do.
+
+Each morning, open your Backlog and choose the tasks you’re committing to today. Not the tasks you’d like to do, or the tasks that feel vaguely important, or the tasks you’ve been putting off so long that you feel obligated to include them. The tasks you’re actually committing to, today, given your actual energy level and the realistic number of hours available.
+
+**How many tasks?** Research on decision-making and cognitive load consistently shows that humans are poor judges of how long tasks take and how many they can fit into a day. A study on the planning fallacy found that people systematically underestimate completion times. The practical implication is to plan for fewer tasks than you think you can handle, not more. Additional resources include this neutral overview of planning bias and a productivity-focused article.
+
+Most productivity practitioners who have worked with task planning for years recommend somewhere between three and five tasks as your daily focus list. Three is often enough. Five is usually pushing it. The point is to make the list small enough that completing everything on it is a realistic outcome, not an aspirational one. A list you complete feels fundamentally different from a list you fall short of, and that feeling determines whether you come back to the system tomorrow. Additional resources on the three-task approach include this guide to the three-task productivity rule and this practical overview for self-employed people.
+
+When you choose your focus tasks, put them on a separate list (physically or digitally separate from your Backlog). The Backlog stays intact. Your Daily Focus list is what you’re working from today. At the end of the day, you’ll return to this distinction.
+
+## Step 3 — Protect Your Focus Time
+
+Choosing your tasks is only half the commitment. The other half is creating conditions where you can actually do them.
+
+The most effective way to do this is to block time on your calendar for your most important task of the day. Rather than “I’ll get to it when I have a moment,” create an actual calendar entry with a start time and duration. This protects that time from meeting requests, interruptions, and the ambient pull of lower-stakes tasks that feel easier in the moment.
+
+You don’t need a fully time-blocked schedule to get the benefit of this. A single protected block (say, 9 AM to 11 AM, reserved for your top task) is enough to anchor your day. Everything else can flex. The one thing that doesn’t flex is the time you’ve committed to your actual priority.
+
+If you can identify your peak cognitive hours (the time of day when your focus and decision-making are sharpest), schedule your most important task then. For most people, this is in the morning before the day’s context-switching has depleted executive function. Reserve that window and treat it as a commitment to yourself, not a suggestion.
+
+## Step 4: Handle the End of Day (The Reset Moment)
+
+This is the step that most daily planning guides skip or treat as an afterthought. It’s actually the step that determines whether your system stays healthy over time.
+
+At the end of each day (or during a short planning session the next morning), you face a simple question, what do you do with the tasks on your Daily Focus list that you didn’t finish?
+
+Most task apps answer this question automatically, they turn the task red and label it overdue. This is psychologically disastrous. The overdue label doesn’t distinguish between a task you deliberately deprioritized because something more important came up and a task you forgot to do. Both get the same red badge. Both feel like failures. Over time, a growing collection of red, overdue items makes opening your task app feel like walking into a room full of accusations. People don’t do that willingly for long. This is a primary reason why to-do lists fail, not because the tasks aren’t real, but because the system’s feedback loop creates avoidance rather than action.
+
+The alternative is a reset. Instead of labeling incomplete tasks as overdue, you return them to the Backlog. They remain neutral and uncharged, available to be chosen again if they’re still worth choosing. The day ends clean. Tomorrow starts clean. You didn’t fail; you made choices, and the tasks you didn’t choose are waiting for another day.
+
+This is the core mechanic in Dawny, incomplete Daily Focus tasks return to the Backlog automatically at the end of each day. There’s no overdue pile. There’s no growing wall of guilt. Tasks that keep getting returned to the Backlog (those that never make it onto the Daily Focus list) eventually get archived automatically through a mechanic called Make It Count. You don’t have to force yourself to do a manual cleanup. The system notices patterns and surfaces them for you.
+
+> “I actually use Dawny every morning. The daily reset gives me the breathing room I need.” – Dawny beta tester
+
+> “Almost all the tasks that were automatically archived were simply not important enough. I haven’t moved a single one back.” – Dawny beta tester
+
+The psychology behind this is straightforward, if a task keeps getting skipped, that’s information. It means the task either isn’t a real priority, belongs to a future version of your life that hasn’t arrived yet, or isn’t actually your task to do. A daily reset lets you act on that information naturally, without a forced decision. You’re not deleting the task. You’re just not choosing it again. The system eventually acknowledges the pattern.
+
+The daily reset and morning routine is worth treating as a ritual rather than an administrative chore. Even two minutes (reviewing what you finished, returning incomplete tasks to the Backlog, choosing tomorrow’s focus) creates a clean psychological boundary between today and tomorrow.
+
+## Step 5: Weekly Review (Five Minutes)
+
+Even with a daily reset in place, your Backlog will grow over time. Capture is ongoing. New items arrive constantly. Without periodic pruning, you’ll eventually be choosing your daily tasks from a Backlog of 200 items, which defeats the purpose of having a Backlog at all.
+
+Once a week (Friday afternoon or Sunday evening both work well), spend five minutes reviewing your Backlog. Not to do the tasks, just to look at them. Ask three questions, Is this still relevant? Is this something I’ll realistically ever do? Is this actually my responsibility?
+
+Anything that fails those questions should be deleted or archived. You are not abandoning those tasks. You’re making an honest assessment that they’re not going to happen and clearing the path for the tasks that are. This is how you prevent task debt from accumulating. Not through a heroic annual purge, but through five minutes of honest pruning each week.
+
+The weekly review also gives you a chance to notice patterns. If the same task has been sitting in your Backlog for three weeks without ever making it onto your Daily Focus list, that task is telling you something. Either it’s not actually a priority, or there’s a blocker you haven’t addressed. Either way, you need to make a decision about it rather than continue to let it sit and take up space.
+
+## Common Mistakes in Daily Planning
+
+Even with a good system, a few recurring mistakes quietly undermine daily planning routines. Here’s what to watch for.
+
+**Too many tasks on the daily list.** This is the most common mistake and the most damaging. When your daily list has twelve items and you complete five, you end the day feeling behind even though you did five things. A shorter list that you complete is motivationally far superior to a longer list that you partially finish. Start with three tasks. Add more only when you’ve reliably completed three.
+
+**Mixing capture with commitment.** If you evaluate tasks while you’re capturing them, you’ll either slow capture to a stop or make premature commitment decisions without seeing the full picture. Keep the two steps separate. Capture first, undiscriminatingly. Choose from the captured pool later, during a dedicated planning moment.
+
+**Never reviewing or pruning the Backlog.** A Backlog that only grows becomes another source of overwhelm, a different kind of task debt. The weekly five-minute review is what keeps the Backlog functional rather than just a longer version of the problem you were trying to solve.
+
+**Letting overdue labels become guilt triggers.** If your current system uses overdue indicators and you feel worse each time you open your task app, that’s not a discipline problem. It’s a design problem. The system is generating a feedback loop that drives avoidance. The fix is either turning off due dates for tasks that don’t have real deadlines, or switching to a system that uses a reset model instead of an overdue model.
+
+**Building a system too complex to maintain daily.** Complexity is the silent killer of planning habits. A system that requires thirty minutes to maintain will get skipped on the days when you most need it (which are always the busy, difficult days). The system that survives contact with your hardest weeks is almost always the simplest one.
+
+## Simple vs. Elaborate Systems: What the Research Says
+
+There’s a persistent idea in productivity culture that a more elaborate system produces better outcomes. More features, more categories, more views, more integrations, and more control. The research on cognitive load suggests this is exactly backwards.
+
+Roy Baumeister’s foundational work on decision fatigue shows that making decisions is a finite cognitive resource. The more decisions you make, the worse subsequent decisions get. A complex planning system that requires many micro-decisions just to maintain (which category does this go in? which project? which priority level?) is depleting exactly the resource you need for actual work.
+
+The practical implication for cognitive load in productivity is stark. A simple system you maintain effortlessly is almost always more effective than a sophisticated system you maintain reluctantly. The question to ask about any new planning feature or workflow is not “would this be useful?” but “would I still be doing this in three months?” Most elaborate systems don’t survive three months of real life. Simple systems do.
+
+This is why the two-list model (Backlog plus Daily Focus, with a daily reset) tends to outperform more sophisticated alternatives in practice. Not because it’s theoretically optimal, but because it’s easy enough to do every day, including the days when everything goes wrong.
+
+## Which Daily Planning Method Is Right for You?
+
+There’s no single answer. Different systems work for different people, and the honest answer is that you’ll probably need to experiment before you find the approach that fits your brain. Here’s a framework for narrowing it down.
+
+**If you thrive with structure and have predictable blocks of time,** Time blocking may work well for you. Assign specific tasks to specific time slots on your calendar, treat those blocks as appointments, and review and rebuild your schedule each morning. The benefit is clarity and commitment. The downside is fragility, as one unplanned meeting can cascade through your whole day.
+
+**If you want minimal friction and a forgiving system,** The two-list model with a daily reset is likely your best fit. Capture in the Backlog, choose three to five tasks each morning, reset at the end of the day. The entire maintenance overhead is about ten minutes daily and five minutes weekly. It doesn’t require a perfect day to work.
+
+**If you’re managing ADHD or executive function differences,** Standard planning advice often fails because it assumes consistent working memory, easy task initiation, and reliable time estimation (none of which come easily with ADHD). The most effective systems for ADHD tend to be those with very low initiation cost, automatic resets that remove the shame loop, and short daily lists that don’t require sustained self-regulation to navigate. There’s a dedicated guide on productivity apps and systems for ADHD if this applies to you.
+
+**If you’re a team lead or knowledge worker with complex projects,** You may need a hybrid. A personal daily planning system for your own tasks, combined with a project management tool for tracking team work. The key is keeping these separate rather than trying to manage both in one system.
+
+The founder of Dawny built his own system (and eventually his own app) because he has ADHD and nothing on the market matched how his brain actually worked. Not to be more productive in the abstract, but to stop dreading his own task list. The philosophy behind Dawny is that the right system isn’t necessarily the most powerful one. It’s the one that removes shame from the equation entirely.
+
+## Frequently Asked Questions
+
+### What is the best daily planning method?
+
+The best daily planning method is the one you’ll actually use consistently, which means the simplest one that meets your core needs. For most people, a two-list system (Backlog plus a small Daily Focus list) with a daily reset covers everything necessary without adding enough friction to cause abandonment. Elaborate methods like full GTD or rigid time blocking work well for people who maintain them, but most people don’t maintain them through difficult stretches.
+
+### How many tasks should I plan per day?
+
+Research on cognitive load and task estimation consistently supports planning fewer tasks than you think you can handle. Three tasks is a reasonable starting point. Most people find that three well-chosen tasks, fully completed, represents a productive and satisfying day. Five is usually the practical upper limit before completion becomes unlikely. The goal is to set a daily list that you can realistically finish, not one that captures everything you wish you could do.
+
+### What time of day should I plan my tasks?
+
+Either early morning (before the day’s interruptions begin) or the evening before both work. Morning planning has the advantage of knowing your energy level and any new inputs from the previous evening. Evening planning has the advantage of being able to close out the day with a clear sense of what comes next. Consistency matters more than timing. Pick a moment that fits your schedule and protect it.
+
+### How do I stick to a daily planning routine?
+
+Reduce friction to the point where the routine feels almost automatic. Keep your planning tool open and visible. Make the daily session short enough (ten minutes or less) that it doesn’t feel like an investment. Attach it to an existing habit (coffee, commute, morning walk). And critically, don’t evaluate whether the routine is “working” until you’ve done it consistently for at least three weeks. One missed day is not a failure. It’s a data point. The routine survives missed days.
+
+### What should I do with tasks I didn’t finish today?
+
+Return them to your Backlog, not to an overdue list. The distinction matters psychologically. An overdue list says you failed. A Backlog says the task is waiting for you to choose it again. When you look at the task tomorrow with fresh eyes, you can make a fresh decision, is this still worth doing? If the same task returns to your Backlog multiple times without ever making it onto your daily list, treat that as a signal. The task may not be a real priority, and a good system will eventually help you see that clearly.
+
+## Conclusion
+
+The most effective daily planning system isn’t the most sophisticated one. It’s the one with low enough friction that you maintain it every day, including the hard days. It separates your backlog from your daily focus list. Lets you commit to a small number of tasks rather than an aspirational pile. And handles the inevitable incompletions without punishment, because punishment breeds avoidance and avoidance is where all planning systems go to die.
+
+The five-step framework in this guide (capture, choose, protect, reset, review) gives you that foundation. You don’t need to implement all five perfectly from day one. Start with capture and the daily focus list. Add the reset ritual after a week. Build in the weekly review once that feels natural. Simple beats elaborate at every stage.
+
+The relationship between you and your task list should not feel adversarial. It should feel like a tool that helps you make good decisions — one that resets cleanly when the day is done and starts fresh when the next one begins.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/dawny-vs-todoist.md
+++ b/website/src/content/blog/en/dawny-vs-todoist.md
@@ -1,0 +1,137 @@
+---
+title: "Dawny vs. Todoist: Two Different Philosophies for Getting Things Done"
+description: "Todoist vs Dawny: an honest comparison of a powerful feature-rich task manager and a minimal iOS app built around daily resets."
+pubDate: 2026-05-10
+---
+
+> **Quick Answer:** Dawny vs Todoist comes down to philosophy. Todoist is a feature-rich task manager built for power users who want full control — projects, labels, subtasks, recurring tasks, integrations, and team collaboration. Dawny is a minimal iOS task app built on one principle: unfinished daily tasks reset automatically instead of becoming overdue. If you have ever felt overwhelmed by your Todoist backlog, Dawny might be worth trying.
+
+You have a system. You have been using Todoist for months — maybe years. You added projects, labels, filters, and priorities. You even watched a YouTube video about the best Todoist setup. And yet, every time you open the app, that sinking feeling arrives before you have processed a single task. The list is long. The overdue items are red. You are somehow more stressed than you were before you had a system.
+
+If this sounds familiar, you are not alone — and you are not bad at productivity. You might just be using a tool that was built for a different kind of brain. This article compares Dawny and Todoist honestly: what each does well, where each falls short, and which type of person belongs in which camp.
+
+## Quick Comparison: Dawny vs Todoist at a Glance
+
+FeatureTodoistDawnyDaily task limitNoneIntentionally smallOverdue tasksShown with red labelsReset to Backlog automaticallyPlatformsiOS, Android, Web, DesktopiOS only (currently)SubtasksYesNoLabels and filtersYesNoTeam collaborationYesNoIntegrations (calendar, Slack, etc.)YesNoPriceFree tier + paid plansFree (beta)Best forPower users, teams, complex projectsIndividuals who feel overwhelmed by their task app
+
+This table alone might tell you everything you need to know. But the numbers and checkboxes miss the more important question: what does it *feel* like to use each app every day?
+
+## What Todoist Does Well
+
+Todoist is genuinely excellent software. It has earned its place as one of the most popular task managers on the market, and for good reason.
+
+Its project system lets you organize work at any level of complexity — personal, professional, or team-wide. Subtasks, sections, and nested projects mean you can model almost any workflow. Labels and filters let power users slice their task list in dozens of ways, surfacing exactly what needs attention at any moment.
+
+The integration library is deep. Todoist connects with Google Calendar, Outlook, Slack, Zapier, and dozens of other tools via its official integrations. If your work already lives in other apps, Todoist can plug in without asking you to change your habits. For an independent assessment, see this Forbes review of Todoist.
+
+For teams, shared projects and task assignment make Todoist a legitimate lightweight project management tool. If you manage multiple people or hand off work regularly, that capability matters.
+
+## Where Todoist Struggles for Some Users
+
+None of this is a criticism of Todoist. It is an observation about a pattern that shows up again and again with certain types of users.
+
+When a task manager has no natural limit on how many items you can add, lists grow. When lists grow faster than you complete tasks, overdue items accumulate. Todoist marks those items in red, because it is trying to help — but for users with ADHD, anxiety, or a tendency toward overwhelm, that red count becomes something to avoid rather than address.
+
+More features also means more decisions. Before you can just *do* something, you have to decide, which project does this belong to? What priority? Which label? Should I set a due date? The overhead of maintaining a perfect system can cost more cognitive energy than the tasks themselves.
+
+This is what researchers sometimes call task debt. The accumulating weight of things you meant to do but did not. Todoist, like most traditional task managers, surfaces that debt constantly. For some users, that visibility is motivating. For others, it is paralyzing.
+
+## What Dawny Does Differently
+
+Dawny was built by an indie developer who has had ADHD his whole life. He tried every productivity app on the market, including Todoist. And hit the same wall every time. He built Dawny for his own brain, not to be more productive but to stop dreading his own task list.
+
+The core mechanic is simple, at the end of each day, any tasks you did not complete in your Daily Focus automatically return to your Backlog. They do not become overdue. They do not turn red. They simply wait, without judgment, until you choose them again.
+
+Your Backlog is everything you might want to do someday. Your Daily Focus is the small set of tasks you choose to focus on *today*. Intentionally kept small. Each morning you make an active, deliberate decision about what matters. Tasks that you keep skipping eventually get archived automatically through the “Make It Count” mechanic. No guilt required.
+
+This is the opposite of why most to-do lists fail, Dawny does not let your list become a monument to your past intentions. It forces a daily renegotiation with what actually matters now.
+
+Beta testers describe the shift clearly,
+
+> “I never thought the reduced approach was right for me. But after the first test, I simply didn’t stop using Dawny. My old to-do list app now sits unopened with all its never-completed tasks still in there.”, *Dawny beta tester*
+
+> “Since using Dawny, I’m no longer afraid to look at my task list. Because the tasks I won’t complete anyway simply don’t show up anymore.”, *Dawny beta tester*
+
+**A note on transparency,** Dawny is currently an iOS-only app in public beta on TestFlight. It has significantly fewer features than Todoist. No subtasks, no labels, no integrations, no web access, no team features. If those things matter to you, Todoist is the better choice right now.
+
+## Who Should Use Todoist
+
+Todoist is the right tool if,
+
+- You manage complex projects with multiple moving parts or stakeholders
+
+- You work on a team and need shared task lists or task assignment
+
+- You rely on integrations with Google Calendar, Slack, or other tools
+
+- You have a high task volume and genuinely need filtering and search to navigate it
+
+- You thrive when you have full visibility into everything on your plate
+
+Todoist rewards users who have the capacity and preference to manage a complex system. If that description fits you, it is one of the best tools available.
+
+## Who Should Try Dawny
+
+Dawny is worth trying if,
+
+- You have abandoned multiple to-do apps because the list eventually became too overwhelming
+
+- You feel a low-grade guilt every time you open your current task app
+
+- You have ADHD, anxiety, or focus challenges and found that feature-rich apps made things worse, not better
+
+- You already have a separate system for complex projects and want something lighter for daily personal focus
+
+- You are an iPhone user looking for a simple daily focus tool with no learning curve
+
+Dawny does not try to replace Todoist for project management. It is designed for the daily question, *what am I actually doing today?*
+
+## The Philosophical Difference
+
+This is the heart of it. Todoist trusts the user to manage complexity. It gives you every tool you need and steps back. If you can handle the cognitive load of a large, detailed system, Todoist rewards that investment.
+
+Dawny removes complexity from the equation. It makes an opinionated bet, for certain people, the best task management is the kind that resets your slate every morning and refuses to let yesterday’s failures haunt today. The limits are not bugs, they are the product.
+
+Neither philosophy is wrong. The question is which one matches how your brain actually works, not how you wish it worked.
+
+## Frequently Asked Questions
+
+### Is Dawny a good Todoist alternative?
+
+Dawny is a good alternative for users who feel overwhelmed by Todoist’s feature set or who struggle with accumulating overdue tasks. It is not a direct replacement. It has far fewer features and is currently iOS-only. If you want project management, team collaboration, or deep integrations, Todoist is still the better tool. Dawny is best for people who need a lighter daily focus system.
+
+### What is the difference between Dawny and Todoist?
+
+The core difference is how they handle unfinished tasks. Todoist marks them overdue and keeps them visible until completed. Dawny automatically resets incomplete Daily Focus tasks back to the Backlog at the end of each day, so you start every morning without a backlog of guilt. Todoist is also cross-platform with many features; Dawny is iOS-only and intentionally minimal.
+
+### Which task app is better for ADHD?
+
+There is no universal answer, but many users with ADHD find that feature-rich apps like Todoist increase overwhelm rather than reduce it. The constant visibility of overdue tasks and the overhead of maintaining a complex system can be counterproductive. Dawny was designed specifically with this pattern in mind. The automatic reset and intentionally small Daily Focus list reduce the cognitive burden. That said, some people with ADHD thrive with structure-heavy tools; it depends on the individual.
+
+### Can I import my Todoist tasks to Dawny?
+
+Not currently. Dawny does not have an import feature in its beta. You would need to manually add tasks you want to carry over. Given Dawny’s philosophy of intentional daily selection, many users find that starting fresh, rather than importing an existing backlog, is actually the better experience.
+
+### Is Dawny free?
+
+Yes. Dawny is currently free to use during its public beta on TestFlight. There is no subscription required to join the beta.
+
+## Conclusion
+
+Todoist is a great app. If you are a power user who needs projects, integrations, team features, and full control over a complex task system, it deserves its reputation.
+
+But if you are someone who has tried apps like Todoist and walked away feeling worse. If the red overdue labels made you avoid your task manager instead of use it. The problem was never your work ethic. It was the mismatch between the tool and the way your brain processes pressure and choice.
+
+Dawny is not trying to out-feature Todoist. It is trying to do one thing differently, make your task list a place you want to open in the morning, not something you dread. It resets instead of accumulates. It limits instead of expands. It archives tasks that keep getting skipped instead of letting them haunt you indefinitely.
+
+It is a beta, it is iOS-only, and it has fewer features than almost every other app in this category. But for the right person, that is exactly the point.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/decision-fatigue-task-management.md
+++ b/website/src/content/blog/en/decision-fatigue-task-management.md
@@ -1,0 +1,131 @@
+---
+title: "Decision Fatigue and Your To-Do List: Why More Tasks Make You Less Productive"
+description: "Decision fatigue drains your focus before you start working. Learn how your task list design causes it — and how a smaller daily list fixes it."
+pubDate: 2026-05-10
+---
+
+> **Quick Answer:** Decision fatigue productivity loss is real — a to-do list with 40 items forces you to make 40 micro-decisions (“should I do this now?”) before you start any actual work. That mental drain leads to poorer choices later in the day and a growing urge to avoid the list entirely. Keeping a small, intentional daily list — separate from your full backlog — prevents decision fatigue before it starts.
+
+You’ve noticed it before: the more you have to do, the less you seem to accomplish. You open your task app with good intentions, scan the list, and somehow end up doing nothing on it — or doing the easiest thing you can find just to feel like you moved. This isn’t laziness. It isn’t a lack of motivation. It’s your brain doing exactly what brains do when they’re asked to make too many choices at once.
+
+Every task on your list is an unresolved question. And unresolved questions cost you — even before you answer any of them. The research is clear on this, and the fix is structural, not motivational. If your task system is exhausting you before the workday properly begins, the problem isn’t you. It’s the design.
+
+## What Is Decision Fatigue?
+
+Decision fatigue is the deterioration in the quality of decisions made by a person after a long session of decision-making. The term was popularized following psychologist Roy Baumeister’s foundational research on ego depletion — the finding that self-control and decision-making draw from a shared, finite cognitive resource. When that resource runs low, your brain doesn’t fail completely; it cuts corners. It defaults to the easiest option, avoids choosing altogether, or makes impulsive decisions it would have rejected with a full tank.
+
+One of the most striking illustrations of this comes from a study of Israeli judges reviewed by Jonathan Levav and Shai Danziger. Prisoners appearing before a parole board early in the day were granted parole about 65% of the time. By the end of a session, approvals dropped close to zero — not because of anything the prisoners did, but because the judges’ decision-making capacity had been depleted. The same cognitive mechanism operates when you stare at a list of 50 tasks before 9 AM.
+
+The concept has since been extensively studied in decision-making research — from healthcare to retail to, increasingly, knowledge work and personal productivity. The core finding holds: more decisions made equals worse decisions made later. For additional context, the original Baumeister study on ego depletion remains a foundational reference, and modern guides like this comprehensive guide to overcoming decision fatigue and this practical article on decision fatigue tactics offer additional perspectives.
+
+## How Your Task List Causes Decision Fatigue
+
+A task list of 40 items isn’t 40 tasks. It’s 40 open questions. Every time you open your app, each item implicitly asks: “Is this relevant today? Is this urgent? Should I do this now or after lunch? Do I even still need to do this?” That’s not one question per item. It’s a cluster of small judgments that your brain processes before it lets you move on.
+
+This happens fast and mostly below the level of conscious awareness. But it still costs you. By the time you’ve scrolled through a long list and landed on something to work on, you’ve already spent a meaningful portion of your daily decision-making budget on meta-decisions. Choices about choices. You haven’t done a single thing on your list, and you’re already more depleted than when you started.
+
+This is why why to-do lists create overwhelm isn’t just a vague complaint. It’s a mechanistic description of what long task lists actually do to cognitive function. The overwhelm isn’t imaginary. It has a neurological basis.
+
+## The Compounding Effect: Why Bigger Lists Feel Worse Than They Should
+
+The damage from a bloated task list isn’t proportional. It’s compounding. As list length increases, each individual item gets less attention during the scanning phase. Your brain can’t evaluate 50 items as carefully as it evaluates 5. So it starts taking shortcuts, ignoring items that seem hard to think about, deferring anything that requires real evaluation, and gravitating toward whatever looks easiest or most familiar.
+
+The result is a predictable pattern, the quick, uncomplicated tasks get done. The important-but-difficult ones stay on the list indefinitely. And the list keeps growing, because you’re adding new tasks faster than you’re completing the ones that actually matter. The system feeds on itself.
+
+There’s also a motivational cost. When you complete three tasks from a list of five, you’ve cleared 60% of your plate. That feels like real progress. When you complete three tasks from a list of fifty, you’ve barely moved the needle. The feedback loop that should make you feel effective is broken. You do the same amount of work and feel worse about it.
+
+## The Paradox of Choice Applied to Task Management
+
+Psychologist Barry Schwartz, in his 2004 book *The Paradox of Choice*, documented something counterintuitive, more options don’t make people happier or more effective. They make them more anxious and less satisfied. When choosing from a small set of options, people decide quickly and feel good about the outcome. When choosing from a large set, they spend more time deciding, feel less confident in their choice, and experience more regret afterward, even if they made the same decision.
+
+Applied to task management, this principle suggests that the anxiety you feel looking at a long task list isn’t just about having too much to do. It’s about having too many options to choose between. Every unconstrained choice carries a hidden cost, the awareness that you might be choosing wrong. With 50 tasks, the chance that you’re working on the optimal one at any given moment is genuinely low. Your brain knows this, even when you don’t consciously think it through.
+
+Constraining your options, deliberately limiting your daily list to a handful of tasks. Doesn’t just make the day more manageable. It removes an entire category of second-guessing. When you’ve already decided what today holds, you don’t have to keep deciding.
+
+## How to Reduce Decision Fatigue in Your Task System
+
+The structural fix for decision fatigue in task management comes down to three changes, each of which reduces the number of choices you have to make in the moment. For a practical overview of these techniques, see this comprehensive guide to overcoming decision fatigue.
+
+**1. Separate your backlog from your daily list.**
+
+Your backlog is where everything lives. Every idea, every someday task, every project that might matter eventually. It should be comprehensive and low-pressure. Your daily list is a completely separate surface, the small set of things you are actually committing to today. The two-list system makes this split explicit. When you open your daily list, you’re not browsing your entire task universe. You’re looking at a pre-filtered view of today’s commitments.
+
+**2. Limit your daily active list to three to five tasks, chosen in advance.**
+
+Limiting your daily tasks to three is one of the most consistently supported recommendations in productivity research. Not because doing more is bad, but because making the commitment explicit, and small enough to be realistic. Changes the quality of the choices you make. When your daily list has three items, each one gets real consideration. When it has thirty, each one gets a scan.
+
+The “chosen in advance” part matters as much as the limit. If you pick tomorrow’s three tasks the night before, you’ve pre-decided during a moment of relative clarity. When you have context about the day ahead and your energy is less depleted than it will be at 9 AM. Morning-you inherits the decisions evening-you made. That’s a gift.
+
+**3. Let unfinished tasks reset automatically, don’t let them accumulate.**
+
+This one is less obvious, but it’s arguably the most powerful. When tasks don’t complete, they become overdue. Overdue tasks don’t disappear. They sit at the top of your list, marked red, demanding attention every single time you open the app. Each one requires you to re-evaluate, Is this still relevant? Should I do it today? Why haven’t I done it yet?
+
+A system that resets incomplete daily tasks back to the backlog, rather than marking them overdue. Eliminates this entire class of recurring micro-decisions. Yesterday’s unfinished task returns to the backlog. Today’s list starts clean. You choose again what today holds.
+
+## The Role of the Daily Reset in Reducing Decisions
+
+The automatic daily reset isn’t just a feel-good feature. It’s a decision-reduction mechanism. Without it, every incomplete task from every previous day compounds your daily decision load. You’re not just deciding what to do today. You’re re-deciding whether yesterday’s unfinished tasks are still valid, and the day before’s, and last week’s. The list becomes a palimpsest of past commitments that may or may not still be relevant.
+
+When tasks reset automatically, that whole category of “is this still worth doing?” disappears from the daily surface. Tasks that matter will be chosen again. Tasks that don’t will sit in the backlog until you notice you keep not choosing them. At which point you have real information about whether they belong on a list at all.
+
+Beta testers of Dawny have noticed this shift directly,
+
+> “Since using Dawny, I’m no longer afraid to look at my task list.”, Dawny beta tester
+
+The fear of looking at your list is a decision fatigue symptom. It means the list has accumulated enough unresolved questions that opening it feels like an unpleasant obligation rather than a useful tool. The reset removes the accumulated weight.
+
+> “I actually use Dawny every morning. The daily reset gives me the breathing room I need.”, Dawny beta tester
+
+Breathing room, in this context, is the cognitive equivalent of a lighter decision load. You open the app knowing the list reflects what you’ve chosen for today, not what you failed to do last Tuesday.
+
+## Pre-Decide to Reduce In-the-Moment Decisions
+
+Beyond the structural changes to the list itself, there are tactics that further reduce the number of decisions you’re making in real time.
+
+**Plan tomorrow the night before.** At the end of each workday, spend five minutes deciding what the next day holds. Your three tasks for tomorrow go on the list before you close the laptop. When you wake up, the decision is already made, you’re executing, not choosing.
+
+**Batch similar tasks by time of day.** Administrative tasks (email, scheduling, short replies) cluster naturally in the morning or after lunch. Deep work tasks belong in whatever window you’re sharpest. When you structure the day this way, the category of “what kind of work should I do right now?” is pre-answered. You’re only deciding within a category, not across all categories simultaneously.
+
+**Use simple time-of-day labels.** You don’t need a complex priority matrix. A simple tag, “morning,” “afternoon,” “whenever”. Narrows the field when you sit down. Instead of evaluating your whole list, you look at the morning subset. Small constraints, applied consistently, compound into significantly lower daily decision load.
+
+The goal across all of these tactics is the same, make more decisions in advance, in moments of higher cognitive clarity, so that fewer decisions are left to the moments when your capacity has been depleted.
+
+## Frequently Asked Questions
+
+### What is decision fatigue in the workplace?
+
+Decision fatigue in the workplace is the decline in decision quality that occurs after employees have made many choices throughout the day. It affects everyone from executives to individual contributors and shows up as avoidance behavior, impulsive choices, and defaulting to the status quo. In knowledge work specifically, it often manifests as difficulty prioritizing tasks, trouble starting complex projects, and a tendency to do low-value busy work instead of meaningful tasks.
+
+### How does a to-do list cause decision fatigue?
+
+Every item on a to-do list is an open question, “Should I do this now?” With a list of 40 items, you implicitly answer that question 40 times before you’ve done any actual work. This scanning and micro-evaluating costs cognitive resources. The same resources you need to make good decisions later. A long, undifferentiated task list front-loads a large number of low-value decisions before your day has even started.
+
+### How do I reduce decision fatigue?
+
+The most effective approaches are structural rather than motivational. Separate your backlog (everything you might do) from your daily list (what you’re committing to today). Limit your daily list to three to five tasks, chosen the evening before when your thinking is clearer. Use automatic resets so incomplete tasks return to the backlog rather than accumulating as overdue items. Each of these reduces the number of decisions you have to make in the moment.
+
+### Why am I more productive when I have fewer tasks?
+
+Fewer tasks means fewer choices, which means less cognitive drain before you start. When your daily list has three items, each one gets genuine attention and you’re more likely to actually complete them. Which creates positive momentum. When the list has thirty items, the evaluation cost is high, completion feels impossible, and motivation drops. Productivity is often less about effort and more about managing the cognitive conditions that make effort possible.
+
+### What time of day should I make important decisions?
+
+Earlier is generally better. Decision-making capacity is highest after rest and declines throughout the day as you make more choices. For most people, the first two to three hours of the workday represent the clearest thinking window. Important decisions, including which tasks deserve your focus. Are best made in that window, or ideally the night before, so they don’t consume morning cognitive resources that would be better spent on actual work.
+
+## Conclusion
+
+Decision fatigue productivity loss is a structural problem, not a personal one. The research is consistent, we have a finite capacity for making choices, it depletes throughout the day, and systems that force us to make hundreds of small decisions before we’ve done anything useful will always undermine our best intentions.
+
+The fix is architectural. A separate backlog for everything. A small daily list for today’s commitments, chosen in advance. And a reset mechanism that keeps incomplete tasks from accumulating into an ever-growing pile of unresolved questions. These aren’t hacks or motivational tricks. They’re design decisions that work with the grain of human cognition rather than against it.
+
+When your task system stops demanding constant re-evaluation and starts reflecting deliberate commitments, the list stops being something you avoid and starts being something you actually use. That’s not a small thing. The difference between a list you open every morning and one you haven’t touched in a week is, more often than not, a design problem with a structural solution.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/morning-routine-task-reset.md
+++ b/website/src/content/blog/en/morning-routine-task-reset.md
@@ -1,0 +1,137 @@
+---
+title: "The 5-Minute Morning Routine That Resets Your Task List Every Day"
+description: "A morning task reset takes 5 minutes and prevents the overwhelm that kills productivity before noon. Here's the exact process — and the philosophy behind it."
+pubDate: 2026-05-10
+---
+
+# The 5-Minute Morning Routine That Resets Your Task List Every Day
+
+> **Quick Answer:** A morning routine for productivity doesn’t need to start at 5 AM. It needs one deliberate step: a task reset. In 5 minutes, you review yesterday’s unfinished work, choose 2–3 tasks that genuinely matter today, and give yourself permission to ignore everything else. That single decision — made before the first email — sets the direction for the entire day and cuts decision fatigue significantly.
+
+Picture two versions of your morning. In the first, you open your task app and immediately feel the weight of yesterday — and the day before, and the week before that. Red items. Tasks that made sense two weeks ago. A list that has grown faster than you could act on it. You close the app without doing anything and tell yourself you’ll deal with it later.
+
+In the second version, you open your app and see a clean list. Yesterday’s unfinished tasks didn’t carry over as failures — they returned to a neutral backlog. You spend five minutes choosing what today is actually about, then close the app and start working. By the time your first meeting begins, you already know what you’re doing today and why.
+
+The difference between those two mornings isn’t discipline or willpower. It’s a system — specifically, a five-minute morning task reset that treats planning as a deliberate act, not a default reaction to accumulated guilt.
+
+## Why Your Morning Sets the Tone for the Whole Day
+
+The first hour after you wake up is the most cognitively valuable part of your day. Research on attention restoration theory, developed by environmental psychologists Rachel and Stephen Kaplan, describes how directed attention — the kind required for focused work and decision-making — is a depletable resource that recovers during rest. A systematic review of attention restoration theory shows that people who start the day with their directed attention intact perform significantly better on complex tasks than those who begin already depleted.
+
+Translate that to your morning: every decision you make before starting your most important work uses up part of that resource. Scrolling email, reacting to Slack notifications, or staring at a 60-item task list and trying to decide where to begin — all of it draws from the same finite pool. By the time you actually sit down to do the work that matters, you’ve already spent a significant portion of your best cognitive capacity.
+
+A deliberate five-minute morning planning ritual changes the equation. Instead of spending mental energy reacting to your environment all morning, you make one clear decision early, what today is about. And that decision guides everything else. You’re not making 60 micro-decisions every time you glance at your task app. You made one macro-decision this morning, and the rest of the day can follow it.
+
+## What Most People Do Wrong with Morning Planning
+
+Most people don’t have a morning planning routine. They have a morning reaction routine. They wake up, reach for their phone, and immediately begin processing other people’s priorities, emails, notifications, messages, before they’ve made a single decision of their own.
+
+**Opening email first.** Email is a list of requests from other people. When you start your morning there, you immediately cede control of your attention to whoever sent you something overnight. By the time you close your inbox, you’re already behind on someone else’s agenda and haven’t thought once about your own.
+
+**Starting with the easiest task.** This one feels productive. You’re doing things. But the easiest task and the most important task are rarely the same thing. Starting with easy creates momentum, but it’s momentum in the wrong direction. The hard, important work keeps getting pushed to later in the day, when your energy is lower and the urgency is higher.
+
+**Reacting instead of planning.** Most mornings don’t feel like there’s time to plan. Something comes up, a message needs a reply, a meeting starts early. But skipping the planning step doesn’t save time. It costs it. Without a clear decision about what today is about, every task feels equally urgent, and you spend the day context-switching rather than making progress on anything significant.
+
+**Carrying yesterday’s list into today unchanged.** This is perhaps the most common pattern. And the most damaging. Yesterday’s undone tasks are already in your app, usually marked as late. You glance at the list, feel a flash of guilt, and decide today you’ll try harder. But the list is still the wrong list. It reflects yesterday’s plan, not today’s reality. And a list built on guilt is a list you’ll want to avoid.
+
+## The 5-Minute Morning Task Reset: Step by Step
+
+This is the entire routine. It takes five minutes. You do it before opening email, before checking Slack, before looking at anything that belongs to someone else’s agenda.
+
+**Step 1: Open your task app. Not your inbox.** The order matters. Your task app is where your own priorities live. Your inbox is where everyone else’s do. Start with yours.
+
+**Step 2, Look at yesterday’s unfinished tasks and ask one question.** Not “why didn’t I do this?”. That question is a guilt spiral waiting to happen. The only question worth asking is, “Is this still relevant today?” If yes, it’s a candidate for today’s list. If no, send it back to the backlog and move on.
+
+**Step 3, Choose 2–3 tasks for today’s Daily Focus.** Not five. Not eight. Two or three. This constraint is the most important part of the whole routine, because it forces a genuine priority decision. If everything can be on today’s list, nothing has to be prioritized. When you can only pick three, you have to figure out what actually matters. Choose from your backlog if yesterday left nothing relevant, that list exists to give you options, not obligations.
+
+**Step 4, Set these as your focus for today.** Call them your Daily Focus, your Big Three, your non-negotiables. The label doesn’t matter. What matters is that you’ve made a clear commitment, these are the things that constitute a successful day. Everything else is secondary.
+
+**Step 5, Close the app and start with the hardest one.** The hardest task on your list is almost always the most important. Starting there isn’t punishment. It’s respect for your own priorities. And your cognitive resources are highest right now, which means this is the best moment you’ll have all day to tackle it.
+
+The entire sequence, from opening the app to closing it again. Takes about five minutes once you’ve made it a habit. The first few times might take longer while you get comfortable with the decisiveness the process requires. That discomfort is part of the reset working, you’re actually making a decision, not just shuffling items around.
+
+If you want a deeper look at the principles behind this kind of intentional daily structure, the daily planning system framework covers the full architecture behind it.
+
+## The Power of the Automatic Overnight Reset
+
+There’s a version of the morning reset that requires almost no effort, because the hardest part, clearing yesterday’s unfinished tasks from your active list, happens automatically while you sleep.
+
+The concept is simple, instead of treating incomplete tasks as overdue (a failure requiring reckoning), the system treats them as undecided. When the day ends and a task didn’t get done, it doesn’t turn red and join an ever-growing pile of missed commitments. It returns to the backlog, neutral and un-judged, waiting to be chosen again tomorrow if it’s still worth choosing.
+
+This is the design philosophy behind Dawny. The app has two lists, a Backlog that holds everything you might want to do someday, and a Daily Focus that holds only what you’ve actively chosen for today. At 3 AM, before you wake up. Any incomplete Daily Focus tasks return to the Backlog automatically. Your morning starts with an empty active list. You choose fresh, without the weight of yesterday.
+
+> “I actually use Dawny every morning. The daily reset gives me the breathing room I need.”, Dawny beta tester
+
+The practical effect of this design is striking. When your morning reset starts from a clean slate, the planning step becomes genuinely forward-looking. You’re not deciding which of yesterday’s failures to rescue. You’re deciding what today’s opportunities are. That’s a completely different mental frame, and it changes how the whole day feels.
+
+> “Since using Dawny, I’m no longer afraid to look at my task list.”, Dawny beta tester
+
+There’s also a subtle intelligence built into the reset over time. Tasks that keep returning to the backlog without ever making it into your Daily Focus are telling you something. If you’ve skipped a task five mornings in a row, it’s almost certainly not as important as you thought when you added it. A good system notices that pattern and eventually surfaces it. So you can make an honest decision about whether it belongs on your list at all.
+
+## How to Make the Morning Reset a Habit (When You’re Not a Morning Person)
+
+You don’t have to be a morning person for this to work. You have to be consistent, and that requires making the habit as friction-free as possible.
+
+**Attach it to an existing trigger.** The most reliable way to build a new habit is to link it to something you already do reliably. Coffee is the classic anchor, the routine becomes “make coffee, then do the task reset.” First phone unlock works just as well. You don’t need to find extra time. You need to use a transition you already make every morning.
+
+**Put the app where you can’t miss it.** A task reset takes five minutes. Forgetting to do it takes zero. Make sure your task app is on your home screen, ideally the first thing you see when you unlock your phone in the morning. Friction reduction isn’t laziness, it’s behavioral design.
+
+**Use a five-minute timer.** Paradoxically, a hard time limit makes the reset easier, not harder. When you know you only have five minutes, you stop second-guessing your choices and start making them. The timer creates a container that makes decisions feel lower-stakes. If you chose wrong, you’ll reset again tomorrow.
+
+**Same time, same process, every day.** Habits form through repetition and consistency, not through intensity. A five-minute reset done every single morning is infinitely more valuable than a thirty-minute deep-planning session done twice a week. Aim for consistency over thoroughness.
+
+**Track the streak, but forgive the breaks.** Knowing that you’ve kept the habit going for two weeks adds positive pressure to keep it going. But a missed morning isn’t a reason to give up, it’s just a missed morning. The reset starts again tomorrow.
+
+## What to Do When the Morning Goes Wrong
+
+Some mornings don’t go as planned. You’re running late, something urgent lands in your inbox before you’ve had a chance to think, a child needs something, a meeting moved earlier. The five-minute routine suddenly doesn’t have five minutes to live in.
+
+That’s real life, and a good system has to work in real life, not just on the ideal days.
+
+The fallback is a sixty-second version, open the app, pick one task. Not three. One. The task that, if it were the only thing you completed today, would make the day feel worthwhile. Close the app.
+
+That’s it. One decision in sixty seconds is infinitely better than no decision and a day spent reacting. It keeps the habit alive on hard days and gives you at least one anchor point for the rest of the day to orbit around. Most of the time, completing that one thing creates enough momentum to continue. But even if it doesn’t, you’ve done the one thing that mattered.
+
+The morning task reset isn’t a rigid ritual that fails the moment conditions aren’t perfect. It’s a mindset, before you react to anyone else’s priorities, make at least one decision about your own. That decision can happen in five minutes or in sixty seconds. Either way, it changes the day.
+
+On days where even the sixty-second fallback isn’t possible, come back at midday. Run the reset then. “Morning” is a metaphor for “before you start”, and it’s never too late to start with intention.
+
+## Frequently Asked Questions
+
+### What is a morning planning routine?
+
+A morning planning routine is a short, deliberate process you complete at the start of each day to decide what you’ll focus on. It typically involves reviewing your task list, choosing 2–3 priorities for the day, and setting those aside as your active focus. The key word is deliberate. A planning routine is distinct from simply opening your email and reacting to whatever arrived overnight.
+
+### How long should morning planning take?
+
+Five minutes is enough for most people. The goal isn’t comprehensive analysis. It’s a single clear decision, what are the two or three things that make today a success? Longer planning sessions can actually work against you by encouraging overthinking and producing an over-ambitious list. If your morning planning takes more than ten minutes, the process has become the work instead of a gateway to it.
+
+### Should I plan tasks the night before or in the morning?
+
+Both approaches work, and combining them is often best. An evening review, briefly noting what’s unfinished and what tomorrow might look like. Primes your brain overnight and makes the morning reset faster. But the final commitment to today’s specific tasks is best made in the morning, when you know what’s fresh, what’s urgent, and how you actually feel. Night planning sets the stage; morning planning sets the intentions.
+
+### What’s the best morning routine for productivity?
+
+The best morning routine for productivity is the one you actually do consistently. For task management specifically, the evidence points toward keeping your active daily list small (2–5 items), making the planning decision before opening email or reactive apps, and starting with the most cognitively demanding task when your energy is highest. The specific order of other habits, exercise, meditation, journaling. Matters far less than the consistent act of choosing your priorities before reacting to other people’s.
+
+### How do I stick to a morning routine?
+
+Consistency over perfection is the rule that matters most. Link the routine to an existing morning habit (coffee, first unlock, shower), reduce friction by putting your app front and center, and set a time limit so the process doesn’t expand. When you miss a morning, and you will. Treat it as one missed day, not a failed system. The routine resumes the next day. Habits are built in months, not broken by a single exception.
+
+## Conclusion
+
+A morning task reset isn’t about waking up earlier, meditating, or optimizing your first hour into a productivity performance. It’s about one decision, made before you start reacting to everyone else, that answers a single question, what is today actually about?
+
+That decision takes five minutes. It requires choosing 2–3 tasks from a clear, manageable list, setting them as your Daily Focus, and then getting out of the planning mode and into the doing mode. The research on morning cognitive resources, decision fatigue, and attention restoration all point in the same direction, people who make clear daily priority decisions early perform better and experience less stress across the rest of the day.
+
+The reset philosophy. Where unfinished tasks return to the backlog overnight rather than accumulating as overdue items. Makes the morning decision genuinely clean. You’re not choosing which failures to rescue. You’re choosing what today’s opportunities are. That shift in framing is small but profound. If you want to experience what that feels like in practice, the article on choosing your three most important tasks is a useful next step.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/productivity-apps-adhd.md
+++ b/website/src/content/blog/en/productivity-apps-adhd.md
@@ -1,0 +1,136 @@
+---
+title: "Productivity Apps for ADHD: What Most Get Wrong"
+description: "Most productivity apps fail ADHD brains by adding features. The real fix is removing the ones that create guilt, overwhelm, and avoidance."
+pubDate: 2026-05-10
+---
+
+# Productivity Apps for ADHD: What Most Get Wrong
+
+> **Quick Answer:** Most productivity apps fail people with ADHD for the same reason: they add features to solve problems that features can’t fix. Overdue labels, reminder stacking, project hierarchies, and streak trackers increase cognitive load without addressing the core challenge — choosing what to focus on today, finishing it, and not feeling guilty about what you didn’t do.
+
+You have a folder on your phone. Maybe you’ve tried to hide it somewhere on the second or third screen. It’s full of apps — task managers, planners, habit trackers — that all started with the same hopeful tap and ended with the same quiet abandonment. Each one looked promising. Each one felt like maybe this time it would stick. None of them did.
+
+This isn’t a story about lacking willpower or discipline. It’s an almost universal experience for people whose brains work differently — and the reason it keeps happening is worth understanding, because it isn’t your fault. It’s a design problem. The developer behind Dawny had this same folder, tried every major task app on the market, and hit the exact same wall every time. So he built something different — for his own brain, not for a productivity ideal he’d never felt like he fit.
+
+## Why Standard To-Do Apps Struggle with ADHD Brains
+
+Standard to-do apps were designed around a set of assumptions about how people plan and execute. Those assumptions work fine for a certain kind of brain. For ADHD brains, they actively backfire.
+
+**Time blindness.** One of the most consistent experiences people with ADHD describe is a fundamentally different relationship with time. Not laziness, but a neurological difficulty perceiving how far away future deadlines actually are. Apps built around deadlines as their primary organizing principle create a constant stream of “overdue” notifications for tasks that genuinely registered as distant until suddenly they weren’t. The overdue pile grows fast, and it grows through no moral failure.
+
+**Interest-driven motivation.** Research published in the journal *Neuropsychology Review* describes ADHD as a deficit not in attention broadly, but in regulating attention. Specifically in applying effort to tasks that aren’t intrinsically motivating or immediately reinforcing. A task due next Tuesday doesn’t generate urgency in the same way for every brain. Long-range deadlines don’t always register as actionable.
+
+**Out of sight, out of mind.** This phrase is often used dismissively, but for many people with ADHD it describes a real cognitive pattern: what is physically visible and immediate competes for attention with everything else; what is buried three screens deep in a project hierarchy simply does not. A long backlog is invisible. What is on the screen right now is what gets done.
+
+**Decision paralysis.** Open a task list with 60 items and you must make a decision before you’ve started anything: which one? For a brain that already struggles with task initiation, that first choice is an enormous obstacle. The larger the list, the higher the barrier to starting.
+
+## What Most “ADHD-Friendly” Apps Do — and Why It Backfires
+
+Search for “best app for ADHD productivity” and you’ll find a familiar category of recommendations. Apps with color coding, streaks, gamification, point systems, and multi-layered reminder schedules. The logic is intuitive, ADHD brains respond to novelty and reward, so build novelty and reward into the app.
+
+The problem is that this approach treats a short-term engagement tactic as a long-term system. And in practice, each of those features creates its own kind of friction.
+
+**Streaks** are particularly destructive. A streak system rewards consistency by making every miss feel catastrophic. You lose your streak, you “broke it,” you’re back to zero. For someone who already struggles with an inner critic that frames any missed task as personal failure, a streak counter turning red is not motivating. It is the opposite. It adds one more thing to feel bad about and one more reason to avoid opening the app.
+
+**More reminders** create notification fatigue. After the third or fourth alert for the same undone task, the notifications become background noise. Swiped away automatically, no longer triggering any action. The intended signal drowns in its own repetition.
+
+**Feature complexity** creates decision paralysis at the app level. When adding a task requires choosing a project, a priority, a due date, a tag, and an estimated duration, the friction of capturing an idea is high enough that many people simply don’t do it. The system that was supposed to help becomes the thing you need energy to operate.
+
+## What Actually Helps — and Why It’s the Opposite of What You’d Expect
+
+The pattern that actually reduces friction for many ADHD brains isn’t addition. It’s removal.
+
+**Fewer tasks visible at once** means fewer decisions before you start. If you see three things on your list today, choosing among them is manageable. If you see forty, the first task is deciding which forty to narrow to three, and many people never get past that step.
+
+**No overdue labels** means no guilt trigger. If a task you didn’t finish yesterday simply isn’t labeled “failed” when you open the app today, the emotional cost of opening the app drops significantly. The task is still there if it matters, but it isn’t punishing you for being human.
+
+**A daily reset** means every morning is a fresh decision, not an inherited pile. Instead of carrying yesterday’s unfinished business forward as debt, you look at what’s in your backlog and choose what matters today. That’s a fundamentally different relationship with your task list, it’s a daily decision, not a growing obligation.
+
+**A small daily focus** creates a clear success signal. “Did I do my three things?” is a question with a real answer. “Did I make progress on my 47-item list?” is not.
+
+These aren’t features designed for ADHD. They’re design choices that remove the elements that create the most cognitive and emotional friction. For anyone, but particularly for brains that struggle with the exact pain points those elements target.
+
+## The Most Important Feature of Any ADHD Task App — and It’s Not a Feature
+
+Here’s the question that matters most when evaluating any task app, what does it do with tasks you didn’t complete?
+
+If undone tasks become red overdue items, the app is punishing the exact pattern. Task initiation failure, underestimating how long things take, getting absorbed in something else. That ADHD makes common. Every day you open the app after a hard day is an encounter with a list of things you “failed” at.
+
+This is why standard to-do lists fail so many people, the design assumes that flagging failure is motivating, when for most people it simply triggers avoidance. The app becomes the thing you hide from, which is precisely the opposite of its purpose.
+
+An app that resets undone tasks without judgment, no red labels, no broken streaks, no rescheduling prompts. Is more forgiving of how ADHD actually works. Task debt doesn’t accumulate because the system is designed not to let it.
+
+Two people who’ve been testing Dawny put it plainly,
+
+> “I actually use Dawny every morning. The daily reset gives me the breathing room I need.”
+, Dawny beta tester
+
+> “Since using Dawny, I’m no longer afraid to look at my task list. Because the tasks I won’t complete anyway simply don’t show up anymore.”
+, Dawny beta tester
+
+That second quote is significant. Not afraid to look at your task list. That should be the baseline expectation for any productivity tool, and for many people, it isn’t.
+
+## What to Look for in a Task App (If Your Brain Works This Way)
+
+This isn’t a ranked list of apps. It’s a set of questions worth asking before you commit to any system. Because the right answer depends on how your brain actually works, not on which app has the best reviews.
+
+**1. How does it handle tasks you didn’t complete?**
+Does it flag them as overdue, or does it let you make a fresh decision each day? The answer tells you a lot about the underlying philosophy.
+
+**2. How many items are visible at once in the default view?**
+A default view showing your entire task history is a different design choice than one showing what you’ve chosen for today. Neither is inherently wrong, but one will work better for certain brains.
+
+**3. Does it punish “failures”?**
+Missed deadlines, broken streaks, incomplete daily goals. Does the app register these as failures and signal them visually? For some people, that signal is useful. For others, it’s the reason they stop opening the app.
+
+**4. Can you capture quickly without complex metadata?**
+The lower the friction of adding a task, the more likely you are to actually add it when the thought occurs. An app that requires a project, a tag, and a due date for every new item creates a barrier that defeats the purpose of capture.
+
+**5. Does opening the app make you feel better or worse?**
+This is the most honest test. Before you check anything else, notice your first reaction when you open your task manager. If it’s relief, the system is working for you. If it’s dread, the system is working against you, regardless of how many features it has.
+
+## A Note on What Apps Can’t Do
+
+This is worth saying clearly, no task app solves ADHD. Not Dawny, not any other app, not the one you haven’t tried yet.
+
+ADHD is a neurodevelopmental condition that affects executive function in ways that go well beyond task management. External accountability, a friend, a coach, a body doubling partner. Often does more than any app. Therapy, particularly cognitive behavioral therapy adapted for ADHD, addresses patterns that no interface can touch. For many people, medication is a significant part of what makes daily functioning possible. These aren’t alternatives to a good app; they’re the things that actually matter most.
+
+An app is a tool. A good one removes friction. A bad one adds it. But even the best tool doesn’t substitute for the support structures that actually help people with ADHD thrive. If you’re struggling significantly, please talk to someone who can actually help, not just download another app.
+
+## FAQ
+
+### What is the best to-do list app for ADHD?
+
+There’s no single best app, because ADHD presents differently across people. The most important factor isn’t features. It’s how the app handles tasks you didn’t complete. An app that resets undone tasks without labeling them as failures reduces the guilt and avoidance cycle that makes many standard apps unsustainable for ADHD brains. Look for simplicity, a limited daily view, and no punishing streak systems.
+
+### Why do to-do lists not work for ADHD?
+
+Most to-do lists were designed as capture tools — places to store everything — not as decision-making systems. For ADHD brains, a long list triggers decision paralysis before a single task is started. The overdue labels and accumulated backlog create a guilt response that leads to avoidance. The list becomes the problem rather than the solution. The Zeigarnik effect — the brain’s tendency to dwell on incomplete tasks — means that a large backlog occupies mental bandwidth even when you’re not looking at it.
+
+### Are productivity apps helpful for ADHD?
+
+They can be, if they’re the right fit. The key is choosing an app whose design matches how your brain actually works rather than how you think it should work. Apps that add more features, more reminders, and more complexity often increase cognitive load rather than reducing it. A simpler app that limits what it shows you, resets daily, and removes guilt triggers may be more sustainable than a powerful one that quickly becomes overwhelming.
+
+### How should someone with ADHD organize their tasks?
+
+The most practical approach is separating capture from daily focus. Keep a backlog for everything you might want to do someday. Don’t filter it too hard at the point of capture. Each day, choose a small number of things (three is a common recommendation) that you’ll actually focus on. Don’t try to work from the full backlog directly. Review it occasionally to remove irrelevant items. The goal is a system where your daily view is small enough that opening it doesn’t require a major decision before you’ve started anything.
+
+### What features should an ADHD productivity app have?
+
+The more useful question is, what features shouldn’t it have? Skip streaks, complex project hierarchies, overdue labels that pile up, and reminder systems that can’t be easily silenced. What’s actually useful, quick task capture with minimal required fields, a limited daily focus view separate from the full backlog, and a way to handle undone tasks that doesn’t create guilt. How Dawny compares to feature-rich alternatives illustrates how much of this comes down to design philosophy rather than feature count.
+
+## Conclusion
+
+The most common mistake in productivity app design for ADHD brains isn’t a missing feature. It’s the presence of features that create exactly the cognitive and emotional friction they were supposed to solve. More reminders create avoidance. Streaks create anxiety. Overdue labels create guilt. Complex structures create paralysis. The pattern compounds until the app sits in that folder alongside every other one you’ve tried.
+
+The developer behind Dawny built the app because he had ADHD and kept hitting this exact wall. Not to build a productivity product. To stop dreading his own task list. The result isn’t an app with ADHD features. It’s an app where the usual sources of friction have been removed. Tasks reset instead of becoming overdue. The daily view is intentionally small. Nothing punishes you for being human.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/three-most-important-tasks.md
+++ b/website/src/content/blog/en/three-most-important-tasks.md
@@ -1,0 +1,123 @@
+---
+title: "The 3 Most Important Tasks Method: How to Choose What to Work On Today"
+description: "The MIT method limits your daily focus to 3 tasks. Learn why it works, how to pick your MITs each morning, and what to do when you don't finish them."
+pubDate: 2026-05-10
+---
+
+> **Quick Answer:** The 3 most important tasks (MIT) method asks you to choose three tasks each morning that you commit to completing that day — and only three. This constraint forces prioritization, reduces decision fatigue during the day, and creates a clear signal of success: if you finish your three tasks, the day was productive. Everything else is a bonus.
+
+You sit down to work, open your task app, and see 47 items. You spend 20 minutes deciding where to start. You pick something easy. You feel vaguely unproductive all day — even if you technically got things done. Sound familiar?
+
+This isn’t a time management failure. It’s a prioritization problem. Most task systems are built to capture everything you might ever want to do, but they offer almost no help deciding what actually deserves your attention today. The result is a daily experience of overwhelm, avoidance, and the nagging sense that you’re working hard without moving forward. The MIT method is a direct answer to exactly this problem — and the reason it works has less to do with willpower than with how the human brain processes choices.
+
+## What Is the MIT Method?
+
+The MIT method — short for Most Important Tasks — is a daily planning practice that asks you to identify, each morning, the three tasks that matter most to you today. Not the ten things you hope to get done. Not your full backlog. Three. You commit to those three before you open your inbox, before you check Slack, before the day has a chance to carry you somewhere else.
+
+The method is most widely credited to Leo Babauta, who popularized it through his Zen Habits article on limiting your daily tasks starting in the late 2000s. The core rule is straightforward: pick three MITs before you start working, write them down separately from your larger task list, and treat them as your non-negotiable commitments for the day. Everything else is optional. For additional perspectives on the three-task method, see this article on the rule of three and this guide to understanding the 3 most important tasks.
+
+## Why Three — Not Five, Not One?
+
+The number three is not arbitrary. It’s a cognitive sweet spot. And understanding why helps you stick with the method even on days when you feel like you should be doing more.
+
+**Why “one” creates too much pressure.** A single daily priority is a worthy ideal for certain frameworks, but in practice it creates a binary outcome: you either had a good day or you didn’t, with no middle ground. One task also tends to be either too big (and never gets done) or too small (and doesn’t feel meaningful). The pressure of a single make-or-break commitment can cause avoidance on its own.
+
+**Why “five” often becomes “some of five.”** Research on decision fatigue — the documented phenomenon where the quality of decisions deteriorates after a long sequence of choices — suggests that longer lists don’t just fail to help: they actively hurt. Studies have shown that people make worse decisions later in the day as their cognitive resources deplete. The same principle applies to task lists: the longer the list, the more decisions you defer, and the less likely you are to act on any of it. Five items is enough to trigger the avoidance that comes with decision fatigue.
+
+**Why three is the Goldilocks number.** Three is small enough to actually hold in your head, large enough to represent a productive day, and structured enough to force genuine triage. When you have only three slots, you can’t include everything that feels vaguely important. You have to decide what actually matters. That constraint is the entire point.
+
+## How to Choose Your Three MITs
+
+The selection process matters as much as the number. Done poorly, MIT selection becomes another form of avoidance. You spend 30 minutes optimizing your list instead of working. Done well, it takes under five minutes and sets a clear direction for the entire day.
+
+**Step 1: Review your backlog briefly. But don’t get lost in it.** Scan your daily planning system or task list to remind yourself what’s waiting. This is a survey, not a deep dive. Give yourself a time cap, two minutes maximum.
+
+**Step 2, Ask one clarifying question.** “If I do nothing else today, what three things would make this day feel worthwhile?” This question filters out the noise. Urgency, guilt, and habit are powerful forces that pull you toward busy work. The question pulls you back toward what actually matters.
+
+**Step 3, Write your MITs separately from your backlog.** Don’t just tag or flag them inside your existing task app. The physical or visual separation matters. It creates a clean, small list that represents today’s commitments, distinct from everything else you might someday do.
+
+**Step 4, Start with the hardest MIT first.** Brian Tracy’s “Eat the Frog” principle applies directly here, if you complete your most difficult or most dreaded task first, everything after it feels easier, and you’ve already secured the day’s most important outcome before your energy and focus begin to dip. Starting with the easy MIT feels productive but often leads to the hardest one never getting done.
+
+## What to Do With Everything Else
+
+Everything not on your MIT list goes into your backlog. A separate holding space for tasks that are real and valid but not today’s commitment. The backlog is not a failure zone. It’s not a list of things you’re neglecting. It’s a parking lot, a safe place for tasks to wait until they move up your priority list or become relevant.
+
+This separation is the structural fix that makes the MIT method work long-term. When your backlog is clearly distinct from your daily commitments, you stop feeling guilty every time you see an unfinished task. The backlog says “someday.” Your MIT list says “today.” Those are very different conversations, and they should not happen in the same place.
+
+The tasks you never actually pick as MITs will eventually reveal themselves, they’re not important enough to act on. That’s useful information, not failure.
+
+## What Happens When You Don’t Finish Your Three MITs?
+
+This is where most productivity advice breaks down. The MIT method tells you to pick three tasks. But almost nothing addresses what happens when one of them doesn’t get done. The standard answer is implicit, you feel bad, you carry it over, you add it to tomorrow’s list with a mental note of disappointment.
+
+That accumulation is exactly why your to-do list feels overwhelming. Unfinished commitments don’t just sit in your app. They sit in the back of your mind. The Zeigarnik effect, a well-studied psychological phenomenon, describes how unresolved tasks occupy working memory and create a persistent low-level cognitive load. Add enough of them and the list itself becomes something you avoid.
+
+A different model, what if an unfinished MIT simply returned to your backlog. Without an overdue label, without a red badge, without guilt? It’s not a failed commitment. It’s an undecided task waiting for the right day. You choose again tomorrow whether it makes the MIT list. If it keeps being skipped, that tells you something important about how much you actually need to do it.
+
+One Dawny beta tester described it this way,
+
+> “Dawny uses the same logic I use with missed calls, ‘If it was really important, they’ll call back.’”, Dawny beta tester
+
+That framing captures something real. Not every task that felt important at 9 AM is actually important. The reset doesn’t erase the task. It gives you one more chance to decide whether it belongs on tomorrow’s MIT list, or whether it belongs in the archive.
+
+## MIT Method in Practice — A Real Example
+
+It’s Tuesday morning. You have a backlog of 34 tasks spanning work projects, personal errands, and a half-formed idea you added three weeks ago. You spend two minutes scanning it. Then you ask the question.
+
+Your three MITs for the day,
+
+- Send the revised contract to the client (most important, most dreaded)
+
+- Write the outline for the team presentation
+
+- Schedule the dentist appointment you’ve been postponing for two months
+
+You write these somewhere separate. A sticky note, a focused daily view in your app, a small notebook. Your backlog still exists. You haven’t deleted the other 31 tasks. You’ve just declared that these three are today’s game.
+
+You start with the contract. It takes longer than expected. 90 minutes instead of 45. By the time you finish it, you feel genuinely accomplished. You work through the presentation outline after lunch. At 4 PM, you realize you haven’t scheduled the dentist appointment. You get distracted, the day ends, and you don’t.
+
+Under a traditional system, “Schedule dentist” is now overdue. It carries a red label. Tomorrow it sits alongside new tasks, competing for attention it probably doesn’t deserve.
+
+Under the MIT model, “Schedule dentist” returns to your backlog. Tomorrow morning you choose your three MITs again. Is scheduling a dentist appointment one of the three things that would make tomorrow feel worthwhile? Probably not. But you’ll decide then. When you’ve skipped it six more times, you’ll know it’s either not important or it’s important enough to finally put it first.
+
+Two out of three MITs completed is, by most measures, a productive day. The MIT method gives you that reading clearly. A list of 34 tasks does not.
+
+## Frequently Asked Questions
+
+### What are the most important tasks (MITs) in productivity?
+
+MITs, Most Important Tasks. Are the specific tasks you pre-commit to completing on a given day, chosen deliberately each morning before you start working. The concept, popularized by Leo Babauta of Zen Habits, limits your daily commitments to three items. The constraint forces prioritization and creates a clear, honest measure of whether the day was productive.
+
+### How do I choose my top 3 tasks for the day?
+
+Start with a brief scan of your backlog, then ask, “If I do nothing else today, what three things would make this day feel worthwhile?” Write your three answers separately from your full task list. Resist the urge to rank by urgency alone. Urgent is not the same as important. And always start with the hardest of the three first.
+
+### What if I finish my 3 MITs early?
+
+That’s a good problem to have. And it happens more often than most people expect once they start picking realistic MITs. When you finish early, go back to your backlog and choose what to work on next. You might pick a fourth task, or you might stop. Either way, the day is already a success. The remaining time is bonus.
+
+### Should I do my MITs in the morning?
+
+Choosing your MITs in the morning is almost universally recommended. Before your inbox, before meetings, before the day sets its own agenda. Whether you work on them in the morning depends on when your peak focus hours fall. If you do your best deep work in the afternoon, pick your MITs in the morning and schedule them for afternoon. The selection and the execution are separate steps.
+
+### How is the MIT method different from time blocking?
+
+Time blocking assigns specific hours to specific work. The MIT method assigns priority to specific tasks without necessarily dictating when you do them. The two approaches are compatible and often complementary, you can time-block your MITs. But the MIT method is simpler to start with and doesn’t require calendar control, making it more resilient on days when plans change.
+
+## Conclusion
+
+The 3 most important tasks method works not because it demands more from you, but because it demands less. Less scanning, less deciding, less guilt. By constraining your daily commitment to three tasks, you force yourself to prioritize honestly, reduce the decision fatigue that drains your energy before you’ve started, and create a system that tells you clearly when the day was worthwhile.
+
+The research on decision fatigue and the psychology of incomplete tasks both point in the same direction, smaller, deliberate lists outperform large, exhaustive ones. Not because ambitious people can’t handle long lists, but because no brain can. The MIT method works with how attention and motivation actually function, rather than demanding that you override them with discipline.
+
+The final piece is what happens to the tasks you don’t finish. A system that turns them red and calls them overdue is working against you. A system that returns them to your backlog, quietly, without accusation. Lets you choose again tomorrow with fresh eyes. That’s not lowering the bar. That’s being honest about the fact that priorities change and days are finite.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/two-list-system-backlog.md
+++ b/website/src/content/blog/en/two-list-system-backlog.md
@@ -1,0 +1,123 @@
+---
+title: "The Two-List System: How to Manage a Backlog Without Drowning in It"
+description: "The two-list system separates everything you might do from what you're doing today. Learn how it eliminates task debt and how to set it up."
+pubDate: 2026-05-10
+---
+
+# The Two-List System: How to Manage a Backlog Without Drowning in It
+
+> **Quick Answer:** The two-list system productivity approach divides your tasks into two distinct lists: a backlog (everything you might want to do someday) and a daily focus list (the small set you’re committing to today). Items only move from backlog to daily focus through a deliberate daily decision — not by deadline, not by default. This separation prevents overwhelm and eliminates task debt before it has a chance to accumulate.
+
+You have one list. Everything is on it — the presentation due Friday, the dentist appointment you keep postponing, the book you want to read, the invoice you need to send, the birthday gift you haven’t bought yet. They all sit together, undifferentiated, demanding equal attention at once. You scroll through the list. You feel overwhelmed. You close the app without doing anything. The problem isn’t that you have too many tasks. The problem is that you’re mixing “things I might do someday” with “things I’m doing today” — and that mix is what turns a useful tool into a source of anxiety.
+
+## The Origin: Warren Buffett’s Two Lists
+
+The two-list concept is often attributed to a story involving Warren Buffett and his personal pilot, Mike Flint. As the story goes, Buffett asked Flint to list his top 25 career goals, then circle the five most important ones. The resulting two groups — the top five and the remaining twenty — became two separate lists. The second list wasn’t a backup priority queue. Buffett reportedly told Flint to actively avoid everything on it until the top five were done.
+
+The story’s origin is disputed and possibly apocryphal, but the principle it illustrates is genuine and well-supported: the act of separating “everything I might do” from “what I’m focusing on” is itself productive. Not because it makes the second list disappear, but because it removes it from your immediate decision-making field. Applied to daily task management, this becomes a powerful structural habit. For an additional perspective, see this TIME article on Warren Buffett’s two-list strategy.
+
+The two-list system for tasks works on the same logic: one list holds everything you might do. The other holds only what you’re doing today. The discipline isn’t in the doing, it’s in keeping the two lists separate.
+
+## List 1: The Backlog
+
+Your backlog is a neutral holding area for every task, idea, or obligation that might matter someday. It has no size limit. Nothing on it is overdue. Nothing on it carries urgency by default. It’s simply a capture point. A place where tasks wait until you decide they’re worth promoting to your daily focus.
+
+This is an important mental shift: the backlog is not a failure pile. A task that has been sitting in your backlog for three weeks isn’t a sign that you’ve been avoiding it. It’s a sign that, on each of the last twenty-one mornings, you looked at your options and decided something else was more important. That’s not procrastination, that’s prioritization.
+
+The backlog works best when you trust it enough to capture freely. If something occurs to you, put it in. Don’t prefilter based on whether it “deserves” to be there. The filter happens when you choose your daily focus, not when you add items. A weekly five-minute review helps prune tasks that have become irrelevant. Not to police the list, but to keep it useful as a source of options.
+
+## List 2: The Daily Focus
+
+Your daily focus list is where real commitment happens. It holds only the tasks you’re genuinely choosing to work on today. Not tasks you feel obligated to address, not tasks that are technically still open, not everything you’d like to accomplish if the day went perfectly. Most practitioners of the two-list system recommend three to five items as a firm upper limit.
+
+The number matters more than it might seem. Research on decision fatigue shows that the more choices we face, the worse each individual decision becomes. A daily focus list with fifteen items isn’t a focused list at all. It’s a second backlog — smaller, but equally paralyzing. Three to five items is a constraint that forces the real prioritization question: if I could only do a handful of things today, which ones actually matter?
+
+The three most important tasks for today approach is a close cousin to this idea, and the overlap is intentional. Whether your daily list has three items or five, the principle is the same, small enough that every item on it is a genuine commitment, not a hope.
+
+## The Daily Transfer Ritual
+
+The two-list system only works if there’s a real process for moving items between lists. Without it, the backlog becomes forgotten and the daily focus list either stays empty or gets loaded with whatever felt urgent at the last possible moment.
+
+The morning is the natural moment for this transfer. Before you open your email, before you check your messages, spend a few minutes with your backlog and ask, what is actually worth committing to today? Not “what do I have to do?” but “what am I choosing to do?” The distinction matters. Obligation and choice feel different, and the daily focus list should feel like choice.
+
+A few questions help guide the selection,
+
+- Which item on this backlog list, if done today, would make the day feel successful?
+
+- Is there anything that has a genuine time constraint I can’t move?
+
+- What have I been wanting to do but keep skipping over, and is today the day to actually commit to it?
+
+The evening transfer is the other half of the ritual. At the end of the day, you clear the daily focus list. Completed tasks move to done. Uncompleted tasks return to the backlog. Not as failures, but as undecided items. They join the pool of things you might choose tomorrow. This is the moment that prevents task debt from accumulating.
+
+## Why This Prevents Task Debt
+
+Task debt is what happens when undone tasks don’t return to a neutral state. They stay in your active list, marked overdue, growing red, accumulating weight. Most task management apps are built on the assumption that if you didn’t do something, you still need to do it, and the app should remind you of that failure prominently and persistently.
+
+The two-list system operates on a different assumption, if you didn’t do something today, you made a decision, consciously or not. That something else was more important. That decision deserves to be respected, not penalized. The undone task goes back to the backlog as a neutral option. Tomorrow, you might choose it. Or you might not. If you never choose it, that pattern eventually tells you something important about whether the task actually matters.
+
+> “I actually use Dawny every morning. The daily reset gives me the breathing room I need.”, Dawny beta tester
+
+> “Almost all the tasks that were automatically archived were simply not important enough. I haven’t moved a single one back.”, Dawny beta tester
+
+The emotional difference between these two approaches, overdue list versus neutral backlog. Is significant. An overdue list is a record of your shortcomings. A backlog is a library of options. You approach the two very differently. The daily planning system that emerges from the two-list approach is one that you can actually maintain, because it doesn’t punish you for being human.
+
+## How to Set This Up Today (Without an App)
+
+The two-list system doesn’t require any particular tool. A notebook with two sections works perfectly. The left-hand page is your backlog. The right-hand page is today’s focus. You write your daily list fresh each morning, choosing from the backlog. At the end of the day, you cross off what’s done and move undone items back to the left page.
+
+The format is less important than the discipline. What matters is that the two lists stay genuinely separate. That items don’t drift automatically from backlog to daily focus just because time has passed, and that your daily focus list doesn’t expand until it’s functionally a third, smaller backlog.
+
+If you prefer digital tools, look for apps that mirror this architecture explicitly, a capture area with no time pressure, and a focused daily list that resets. The principle scales from a pocket notebook to any software setup that respects the same separation.
+
+## Common Mistakes
+
+**The daily focus list becomes a second backlog.** This is the most common failure mode. You start with five items, then add two more because they’re “quick,” then three more because the day’s going well, and by noon you have twelve items and the focus is gone. The size limit is structural, it’s not a suggestion.
+
+**The backlog never gets reviewed.** If you never return to your backlog, it becomes a graveyard. Items accumulate, drift into irrelevance, and the backlog loses its value as a source of genuine options. A five-minute weekly review is enough to keep it alive.
+
+**Items move automatically instead of deliberately.** The two-list system breaks when items migrate by deadline rather than by choice. “This is due Friday” is a reason to consider moving something. Not a reason to move it automatically. The daily selection should always feel like an active decision.
+
+**The daily list never gets cleared.** If you don’t close out your daily focus list at the end of the day, undone items quietly stay there and begin to accumulate. The reset is the whole mechanism. Skipping it is what turns a healthy daily list into the overdue pile you were trying to avoid.
+
+**Guilt about the backlog.** Some people feel compelled to work through the backlog systematically. To eventually “finish” it. The backlog isn’t a queue. It’s a collection. Not everything in it will ever become a daily focus item, and that’s fine. The backlog’s job is to hold things safely, not to guarantee they’ll get done.
+
+## Frequently Asked Questions
+
+### What is the two-list system?
+
+The two-list system is a task management approach that separates all your potential tasks (the backlog) from the small set you’re committing to today (the daily focus). Items only move from backlog to daily list through a deliberate daily decision. This separation prevents the overdue pile that causes most people to abandon their task systems. The concept draws on Warren Buffett’s goal-separation advice, applied to daily task management.
+
+### How many tasks should be on a daily to-do list?
+
+Most research and practitioners suggest three to five tasks as a firm upper limit for a daily focus list. Fewer than three risks undercommitting on productive days; more than five tends to reproduce the overwhelm of a full task list. The constraint is intentional. It forces you to identify what actually matters today rather than listing everything you’d like to accomplish.
+
+### What’s the difference between a backlog and a to-do list?
+
+A to-do list is typically a single flat list of active tasks, often mixed with both long-term goals and immediate actions. A backlog is a deliberate holding area with no built-in urgency. Items sit there until you actively choose to promote them to your daily list. The key difference is psychological, a to-do list creates pressure on everything it contains, while a well-maintained backlog is a neutral pool of options.
+
+### How do I stop my to-do list from getting too long?
+
+The structural fix is separating your list into backlog and daily focus. Your backlog can be as long as it needs to be. Length doesn’t matter there, because it carries no urgency. Your daily list stays short by design (three to five items). Combine this with a weekly backlog review to remove irrelevant items, and the overwhelming single-list experience disappears.
+
+### What did Warren Buffett say about to-do lists?
+
+The widely circulated story attributes to Buffett a two-list method for goal setting: write down your top 25 goals, circle the five most important, and treat the remaining twenty as an avoid-at-all-costs list until the top five are complete. The exact origin of this story is disputed, and it may be apocryphal. But the underlying principle — that separating “everything” from “the few things that matter most” is itself the productive act — is well-established in both research and practice.
+
+## Conclusion
+
+The two-list system works because it solves the right problem. The issue with most task management approaches isn’t that people lack discipline or motivation. It’s that their tools force them to look at everything at once, the urgent and the someday, the important and the irrelevant. With equal visual weight. The result is overwhelm, avoidance, and eventually abandonment.
+
+Separating your tasks into a backlog and a daily focus list changes the emotional experience of task management entirely. The backlog holds your options. The daily focus holds your commitments. Nothing accumulates as overdue. Nothing punishes you for choosing one task over another. The system resets each evening, and each morning starts with a real decision, not a reckoning.
+
+The two-list system isn’t a new idea. But it remains one of the most effective structures available, precisely because it matches how humans actually make decisions, one day at a time, with a reasonable number of choices, in a context where they don’t feel guilty for what they didn’t do yesterday.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/what-is-task-debt.md
+++ b/website/src/content/blog/en/what-is-task-debt.md
@@ -1,0 +1,117 @@
+---
+title: "What Is Task Debt"
+description: "Task debt is the growing pile of overdue and abandoned tasks that makes your to-do list feel impossible. Learn what causes it and how to eliminate it."
+pubDate: 2026-05-10
+---
+
+# What Is Task Debt — and Why Your To-Do List Keeps Getting Worse
+
+> **Quick Answer:** Task debt is the accumulation of overdue, missed, or abandoned tasks that build up in your to-do list over time. Like financial debt, it compounds: the longer you ignore it, the worse it feels. Most productivity apps make task debt worse by displaying everything that went undone. The solution isn’t more discipline — it’s a system that prevents debt from accumulating in the first place.
+
+You open your task app and immediately feel worse than before you opened it. Red items. Missed deadlines from two weeks ago. Tasks you added in January that made sense then but mean nothing now. You scroll through the list, feel a wave of guilt, and close the app without doing anything. You’ve been here before. This feeling has a name: task debt — and you’re far from alone in carrying it. This article explains what task debt is, why it builds up, and what you can actually do about it.
+
+## What Is Task Debt?
+
+Task debt is the accumulated weight of unfinished, overdue, or no-longer-relevant tasks that pile up in your to-do list. Just like financial debt, it doesn’t stay still — it compounds. Each day you don’t address it, the list grows longer, the guilt grows heavier, and the idea of opening your task manager becomes more daunting.
+
+The term borrows from the concept of technical debt in software development, where shortcuts today create bigger problems tomorrow. Task debt works the same way: every task you defer without a decision adds to a backlog that eventually becomes unmanageable.
+
+What makes task debt particularly insidious is its psychological effect. Research on the Zeigarnik effect — first described by Soviet psychologist Bluma Zeigarnik in the 1920s — shows that incomplete tasks create persistent cognitive intrusion. Your brain keeps returning to unfinished business, even when you’re trying to focus on something else. A long list of overdue tasks isn’t just visually overwhelming; it occupies mental bandwidth around the clock. Additional resources include this article on how unfinished tasks drain mental energy and this modern look at the Zeigarnik effect.
+
+## How Does Task Debt Build Up?
+
+Task debt rarely happens all at once. It accumulates gradually, through patterns that feel completely normal in the moment.
+
+**Optimistic deadlines.** You add a task and give it a due date based on how long you hope it takes, not how long it will actually take. When the deadline passes and the task isn’t done, it turns red and joins the debt pile.
+
+**Tasks that become irrelevant.** You added “email Marcus about the Q3 proposal” three weeks ago. Q3 has come and gone. Marcus got a different job. The task is meaningless now — but it’s still sitting there, taking up space and attention.
+
+**Recurring low-priority items.** Some tasks never feel urgent enough to actually do, but never feel safe enough to delete. They live on the list indefinitely, half-forgotten, quietly adding to the cognitive load every time you scroll past them.
+
+**The avoidance loop.** This is where task debt becomes self-reinforcing. You open your app, see the overwhelming list, feel anxious, and close the app without doing anything. The debt grows. The next time you open it, the list is even longer. The anxiety is even stronger. You close it faster. Over time, you stop opening it at all.
+
+## Why Do Most To-Do Apps Make Task Debt Worse?
+
+Most task management apps are built on a single assumption, if you didn’t do it, you still need to do it. That assumption drives every design decision — overdue labels, red indicators, rescheduling prompts, streaks that break when you miss a day. The app is constantly signaling that you’ve failed.
+
+The problem is that this design doesn’t distinguish between two very different situations, “I haven’t done this yet” and “I’ve decided not to do this today.” Those are completely different mental states. One is a delay. The other is a judgment call. But your app treats them identically, and the result is a list that grows relentlessly regardless of whether your decisions are actually sound.
+
+Florian, the developer behind Dawny, experienced this firsthand. He tried every major productivity app, Todoist, Any.do, Microsoft To-Do, Apple Reminders. And hit the same wall every time. Tasks multiplied. Deadlines passed. Some tasks had already resolved themselves by the time he got to them. He kept looking at a growing wall of red, overdue items. Tasks he’d meant to do, tasks that no longer mattered, tasks that made him feel guilty. And he’d just close the app. The apps weren’t broken. They were working exactly as designed. But the design was wrong for how his brain, and many brains, actually work.
+
+This is one of the core reasons why to-do lists fail by design, they’re built around the assumption that more visibility equals more accountability. In practice, more visibility of things you haven’t done mostly equals more anxiety.
+
+## What Does Task Debt Actually Cost You?
+
+The cost of carrying task debt isn’t just the vague guilt you feel when you see that red number on your app icon. There are concrete, measurable effects on how well you think and work.
+
+**Decision fatigue.** Every item in your backlog is a micro-decision you haven’t made yet, do I do this now, defer it, or delete it? When your list has 80 items, you’re starting every day by scrolling through 80 unresolved decisions before you’ve even had coffee. That burns through cognitive resources before the real work begins.
+
+**Anxiety that reduces motivation.** The Zeigarnik effect doesn’t just affect focus. It affects mood. Carrying a mental load of incomplete tasks creates a background hum of stress that makes it harder to enjoy the work you’re actually doing.
+
+**Inability to see real priorities.** When everything is on the list equally, nothing stands out. The task you actually need to do today is buried under 60 things that are theoretically still relevant but practically dormant.
+
+**Complete abandonment.** This is the most common outcome. Not a dramatic decision to quit, but a gradual drift. You open the app less and less, until one day you realize you haven’t looked at it in three weeks. The tasks are still there. You’re just not looking anymore.
+
+## How Does a Daily Reset Eliminate Task Debt?
+
+The architectural solution to task debt is a shift in what “not done” means. Instead of treating an incomplete task as overdue, a failure requiring reckoning. A reset-based system treats it as undecided. The task returns to a neutral state and waits for you to choose it again tomorrow, if it’s still worth choosing.
+
+This is the philosophy behind the two-list system, keep a Backlog for everything that might matter someday, and a Daily Focus list for the small number of tasks you’re genuinely committing to today. At the end of the day, tasks that didn’t get done return to the Backlog, not to an overdue pile. Every morning starts clean.
+
+There’s a secondary mechanism that makes this approach even more powerful, tasks that keep getting skipped eventually reveal themselves. If you’ve moved a task back to the Backlog five times without ever choosing it for your Daily Focus, that’s data. That task is telling you something. Probably that it’s not actually a priority. In Dawny, tasks that are repeatedly skipped get archived automatically, through a mechanic called Make It Count. You don’t have to decide to delete them. The system notices the pattern for you.
+
+> “Since using Dawny, I’m no longer afraid to look at my task list. Because the tasks I won’t complete anyway simply don’t show up anymore.”, Dawny beta tester
+
+This reframe is significant. Instead of your task list being a record of everything you’ve failed to do, it becomes a curated set of things you might genuinely choose. The list stays manageable because it’s actively maintained by design, not by periodic manual cleanups that you have to force yourself to do.
+
+## What Can You Do Today If You Have Task Debt?
+
+If your current task list is already deep in debt, here are five concrete steps to start clearing it.
+
+**1. Do a debt audit.** Go through your list and mark every task as one of three things, still relevant, no longer relevant, or uncertain. Don’t try to do anything yet, just categorize.
+
+**2. Archive everything irrelevant. Ruthlessly.** Any task that no longer applies, has already resolved itself, or belongs to a version of your life that no longer exists, archive it or delete it. You are not abandoning these tasks. You are acknowledging reality.
+
+**3. Move uncertain items out of your daily view.** Anything you’re not sure about shouldn’t be in your active list. Move it to a “someday” or “maybe” category. It’s still accessible if it becomes relevant, but it’s not competing for your attention today.
+
+**4. Limit your active daily list to 3–5 tasks.** The research on decision fatigue is clear, more choices lead to worse decisions. A shorter list isn’t laziness. It’s clarity. Choose the tasks that actually matter today and let the rest wait.
+
+**5. Commit to a daily reset ritual.** At the end of each day (or the start of the next), spend five minutes reviewing what got done and what didn’t. Make a conscious decision about each item, does it come forward to tomorrow’s list, or does it go back to the backlog to wait? This is the habit that prevents new debt from accumulating.
+
+## Frequently Asked Questions
+
+### What is task debt in productivity?
+
+Task debt is the growing accumulation of overdue, skipped, or no-longer-relevant tasks in your to-do list. Like financial debt, it compounds over time. The longer it goes unaddressed, the more overwhelming it becomes. It creates cognitive load through the Zeigarnik effect, meaning your brain keeps returning to unfinished tasks even when you’re trying to focus on something else.
+
+### Why do my to-do lists keep growing?
+
+To-do lists grow for three main reasons, optimistic deadlines that create overdue items, tasks that become irrelevant but never get removed, and avoidance behavior triggered by seeing too many incomplete items. Most task apps make this worse by treating every undone task as an active obligation, regardless of whether it’s still relevant.
+
+### How do I clear an overwhelming to-do list?
+
+Start with a debt audit, categorize every task as still relevant, no longer relevant, or uncertain. Delete or archive everything in the second category. Move uncertain items to a “someday” list out of your daily view. Then limit your active daily list to 3–5 tasks. Going forward, adopt a daily reset habit that prevents new debt from accumulating.
+
+### What is the difference between a backlog and an overdue list?
+
+An overdue list is a record of your failures. Tasks that had deadlines and didn’t meet them. A backlog is a neutral holding area for tasks that haven’t been prioritized yet. The distinction matters psychologically, an overdue list generates guilt and avoidance, while a well-maintained backlog is simply a pool of options to choose from. Good task management systems use backlogs, not overdue lists.
+
+### Is task debt the same as procrastination?
+
+They’re related but different. Procrastination is a behavior. Delaying a task you intend to do. Task debt is the systemic result of procrastination (and other factors like poor tooling, overly optimistic planning, and changing circumstances). You can have significant task debt without being a procrastinator, simply because you added too many tasks with deadlines that didn’t match your actual capacity.
+
+## Conclusion
+
+Task debt is real, it’s common, and it’s not a character flaw. It’s what happens when the design of your tools doesn’t match how humans actually make decisions. Most task apps assume that visibility creates accountability. In practice, overwhelming visibility mostly creates avoidance, and avoidance is what lets debt compound.
+
+The solution isn’t a more aggressive system with harder deadlines and more red indicators. It’s a system that treats unfinished tasks not as failures, but as undecided choices. One that resets daily, keeps your active list small, and lets patterns reveal themselves over time rather than forcing you to maintain everything manually. That shift, from debt to reset, changes the entire relationship with your task list.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/blog/en/why-to-do-lists-fail.md
+++ b/website/src/content/blog/en/why-to-do-lists-fail.md
@@ -1,0 +1,111 @@
+---
+title: "Why To-Do Lists Don't Work (and What the Research Says Instead)"
+description: "To-do lists fail not because you lack discipline, but because they're designed to capture everything without helping you prioritize anything."
+pubDate: 2026-05-10
+---
+
+> **Quick Answer:** To-do lists fail because they were designed to capture everything — not to prioritize anything. A list that grows indefinitely triggers decision fatigue, generates guilt from undone tasks, and creates a cognitive burden that makes you avoid the list entirely. The problem isn’t your discipline. It’s that most task systems mistake volume for value.
+
+You’ve been here before. You open your task app with good intentions, add a few things, and tell yourself today will be different. Then the day happens. Some tasks get done, most don’t, and by evening the list is longer than it was this morning. A week later you’re not even opening the app anymore.
+
+This isn’t a character flaw. It isn’t laziness or poor time management or a lack of discipline. It’s a design problem — and it’s almost universal. The way most to-do apps are built runs directly against how human cognition actually works. Before you blame yourself again, it’s worth understanding exactly why to-do list failure is so common — and what a better system looks like.
+
+## What Was the Original Purpose of a To-Do List?
+
+To-do lists were invented as capture tools, not decision-making systems. The original idea was simple: write things down so your brain doesn’t have to hold them. That’s genuinely useful. Our working memory is limited, and offloading thoughts to paper (or an app) frees up mental space.
+
+The problem starts when we use a capture tool as a prioritization engine. A list designed to hold everything becomes the thing we’re supposed to use to decide what to do next. That’s an enormous job for something that was never built for it. And most to-do apps have never solved this mismatch — they’ve just made the capture part faster and more convenient.
+
+## Reason 1: Every Undone Task Is a Decision You Still Have to Make
+
+Decision fatigue is real and well-documented. Psychologist Roy Baumeister’s research on ego depletion — later expanded into the broader field of decision fatigue research. Showed that the more decisions a person makes, the worse their subsequent decisions become. The mental resource you use to decide is finite, and it depletes throughout the day.
+
+Now consider what happens when you open a to-do list with 40 items. Before you’ve done a single thing, your brain has to scan 40 options and make 40 micro-decisions: Is this relevant today? Is this urgent? Should I do this now or later? That’s an enormous cognitive load before you’ve typed a single word or made a single phone call. Most people respond to this load the only rational way they can, they close the app.
+
+A leaner daily list limited to your three most important tasks sidesteps this entirely. Fewer items means fewer decisions, which means more energy for actually doing things.
+
+## Reason 2: Undone Tasks Create a Guilt Spiral
+
+There’s a psychological phenomenon called the Zeigarnik effect, your brain holds on to incomplete tasks and keeps returning to them. It was originally observed as a memory effect. We remember unfinished things better than finished ones. In the context of a modern task list, it has an unfortunate side effect, every overdue item carries a small but real emotional penalty.
+
+One overdue task is a mild nagging feeling. Five overdue tasks feel like a bad day. Thirty of them, red, bolded, accumulating. Feel like failure. At that point, the app itself triggers anxiety before you’ve done anything wrong. You stop opening it not because you’re lazy, but because your nervous system has correctly learned that opening it feels bad.
+
+This is what task debt actually costs you. It’s not just the undone work. It’s the psychological weight you carry every time you think about the list.
+
+## Reason 3: Digital Lists Have No Natural Expiration Date
+
+There’s something that paper to-do lists got right by accident, they expired. You’d fill a page, lose the notebook, throw out the sticky note. The old list disappeared, and you’d start fresh. That forced a natural reset that removed tasks that were no longer relevant.
+
+Digital lists are permanent. A task you added in January sits right next to one you added this morning, with equal visual weight and equal accusatory presence. The “buy birthday card” from four months ago, for a birthday that has long since passed. Still stares at you from the list. Nothing prompts you to reconsider whether an old task still matters. Everything accumulates, forever, until you manually delete it.
+
+Most people don’t go back and prune regularly. That’s not a failure of discipline. It’s just not how attention works. A system that requires ongoing manual maintenance will always decay.
+
+## Reason 4: Volume Gets Confused With Priority
+
+Open any standard to-do app and look at the list. “Buy birthday card” sits next to “prepare quarterly review” with identical formatting, identical visual weight, identical urgency. There is no hierarchy, no signal. Your attention has to do all the work of sorting, ranking, and deciding, every single time you open the app.
+
+Human attention doesn’t work this way. We’re wired to notice contrast and distinction, not to rank uniform lists. When everything looks equally important, nothing feels important. And the result is that you default to the easiest task, not the most meaningful one. “Buy birthday card” gets done. The quarterly review gets pushed to tomorrow. And then the day after.
+
+The productivity system doesn’t work because it treats all tasks as equivalent when they are not.
+
+## What Actually Works Instead: Separate Capture From Commitment
+
+The research points toward a simple structural fix, separate the place where you capture everything from the place where you commit to today. A large backlog, everything you might want to do, with no time pressure. Is fine and useful. What’s not fine is using that same list as your daily work surface.
+
+What works is a small daily list you choose deliberately each morning. Not everything. Just the things you’re actually committing to today. When you look at five items instead of fifty, you make better decisions. You’re working with your cognitive capacity, not against it.
+
+One beta tester described it this way,
+
+> “I actually use Dawny every morning. The daily reset gives me the breathing room I need.”, Dawny beta tester
+
+The “daily reset” concept is central to this approach. What if the tasks you didn’t complete today simply returned to your backlog automatically. No overdue label, no red badge, no guilt? You’d start tomorrow with a clean list. You’d choose again what deserves your focus. And the tasks that keep getting skipped would eventually reveal themselves as things that weren’t actually important enough to act on.
+
+Another tester put it plainly,
+
+> “Almost all the tasks that were automatically archived were, when I thought about it, simply not important enough at that moment.”, Dawny beta tester
+
+## What Does a To-Do List Worth Opening Actually Look Like?
+
+A task system designed for how cognition actually works has a few defining properties. First, a small daily surface. Research and practice both support keeping your active daily list to a handful of items. Most experts suggest three to five. Second, clear separation between “someday” and “today.” Your backlog is a safe holding space, not a source of guilt. Third, automatic expiration. Tasks that don’t get acted on should return to the holding space on their own, not accumulate as overdue items.
+
+This isn’t about doing less. It’s about being honest about what today actually holds. And designing the system to handle the natural reality that plans change, energy fluctuates, and priorities shift. A good system accommodates human behavior. A bad one demands that you change your behavior to accommodate the system.
+
+## Frequently Asked Questions
+
+### Why do I always fail at keeping a to-do list?
+
+You’re most likely not failing. The list is. Most to-do apps are designed to capture everything without helping you prioritize. The result is a list that grows faster than you can act on it, which triggers decision fatigue and avoidance. The fix is structural, separate your backlog from your daily list, and keep your daily list small enough to be actionable.
+
+### Are to-do lists bad for ADHD?
+
+Traditional to-do lists are particularly difficult for ADHD brains. Long lists with no hierarchy demand sustained attention, working memory, and impulse control. All areas where ADHD creates challenges. The guilt from undone tasks also compounds quickly and can make the list feel aversive. Shorter daily lists with automatic resets align much better with how ADHD attention actually works.
+
+### What should I use instead of a to-do list?
+
+The best alternative isn’t abandoning lists entirely. It’s redesigning them. Use a two-layer system, a backlog that holds everything (without time pressure), and a small daily list you actively choose each morning. The critical difference is that incomplete daily tasks reset automatically rather than becoming overdue. This removes the accumulated guilt that makes traditional lists unusable over time.
+
+### How many tasks should be on a daily to-do list?
+
+Most productivity research and practitioners converge on three to five tasks as the effective daily limit. This isn’t about doing less. It’s about making real commitments rather than aspirational ones. When you limit your daily list to three tasks, you’re forced to make genuine priority decisions. The result is that you complete what you plan, which builds momentum instead of guilt.
+
+### Why does my to-do list make me anxious?
+
+The anxiety comes from accumulated task debt. Every overdue item is a small psychological signal that you’ve failed a commitment to yourself. Even if the original commitment was unrealistic. Over time, the list becomes associated with that feeling, and opening it triggers anxiety before you’ve done anything. The solution is a system that doesn’t accumulate overdue items in the first place, one where incomplete tasks return to a backlog rather than turning red.
+
+## Conclusion
+
+To-do lists don’t fail because you’re not disciplined enough to use them. They fail because they were built on a flawed assumption, that capturing everything and acting on everything are the same problem. They’re not.
+
+Decision fatigue, the guilt spiral of the Zeigarnik effect, infinite accumulation, and the flattening of all tasks into visual equals. These aren’t personal weaknesses. They’re design flaws in the systems most of us have been handed. The research is clear that willpower and good intentions aren’t the bottleneck. The architecture is.
+
+A system worth using looks different, a safe backlog for everything, a small daily list you choose deliberately, and automatic resets that prevent the guilt from building. It’s not about being more productive. It’s about removing the friction that makes you avoid the list entirely.
+
+If you want to try a task app built around this philosophy, Dawny is free to test on TestFlight.
+    
+The developer behind Dawny has ADHD and built the app after years of trying — and abandoning — every productivity app on the market.
+  
+Want to try a task app built around this philosophy?
+ 
+Dawny is free to test on TestFlight — no commitment required.
+ 
+Try Dawny free on TestFlight

--- a/website/src/content/config.ts
+++ b/website/src/content/config.ts
@@ -1,0 +1,13 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+  }),
+});
+
+export const collections = { blog };

--- a/website/src/i18n/de.json
+++ b/website/src/i18n/de.json
@@ -122,5 +122,12 @@
   "legal": {
     "privacyTitle": "Datenschutzerklärung",
     "imprintTitle": "Impressum"
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Praktische Anleitungen zu Tagesplanung, Aufgabenmanagement und wie du Entscheidungsmüdigkeit überwindest. Vom Team hinter Dawny, der iOS-App mit täglichem Reset.",
+    "readMore": "Artikel lesen",
+    "backToBlog": "← Blog",
+    "publishedOn": "Veröffentlicht"
   }
 }

--- a/website/src/i18n/en.json
+++ b/website/src/i18n/en.json
@@ -122,5 +122,12 @@
   "legal": {
     "privacyTitle": "Privacy Policy",
     "imprintTitle": "Imprint"
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Practical guides on daily planning, task management, and beating decision fatigue. From the team behind Dawny, the iOS task app built on a daily reset.",
+    "readMore": "Read article",
+    "backToBlog": "← Blog",
+    "publishedOn": "Published"
   }
 }

--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -1,0 +1,187 @@
+---
+import Base from "@/layouts/Base.astro";
+import { type Lang, getDict } from "@/i18n";
+
+interface Props {
+  lang: Lang;
+  title: string;
+  description: string;
+  pubDate: Date;
+  slug: string;
+}
+
+const { lang, title, description, pubDate, slug } = Astro.props;
+const dict = getDict(lang);
+
+const canonicalPath = `/blog/${slug}/`;
+const formattedDate = pubDate.toLocaleDateString(lang === "de" ? "de-DE" : "en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+---
+
+<Base
+  lang={lang}
+  title={`${title} — Dawny`}
+  description={description}
+  canonicalPath={canonicalPath}
+  altCanonicalPath={canonicalPath}
+>
+  <article class="blog-article">
+    <div class="container-narrow">
+      <p class="blog-eyebrow">
+        <a href={`/${lang}/blog/`} class="blog-back">{dict.blog.backToBlog}</a>
+      </p>
+      <header class="blog-header">
+        <time datetime={pubDate.toISOString()} class="blog-date">
+          {dict.blog.publishedOn} {formattedDate}
+        </time>
+        <h1 class="blog-title">{title}</h1>
+        <p class="blog-description">{description}</p>
+      </header>
+      <div class="blog-prose">
+        <slot />
+      </div>
+    </div>
+  </article>
+</Base>
+
+<style is:global>
+  .blog-article {
+    background: var(--color-paper);
+    color: var(--color-ink);
+    padding: 8rem 0 6rem;
+    min-height: 80vh;
+  }
+
+  .blog-eyebrow {
+    margin-bottom: 2rem;
+    font-size: 0.85rem;
+    color: var(--color-ink-soft);
+  }
+
+  .blog-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--color-ink-soft);
+    transition: color 200ms;
+  }
+
+  .blog-back:hover {
+    color: var(--color-ink);
+  }
+
+  .blog-header {
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid rgba(14, 26, 46, 0.1);
+  }
+
+  .blog-date {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--color-ink-soft);
+    margin-bottom: 1rem;
+  }
+
+  .blog-title {
+    font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    margin-bottom: 1rem;
+  }
+
+  .blog-description {
+    font-size: 1.1rem;
+    line-height: 1.6;
+    color: var(--color-ink-soft);
+    max-width: 60ch;
+  }
+
+  .blog-prose {
+    font-size: 1.0625rem;
+    line-height: 1.75;
+    color: var(--color-ink-soft);
+  }
+
+  .blog-prose h1,
+  .blog-prose h2,
+  .blog-prose h3,
+  .blog-prose h4 {
+    color: var(--color-ink);
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.25;
+    font-family: var(--font-display);
+    letter-spacing: -0.01em;
+  }
+
+  .blog-prose h2 {
+    font-size: 1.5rem;
+  }
+
+  .blog-prose h3 {
+    font-size: 1.2rem;
+  }
+
+  .blog-prose h4 {
+    font-size: 1.05rem;
+  }
+
+  .blog-prose p,
+  .blog-prose ul,
+  .blog-prose ol,
+  .blog-prose blockquote {
+    margin-bottom: 1.25rem;
+  }
+
+  .blog-prose ul,
+  .blog-prose ol {
+    padding-left: 1.5rem;
+  }
+
+  .blog-prose li {
+    margin-bottom: 0.5rem;
+  }
+
+  .blog-prose a {
+    color: var(--color-horizon);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  .blog-prose a:hover {
+    color: var(--color-dawn);
+  }
+
+  .blog-prose blockquote {
+    border-left: 3px solid var(--color-dawn);
+    padding: 0.75rem 0 0.75rem 1.25rem;
+    background: rgba(245, 176, 66, 0.06);
+    border-radius: 0 8px 8px 0;
+    color: var(--color-ink);
+    font-style: italic;
+  }
+
+  .blog-prose strong {
+    color: var(--color-ink);
+    font-weight: 600;
+  }
+
+  .blog-prose code {
+    background: rgba(14, 26, 46, 0.06);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  .blog-prose hr {
+    margin: 2.5rem 0;
+    border: 0;
+    border-top: 1px dashed rgba(14, 26, 46, 0.15);
+  }
+</style>

--- a/website/src/pages/de/blog/[slug].astro
+++ b/website/src/pages/de/blog/[slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection, render } from "astro:content";
+import BlogPost from "@/layouts/BlogPost.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ id }) => id.startsWith("de/"));
+  return posts.map((post) => ({
+    params: { slug: post.id.replace("de/", "").replace(".md", "") },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const slug = post.id.replace("de/", "").replace(".md", "");
+---
+
+<BlogPost
+  lang="de"
+  title={post.data.title}
+  description={post.data.description}
+  pubDate={post.data.pubDate}
+  slug={slug}
+>
+  <Content />
+</BlogPost>

--- a/website/src/pages/de/blog/index.astro
+++ b/website/src/pages/de/blog/index.astro
@@ -1,0 +1,137 @@
+---
+import { getCollection } from "astro:content";
+import Base from "@/layouts/Base.astro";
+import { getDict } from "@/i18n";
+
+const lang = "de" as const;
+const dict = getDict(lang);
+
+const posts = await getCollection("blog", ({ id }) => id.startsWith("de/"));
+posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Base
+  lang={lang}
+  title={`${dict.blog.title} — Dawny`}
+  description={dict.blog.description}
+  canonicalPath="/blog/"
+  altCanonicalPath="/blog/"
+>
+  <section class="blog-index">
+    <div class="container-narrow">
+      <header class="blog-index-header">
+        <h1 class="blog-index-title">{dict.blog.title}</h1>
+        <p class="blog-index-description">{dict.blog.description}</p>
+      </header>
+
+      <ul class="blog-list" role="list">
+        {posts.map((post) => {
+          const slug = post.id.replace("de/", "").replace(".md", "");
+          const formattedDate = post.data.pubDate.toLocaleDateString("de-DE", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          });
+          return (
+            <li class="blog-card">
+              <a href={`/de/blog/${slug}/`} class="blog-card-link">
+                <time datetime={post.data.pubDate.toISOString()} class="blog-card-date">
+                  {formattedDate}
+                </time>
+                <h2 class="blog-card-title">{post.data.title}</h2>
+                <p class="blog-card-description">{post.data.description}</p>
+                <span class="blog-card-read">{dict.blog.readMore} →</span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .blog-index {
+    background: var(--color-paper);
+    color: var(--color-ink);
+    padding: 8rem 0 6rem;
+    min-height: 80vh;
+  }
+
+  .blog-index-header {
+    margin-bottom: 3.5rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid rgba(14, 26, 46, 0.1);
+  }
+
+  .blog-index-title {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
+  }
+
+  .blog-index-description {
+    font-size: 1.05rem;
+    color: var(--color-ink-soft);
+    max-width: 60ch;
+    line-height: 1.6;
+  }
+
+  .blog-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .blog-card {
+    border-bottom: 1px solid rgba(14, 26, 46, 0.08);
+  }
+
+  .blog-card-link {
+    display: block;
+    padding: 2rem 0;
+    text-decoration: none;
+    color: inherit;
+    transition: opacity 150ms;
+  }
+
+  .blog-card-link:hover {
+    opacity: 0.75;
+  }
+
+  .blog-card-date {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--color-ink-soft);
+    margin-bottom: 0.5rem;
+    letter-spacing: 0.02em;
+  }
+
+  .blog-card-title {
+    font-family: var(--font-display);
+    font-size: 1.3rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.6rem;
+    color: var(--color-ink);
+  }
+
+  .blog-card-description {
+    font-size: 0.95rem;
+    color: var(--color-ink-soft);
+    line-height: 1.6;
+    margin-bottom: 0.75rem;
+    max-width: 65ch;
+  }
+
+  .blog-card-read {
+    font-size: 0.85rem;
+    color: var(--color-horizon);
+    font-weight: 500;
+  }
+</style>

--- a/website/src/pages/en/blog/[slug].astro
+++ b/website/src/pages/en/blog/[slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection, render } from "astro:content";
+import BlogPost from "@/layouts/BlogPost.astro";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ id }) => id.startsWith("en/"));
+  return posts.map((post) => ({
+    params: { slug: post.id.replace("en/", "").replace(".md", "") },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const slug = post.id.replace("en/", "").replace(".md", "");
+---
+
+<BlogPost
+  lang="en"
+  title={post.data.title}
+  description={post.data.description}
+  pubDate={post.data.pubDate}
+  slug={slug}
+>
+  <Content />
+</BlogPost>

--- a/website/src/pages/en/blog/index.astro
+++ b/website/src/pages/en/blog/index.astro
@@ -1,0 +1,137 @@
+---
+import { getCollection } from "astro:content";
+import Base from "@/layouts/Base.astro";
+import { getDict } from "@/i18n";
+
+const lang = "en" as const;
+const dict = getDict(lang);
+
+const posts = await getCollection("blog", ({ id }) => id.startsWith("en/"));
+posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Base
+  lang={lang}
+  title={`${dict.blog.title} — Dawny`}
+  description={dict.blog.description}
+  canonicalPath="/blog/"
+  altCanonicalPath="/blog/"
+>
+  <section class="blog-index">
+    <div class="container-narrow">
+      <header class="blog-index-header">
+        <h1 class="blog-index-title">{dict.blog.title}</h1>
+        <p class="blog-index-description">{dict.blog.description}</p>
+      </header>
+
+      <ul class="blog-list" role="list">
+        {posts.map((post) => {
+          const slug = post.id.replace("en/", "").replace(".md", "");
+          const formattedDate = post.data.pubDate.toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          });
+          return (
+            <li class="blog-card">
+              <a href={`/en/blog/${slug}/`} class="blog-card-link">
+                <time datetime={post.data.pubDate.toISOString()} class="blog-card-date">
+                  {formattedDate}
+                </time>
+                <h2 class="blog-card-title">{post.data.title}</h2>
+                <p class="blog-card-description">{post.data.description}</p>
+                <span class="blog-card-read">{dict.blog.readMore} →</span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .blog-index {
+    background: var(--color-paper);
+    color: var(--color-ink);
+    padding: 8rem 0 6rem;
+    min-height: 80vh;
+  }
+
+  .blog-index-header {
+    margin-bottom: 3.5rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid rgba(14, 26, 46, 0.1);
+  }
+
+  .blog-index-title {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.75rem;
+  }
+
+  .blog-index-description {
+    font-size: 1.05rem;
+    color: var(--color-ink-soft);
+    max-width: 60ch;
+    line-height: 1.6;
+  }
+
+  .blog-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .blog-card {
+    border-bottom: 1px solid rgba(14, 26, 46, 0.08);
+  }
+
+  .blog-card-link {
+    display: block;
+    padding: 2rem 0;
+    text-decoration: none;
+    color: inherit;
+    transition: opacity 150ms;
+  }
+
+  .blog-card-link:hover {
+    opacity: 0.75;
+  }
+
+  .blog-card-date {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--color-ink-soft);
+    margin-bottom: 0.5rem;
+    letter-spacing: 0.02em;
+  }
+
+  .blog-card-title {
+    font-family: var(--font-display);
+    font-size: 1.3rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.6rem;
+    color: var(--color-ink);
+  }
+
+  .blog-card-description {
+    font-size: 0.95rem;
+    color: var(--color-ink-soft);
+    line-height: 1.6;
+    margin-bottom: 0.75rem;
+    max-width: 65ch;
+  }
+
+  .blog-card-read {
+    font-size: 0.85rem;
+    color: var(--color-horizon);
+    font-weight: 500;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Migrate blog content from compiled HTML to Astro 5 Content Layer API
- Add 10 English posts as markdown sources (extracted from dist/)
- Add 10 German translations with same slugs, language derived from file path
- Create BlogPost layout, index pages, and dynamic routes for `/en/blog/` and `/de/blog/`
- Add hreflang tags for EN/DE cross-linking
- Update Header with blog navigation and dynamic URL-swap for language toggle
- Update i18n strings (en.json, de.json)
- Update CLAUDE.md with blog post guidelines

## Test Plan

- ✅ `astro build` succeeds (29 pages: 10 EN posts + 10 DE posts + indices + existing pages)
- ✅ `/en/blog/` and `/de/blog/` load correctly
- ✅ Individual posts render with correct language and date format
- ✅ hreflang tags present for EN/DE cross-linking
- ✅ Language toggle swaps `/en/` ↔ `/de/` on blog routes
- ✅ `dist/de/blog/` contains all 10 German posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)