### PR TITLE
feat(archive): two collapsible sections — Archived and Completed

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -350,6 +350,96 @@
         }
       }
     },
+    "archive.dialog.delete": {
+      "comment": "Archive tab · ConfirmationDialog · Destructive button to permanently delete the task.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        }
+      }
+    },
+    "archive.dialog.move_backlog": {
+      "comment": "Archive tab · ConfirmationDialog · Moves task back to Backlog.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Backlog verschieben"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Backlog"
+          }
+        }
+      }
+    },
+    "archive.dialog.move_today": {
+      "comment": "Archive tab · ConfirmationDialog · Moves task directly to Today.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für heute übernehmen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Today"
+          }
+        }
+      }
+    },
+    "archive.section.archive.title": {
+      "comment": "Archive tab · Collapsible section header title for auto-archived tasks.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archiviert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archived"
+          }
+        }
+      }
+    },
+    "archive.section.completed.title": {
+      "comment": "Archive tab · Collapsible section header title for manually completed tasks (last 30 days).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erledigt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completed"
+          }
+        }
+      }
+    },
     "archive.section.header": {
       "comment": "Archive tab · Section header below the tab title.",
       "extractionState": "manual",

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -61,6 +61,9 @@ final class Task {
     /// Zeitpunkt der Archivierung (nil wenn nicht archiviert)
     var archivedAt: Date? = nil
 
+    /// Zeitpunkt der manuellen Erledigung (nil wenn nicht oder noch nicht erledigt)
+    var completedAt: Date? = nil
+
     // MARK: - Relationships
     
     /// Referenz zum Parent-Backlog
@@ -135,6 +138,7 @@ final class Task {
     func complete() {
         isCompleted = true
         status = .completed
+        completedAt = Date()
         modifiedAt = Date()
     }
     

--- a/App/Sources/ViewModels/ArchiveViewModel.swift
+++ b/App/Sources/ViewModels/ArchiveViewModel.swift
@@ -6,7 +6,7 @@
 //  ArchiveViewModel.swift
 //  Dawny
 //
-//  ViewModel für das Archiv (Make it count)
+//  ViewModel für das Archiv (Make it count) und die Erledigt-Historie
 //
 
 import Foundation
@@ -19,27 +19,42 @@ final class ArchiveViewModel {
 
     private let modelContext: ModelContext
 
+    /// Automatisch archivierte Tasks (Make-It-Count via ResetEngine)
     var archivedTasks: [Task] = []
+
+    /// Manuell erledigte Tasks der letzten 30 Tage
+    var completedTasks: [Task] = []
+
     var errorMessage: String?
 
-    var isEmpty: Bool { archivedTasks.isEmpty }
+    var isEmpty: Bool { archivedTasks.isEmpty && completedTasks.isEmpty }
 
     // MARK: - Initializer
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
-        loadArchivedTasks()
+        loadAll()
     }
 
     // MARK: - Loading
 
-    func loadArchivedTasks() {
-        let descriptor = FetchDescriptor<Task>(
-            sortBy: [SortDescriptor(\.archivedAt, order: .reverse)]
-        )
+    func loadAll() {
+        let descriptor = FetchDescriptor<Task>()
         do {
             let all = try modelContext.fetch(descriptor)
-            archivedTasks = all.filter { $0.status == .archived && !$0.isDeleted }
+            let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+
+            archivedTasks = all
+                .filter { $0.status == .archived && !$0.isDeleted }
+                .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+
+            completedTasks = all
+                .filter {
+                    $0.status == .completed
+                    && !$0.isDeleted
+                    && ($0.completedAt ?? .distantPast) >= cutoff
+                }
+                .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
         } catch {
             errorMessage = String(
                 localized: "error.archive.load",
@@ -48,10 +63,9 @@ final class ArchiveViewModel {
         }
     }
 
-    // MARK: - Task Actions
+    // MARK: - Archived Task Actions
 
-    /// Unarchiviert einen Task zurück ins Backlog (in seine letzte Kategorie).
-    /// Falls die Kategorie zwischenzeitlich gelöscht wurde, wird „Unkategorisiert" verwendet.
+    /// Unarchiviert einen Task zurück ins Backlog.
     func unarchiveToBacklog(taskID: UUID) {
         guard let task = task(withID: taskID) else { return }
         ensureCategoryExists(for: task)
@@ -60,7 +74,6 @@ final class ArchiveViewModel {
     }
 
     /// Unarchiviert einen Task direkt in den Daily Focus.
-    /// Falls die Kategorie zwischenzeitlich gelöscht wurde, wird „Unkategorisiert" verwendet.
     func unarchiveToDailyFocus(taskID: UUID) {
         guard let task = task(withID: taskID) else { return }
         ensureCategoryExists(for: task)
@@ -75,6 +88,49 @@ final class ArchiveViewModel {
         saveAndReload()
     }
 
+    // MARK: - Completed Task Actions
+
+    /// Verschiebt einen erledigten Task zurück ins Backlog.
+    /// Löscht einen verknüpften Recurring-Clone, falls vorhanden.
+    func moveCompletedToBacklog(taskID: UUID) {
+        guard let task = task(withID: taskID) else { return }
+        if let cloneID = task.recurringCloneID, let clone = self.task(withID: cloneID) {
+            modelContext.delete(clone)
+        }
+        task.recurringCloneID = nil
+        task.isCompleted = false
+        task.completedAt = nil
+        task.status = .inBacklog
+        task.sortPriority = Date()
+        task.modifiedAt = Date()
+        ensureCategoryExists(for: task)
+        saveAndReload()
+    }
+
+    /// Verschiebt einen erledigten Task direkt in den Daily Focus.
+    /// Löscht einen verknüpften Recurring-Clone, falls vorhanden.
+    func moveCompletedToDailyFocus(taskID: UUID) {
+        guard let task = task(withID: taskID) else { return }
+        if let cloneID = task.recurringCloneID, let clone = self.task(withID: cloneID) {
+            modelContext.delete(clone)
+        }
+        task.recurringCloneID = nil
+        task.isCompleted = false
+        task.completedAt = nil
+        task.status = .dailyFocus
+        task.scheduledDate = Date()
+        task.modifiedAt = Date()
+        ensureCategoryExists(for: task)
+        saveAndReload()
+    }
+
+    /// Löscht einen erledigten Task permanent.
+    func deleteCompletedTask(taskID: UUID) {
+        guard let task = task(withID: taskID) else { return }
+        modelContext.delete(task)
+        saveAndReload()
+    }
+
     // MARK: - Private Helpers
 
     private func task(withID id: UUID) -> Task? {
@@ -84,7 +140,6 @@ final class ArchiveViewModel {
     }
 
     /// Stellt sicher, dass der Task eine gültige Kategorie hat.
-    /// Wenn die Kategorie gelöscht wurde (nil oder isDeleted), wird „Unkategorisiert" zugewiesen.
     private func ensureCategoryExists(for task: Task) {
         guard task.category == nil || task.category?.isDeleted == true else { return }
         let descriptor = FetchDescriptor<Category>()
@@ -97,7 +152,7 @@ final class ArchiveViewModel {
     private func saveAndReload() {
         do {
             try modelContext.save()
-            loadArchivedTasks()
+            loadAll()
         } catch {
             errorMessage = String(
                 localized: "error.archive.save",

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -168,6 +168,7 @@ final class DailyFocusViewModel {
 
         task.recurringCloneID = nil
         task.isCompleted = false
+        task.completedAt = nil
         task.status = .dailyFocus
         task.modifiedAt = Date()
 

--- a/App/Sources/Views/ArchiveView.swift
+++ b/App/Sources/Views/ArchiveView.swift
@@ -6,7 +6,8 @@
 //  ArchiveView.swift
 //  Dawny
 //
-//  Archiv-Tab – zeigt nicht erledigte Tasks, die nach wiederholtem Nicht-Erledigen archiviert wurden.
+//  Archiv-Tab – zeigt automatisch archivierte Tasks (Make-It-Count) und
+//  manuell erledigte Tasks der letzten 30 Tage in getrennten Sektionen.
 //
 
 import SwiftUI
@@ -15,6 +16,9 @@ import SwiftData
 struct ArchiveView: View {
     @Bindable var viewModel: ArchiveViewModel
     @Environment(\.modelContext) private var modelContext
+
+    @State private var isArchiveExpanded: Bool = true
+    @State private var isCompletedExpanded: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -27,7 +31,9 @@ struct ArchiveView: View {
             }
             .toolbar(.hidden, for: .navigationBar)
             .onAppear {
-                viewModel.loadArchivedTasks()
+                viewModel.loadAll()
+                isArchiveExpanded = true
+                isCompletedExpanded = false
             }
             .overlay(alignment: .top) {
                 if let error = viewModel.errorMessage {
@@ -44,39 +50,71 @@ struct ArchiveView: View {
 
     private var taskList: some View {
         List {
-            Section {
-                ForEach(viewModel.archivedTasks, id: \.id) { task in
-                    archivedTaskRow(task: task)
+            if !viewModel.archivedTasks.isEmpty {
+                Section {
+                    if isArchiveExpanded {
+                        ForEach(viewModel.archivedTasks, id: \.id) { task in
+                            archivedTaskRow(task: task)
+                        }
+                    }
+                } header: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ArchiveSectionHeader(
+                            title: String(
+                                localized: "archive.section.archive.title",
+                                defaultValue: "Archived"
+                            ),
+                            count: viewModel.archivedTasks.count,
+                            isExpanded: isArchiveExpanded,
+                            onToggle: { isArchiveExpanded.toggle() }
+                        )
+                        if isArchiveExpanded {
+                            Text(
+                                String(
+                                    localized: "archive.section.header",
+                                    defaultValue: "Archived tasks can be reactivated or deleted."
+                                )
+                            )
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .textCase(nil)
+                            .padding(.top, 2)
+                        }
+                    }
                 }
-            } header: {
-                Text(
-                    String(
-                        localized: "archive.section.header",
-                        defaultValue: "Archived tasks can be reactivated or deleted."
+            }
+
+            if !viewModel.completedTasks.isEmpty {
+                Section {
+                    if isCompletedExpanded {
+                        ForEach(viewModel.completedTasks, id: \.id) { task in
+                            completedTaskRow(task: task)
+                        }
+                    }
+                } header: {
+                    ArchiveSectionHeader(
+                        title: String(
+                            localized: "archive.section.completed.title",
+                            defaultValue: "Completed"
+                        ),
+                        count: viewModel.completedTasks.count,
+                        isExpanded: isCompletedExpanded,
+                        onToggle: { isCompletedExpanded.toggle() }
                     )
-                )
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .textCase(nil)
+                }
             }
         }
         .listStyle(.plain)
     }
 
-    // MARK: - Row
+    // MARK: - Archived Row
 
     private func archivedTaskRow(task: Task) -> some View {
         ArchivedTaskRowView(
             task: task,
-            onUnarchiveToBacklog: {
-                viewModel.unarchiveToBacklog(taskID: task.id)
-            },
-            onUnarchiveToDailyFocus: {
-                viewModel.unarchiveToDailyFocus(taskID: task.id)
-            },
-            onDelete: {
-                viewModel.deleteTask(taskID: task.id)
-            }
+            onUnarchiveToBacklog: { viewModel.unarchiveToBacklog(taskID: task.id) },
+            onUnarchiveToDailyFocus: { viewModel.unarchiveToDailyFocus(taskID: task.id) },
+            onDelete: { viewModel.deleteTask(taskID: task.id) }
         )
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             Button {
@@ -111,6 +149,48 @@ struct ArchiveView: View {
         }
     }
 
+    // MARK: - Completed Row
+
+    private func completedTaskRow(task: Task) -> some View {
+        CompletedTaskRowView(
+            task: task,
+            onMoveToBacklog: { viewModel.moveCompletedToBacklog(taskID: task.id) },
+            onMoveToDailyFocus: { viewModel.moveCompletedToDailyFocus(taskID: task.id) },
+            onDelete: { viewModel.deleteCompletedTask(taskID: task.id) }
+        )
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            Button {
+                viewModel.moveCompletedToBacklog(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.backlog", defaultValue: "Backlog"),
+                    systemImage: "tray.fill"
+                )
+            }
+            .tint(.blue)
+
+            Button {
+                viewModel.moveCompletedToDailyFocus(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.today", defaultValue: "Today"),
+                    systemImage: "sun.max.fill"
+                )
+            }
+            .tint(.orange)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                viewModel.deleteCompletedTask(taskID: task.id)
+            } label: {
+                Label(
+                    String(localized: "archive.swipe.delete", defaultValue: "Delete"),
+                    systemImage: "trash"
+                )
+            }
+        }
+    }
+
     // MARK: - Empty State
 
     private var emptyStateView: some View {
@@ -126,15 +206,51 @@ struct ArchiveView: View {
     }
 }
 
+// MARK: - Section Header
+
+private struct ArchiveSectionHeader: View {
+    let title: String
+    let count: Int
+    let isExpanded: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .textCase(nil)
+
+            Spacer()
+
+            Text(count, format: .number)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.secondary.opacity(0.2))
+                .clipShape(Capsule())
+
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .animation(.easeInOut(duration: 0.2), value: isExpanded)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onToggle)
+    }
+}
+
 // MARK: - Archived Task Row
 
-/// Zeigt einen archivierten Task ausgegraut an (keine Checkbox, kein Drag-Handle).
+/// Zeigt einen automatisch archivierten Task ausgegraut an.
 private struct ArchivedTaskRowView: View {
     let task: Task
     let onUnarchiveToBacklog: () -> Void
     let onUnarchiveToDailyFocus: () -> Void
     let onDelete: () -> Void
 
+    @State private var isActionDialogPresented: Bool = false
     @Environment(\.modelContext) private var modelContext
 
     var body: some View {
@@ -149,9 +265,15 @@ private struct ArchivedTaskRowView: View {
 
     private func rowContent(task: Task) -> some View {
         HStack(spacing: 12) {
-            Image(systemName: "archivebox")
-                .font(.subheadline)
-                .foregroundStyle(.tertiary)
+            Button {
+                HapticFeedback.light()
+                isActionDialogPresented = true
+            } label: {
+                Image(systemName: "archivebox")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(task.title)
@@ -187,5 +309,104 @@ private struct ArchivedTaskRowView: View {
         }
         .padding(.vertical, 4)
         .opacity(0.75)
+        .confirmationDialog(task.title, isPresented: $isActionDialogPresented, titleVisibility: .visible) {
+            Button(String(localized: "archive.dialog.move_backlog", defaultValue: "Move to Backlog")) {
+                onUnarchiveToBacklog()
+            }
+            Button(String(localized: "archive.dialog.move_today", defaultValue: "Move to Today")) {
+                onUnarchiveToDailyFocus()
+            }
+            Button(
+                String(localized: "archive.dialog.delete", defaultValue: "Delete"),
+                role: .destructive
+            ) {
+                onDelete()
+            }
+        }
+    }
+}
+
+// MARK: - Completed Task Row
+
+/// Zeigt einen manuell erledigten Task ausgegraut mit Checkmark-Icon an.
+private struct CompletedTaskRowView: View {
+    let task: Task
+    let onMoveToBacklog: () -> Void
+    let onMoveToDailyFocus: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isActionDialogPresented: Bool = false
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        if let resolved: Task = modelContext.registeredModel(for: task.persistentModelID),
+           resolved.modelContext != nil,
+           !resolved.isDeleted {
+            rowContent(task: resolved)
+        } else {
+            EmptyView()
+        }
+    }
+
+    private func rowContent(task: Task) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                HapticFeedback.light()
+                isActionDialogPresented = true
+            } label: {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(task.title)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                if let notes = task.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+
+                if let category = task.category {
+                    HStack(spacing: 4) {
+                        Image(systemName: category.displayIconName)
+                            .font(.caption2)
+                        Text(category.displayName)
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer()
+
+            if let completedAt = task.completedAt {
+                Text(completedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.quaternary)
+            }
+        }
+        .padding(.vertical, 4)
+        .opacity(0.75)
+        .confirmationDialog(task.title, isPresented: $isActionDialogPresented, titleVisibility: .visible) {
+            Button(String(localized: "archive.dialog.move_backlog", defaultValue: "Move to Backlog")) {
+                onMoveToBacklog()
+            }
+            Button(String(localized: "archive.dialog.move_today", defaultValue: "Move to Today")) {
+                onMoveToDailyFocus()
+            }
+            Button(
+                String(localized: "archive.dialog.delete", defaultValue: "Delete"),
+                role: .destructive
+            ) {
+                onDelete()
+            }
+        }
     }
 }

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -191,7 +191,7 @@ struct ContentView: View {
             withTransaction(transaction) {
                 selectedTab = .archive
                 settings.hasNewArchivedTasks = false
-                archiveViewModel?.loadArchivedTasks()
+                archiveViewModel?.loadAll()
             }
         } label: {
             ZStack(alignment: .topTrailing) {
@@ -268,7 +268,7 @@ struct ContentView: View {
         backlogVM.loadBacklogs()
         backlogVM.loadCategories()
         dailyFocusViewModel?.loadDailyTasks()
-        archiveViewModel?.loadArchivedTasks()
+        archiveViewModel?.loadAll()
         #endif
     }
 

--- a/docs/context/PRD.md
+++ b/docs/context/PRD.md
@@ -48,7 +48,9 @@ Der Nutzer entscheidet jeden Tag aktiv, welche Tasks er in den "Daily Focus" ver
 
 - Today (Daily Focus): Tasks für den heutigen Tag
 
-- Archiv: Abgelaufene, archivierte oder erledigte Tasks
+- Archiv: Zwei Sektionen:
+  - **Archiviert**: Automatisch archivierte Tasks (via ResetEngine/Make-It-Count)
+  - **Erledigt**: Manuell erledigte Tasks aus den letzten 30 Tagen. Beide Sektionen sind kollabierbar, die Erledigt-Sektion ist standardmäßig eingeklappt.
 
 ### 2. Konfigurierbarer Reset ("Make it Count")
 

--- a/docs/context/QA_checklist.md
+++ b/docs/context/QA_checklist.md
@@ -48,13 +48,36 @@ _Hintergrund: System-Permissions sind dynamisch. User ändern gerne mittendrin i
 - [ ] **Kategorien (falls in V1 aktiv):** Neue Kategorie anlegen, Task zuweisen, Kategorie löschen.
   - _Erwartet:_ Task verliert Zuweisung, aber App stürzt nicht durch fehlende Referenzen (Cascade Deletion Rules) ab.
 
-## 5. UI, Design & Accessibility
+## 5. Archive-Feature (Getrennte Sektionen)
+
+- [ ] **Task erledigen → Erledigt-Sektion:** Task in "Today" abhaken.
+  - _Erwartet:_ Task erscheint in Archive-Tab unter "Erledigt"-Sektion mit aktuellem Datum. "Archiviert"-Sektion bleibt von manuell erledigten Tasks unberührt.
+
+- [ ] **Erledigt-Sektion default eingeklappt:** Archive-Tab öffnen.
+  - _Erwartet:_ "Archiviert"-Sektion ist ausgeklappt und angezeigt. "Erledigt"-Sektion ist eingeklappt (nur Chevron sichtbar).
+
+- [ ] **Tap auf Icon → ConfirmationDialog:** In einer der beiden Sektionen auf das Icon (Archiv oder Checkmark) tippen.
+  - _Erwartet:_ Dialog öffnet sich mit 4 Optionen: "Backlog", "Today", "Delete", "Abbrechen". Dialog ist scrollbar wenn Text zu lang.
+
+- [ ] **Dialog-Aktion "Backlog":** Task aus Dialog ins Backlog verschieben.
+  - _Erwartet:_ Task verschwindet aus Archive. Status wird auf `.inBacklog` gesetzt. Swipe-Actions (besteht aus 1-2 Actions) funktionieren unverändert.
+
+- [ ] **Dialog-Aktion "Today":** Task aus Dialog zu Daily Focus verschieben.
+  - _Erwartet:_ Task verschwindet aus Archive. Status wird auf `.dailyFocus` gesetzt.
+
+- [ ] **Erledigt-Sektion: 30-Tage-Cutoff:** Task vor >30 Tagen erledigen (oder Systemdatum manipulieren). Zurück zu Archive.
+  - _Erwartet:_ Alte Tasks erscheinen NICHT in "Erledigt". Sie können manuell in Backlog/Today verschoben werden (nicht möglich aus UI, da nicht sichtbar) oder bleiben in der Datenbank ohne Anzeige.
+
+- [ ] **Abschnitte-Collapse-State flüchtig:** "Erledigt" ausgeklappt. Zu einem anderen Tab wechseln. Zurück zu Archive.
+  - _Erwartet:_ "Erledigt"-Sektion ist wieder eingeklappt (Default-State).
+
+## 6. UI, Design & Accessibility
 
 - [ ] **Dark Mode Check:** Gerät in den Dark Mode schalten. Alle Views durchklicken.
-  - _Erwartet:_ Keine schwarzen Texte auf dunkelgrauem Grund. Alle Kontraste (besonders Custom Views und leere States) sind gut lesbar.
+  - _Erwartet:_ Keine schwarzen Texte auf dunkelgrauem Grund. Alle Kontraste (besonders Custom Views und leere States) sind gut lesbar. Archive-Icons und Badges sind in Dark Mode lesbar.
 
 - [ ] **Dynamic Type (Große Schrift):** In den iOS-Einstellungen (Bedienungshilfen) die Schriftgröße auf Maximum stellen.
-  - _Erwartet:_ Keine überlappenden Texte, unlesbaren Buttons oder abgeschnittenen Task-Titel. Die UI bricht sauber um.
+  - _Erwartet:_ Keine überlappenden Texte, unlesbaren Buttons oder abgeschnittenen Task-Titel. Die UI bricht sauber um. Section-Header und Badges passen sich an.
 
 ---
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -90,6 +90,7 @@ The application leverages SwiftUI's environment for Dependency Injection (DI). T
 - **Environment Injection:** Services are injected into the SwiftUI hierarchy using custom `EnvironmentKey`s (`\.resetEngine`, `\.syncEngine`) defined at the bottom of `DawnyApp.swift`.
 - **Settings Singleton:** `AppSettings.shared` is accessed directly throughout the codebase — in services, ViewModels, and Views — rather than being injected via Environment. It is an `@Observable` class, so SwiftUI views that read its properties re-render automatically.
 - **ViewModel Lifecycle:** ViewModels (`BacklogViewModel`, `DailyFocusViewModel`, `ArchiveViewModel`) are `@State` optional properties on `ContentView`, initialized lazily in `initializeViewModels()` which is called from `.onAppear`. Because they are `@State`, they survive view re-renders. The pattern is safe for the current architecture since `ContentView` is the permanent root view, but if `ContentView` were ever to disappear and reappear (e.g., due to a deep scene reconstruction), ViewModels would be re-created. Moving initialization to a stable coordinator above `ContentView` would be more robust.
+- **ArchiveView two-section layout:** `ArchiveView` displays two collapsible sections: (1) "Archiviert" (auto-archived tasks, default expanded, icon: `archivebox`), and (2) "Erledigt" (manually completed tasks from last 30 days, default collapsed, icon: `checkmark.circle.fill`). Each section header includes a task count badge. Tapping an icon opens a `ConfirmationDialog` with actions: move to Backlog, move to Daily Focus, delete, or cancel. The "Erledigt" section filters tasks with `status == .completed && completedAt >= Date().addingTimeInterval(-30*86400)`, sorted by `completedAt` descending. Collapse state is stored in `@State`, not persisted.
 
 ---
 
@@ -124,6 +125,7 @@ The schema is registered in `DawnyApp.init()` with `isStoredInMemoryOnly: false`
 | `isCompleted` | `Bool` | |
 | `recurringCloneID` | `UUID?` | Links a recurring task to the fresh Backlog clone created when it is completed in Daily Focus |
 | `resetCount` | `Int` | Incremented each time the task is in Daily Focus and not completed at reset. Reset to 0 on manual move-to-backlog and on unarchive. |
+| `completedAt` | `Date?` | Timestamp set by `complete()`; used to group completed tasks in ArchiveView by completion date. Nil when not completed. |
 | `archivedAt` | `Date?` | Timestamp set by `archive()`; nil when not archived |
 
 **Relationships:**


### PR DESCRIPTION
## Summary

- **New `completedAt: Date?` field** on `Task` — set in `complete()`, cleared in `uncompleteTask()`
- **ArchiveViewModel** now maintains two lists: `archivedTasks` (Make-It-Count) and `completedTasks` (last 30 days), each with their own move/delete actions including recurring-clone cleanup
- **ArchiveView** shows two collapsible sections — "Archived" expanded by default, "Completed" collapsed; state resets to default on every tab open
- **Icon tap** on `archivebox` (Archived) and `checkmark.circle.fill` (Completed) opens a `ConfirmationDialog` with the same actions as the swipe gestures (Backlog / Today / Delete)
- **5 new localisation keys** added in both en and de
- Docs updated: architecture schema, QA checklist, PRD

## Test plan

- [ ] Task erledigen → erscheint in Archive unter "Erledigt"
- [ ] Make-It-Count-Reset triggern → Task erscheint unter "Archiviert"
- [ ] Archiv-Header tippen → Sektion klappt ein/aus
- [ ] Erledigt-Header tippen → Sektion klappt ein/aus
- [ ] Tab verlassen + zurück → Erledigt wieder eingeklappt
- [ ] Icon tippen (beide Sektionen) → ConfirmationDialog mit Backlog / Today / Delete
- [ ] Swipe-Aktionen beider Sektionen funktionieren korrekt
- [ ] Recurring-Task in Erledigt → via Backlog reaktivieren: Clone gelöscht, Parent reaktiviert
- [ ] Nur eine Sektion befüllt → keine leere Header-Zeile der anderen Sektion
- [ ] Beide Sektionen leer → EmptyStateView erscheint
- [ ] Sprachtest de/en: alle neuen Keys korrekt übersetzt

🤖 Generated with [Claude Code](https://claude.com/claude-code)