### PR TITLE
Tests wieder aktiviert oder so

### DIFF
--- a/Dawny.xcodeproj/xcshareddata/xcschemes/Dawny.xcscheme
+++ b/Dawny.xcodeproj/xcshareddata/xcschemes/Dawny.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -43,8 +43,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D769C0012FAD439D00BFA1D1"

--- a/DawnyUITests/DawnyUITestsLaunchTests.swift
+++ b/DawnyUITests/DawnyUITestsLaunchTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class DawnyUITestsLaunchTests: XCTestCase {
 
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        true
+        false
     }
 
     override func setUpWithError() throws {


### PR DESCRIPTION
## Summary

Reduces UI test run count by disabling per-configuration repetition on the launch test, and removes a redundant explicit `parallelizable = "NO"` attribute from the Xcode scheme.

- `runsForEachTargetApplicationUIConfiguration` changed from `true` to `false` — the launch screenshot test now runs once in the default configuration instead of once per appearance variant (Light/Dark Mode etc.)
- Removes `parallelizable = "NO"` from the UI test `<TestableReference>` in `Dawny.xcscheme` — this was the implicit default anyway, so no behavioral change
- Scheme version bumped `1.7 → 1.8` (Xcode-managed)

Speeds up the UI test target in CI and locally. Trade-off: launch screenshot coverage no longer automatically covers Dark Mode and other appearance variants.
