### PR TITLE
feat(debug): add Perform Reset, Mark Incomplete+Reset, and Reset Welcome actions

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -3662,6 +3662,60 @@
         }
       }
     },
+    "debug.reset.now": {
+      "comment": "Settings · Debug action · Triggers the reset engine immediately without waiting for the scheduled reset hour.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset jetzt ausführen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perform Reset Now"
+          }
+        }
+      }
+    },
+    "debug.markincomplete.reset": {
+      "comment": "Settings · Debug action · Marks all Today tasks as incomplete, then triggers the reset engine.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heute auf offen + Reset"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark Today Incomplete + Reset"
+          }
+        }
+      }
+    },
+    "debug.reset.welcome": {
+      "comment": "Settings · Debug action · Resets the hasSeenWelcome flag and re-shows the onboarding welcome screen.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome zurücksetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Welcome"
+          }
+        }
+      }
+    },
     "quickadd.notes.section": {
       "comment": "QuickAdd · Section header for the optional notes field · Noun phrase.",
       "extractionState": "manual",

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -45,6 +45,55 @@ struct ContentView: View {
         return nil
         #endif
     }
+
+    private var performResetAction: (() -> Void)? {
+        #if DEBUG
+        return {
+            _Concurrency.Task {
+                await resetEngine?.performReset()
+                backlogViewModel?.loadBacklogs()
+                dailyFocusViewModel?.loadDailyTasks()
+                archiveViewModel?.loadAll()
+            }
+        }
+        #else
+        return nil
+        #endif
+    }
+
+    private var markIncompleteAndResetAction: (() -> Void)? {
+        #if DEBUG
+        return {
+            _Concurrency.Task {
+                let descriptor = FetchDescriptor<Task>()
+                if let allTasks = try? modelContext.fetch(descriptor) {
+                    for task in allTasks where task.status == .dailyFocus {
+                        task.isCompleted = false
+                    }
+                    try? modelContext.save()
+                }
+                await resetEngine?.performReset()
+                backlogViewModel?.loadBacklogs()
+                dailyFocusViewModel?.loadDailyTasks()
+                archiveViewModel?.loadAll()
+            }
+        }
+        #else
+        return nil
+        #endif
+    }
+
+    private var resetWelcomeAction: (() -> Void)? {
+        #if DEBUG
+        return {
+            AppSettings.shared.hasSeenWelcome = false
+            showingSettings = false
+            showWelcome = true
+        }
+        #else
+        return nil
+        #endif
+    }
     
     enum Tab: Int {
         case backlog = 0
@@ -108,6 +157,9 @@ struct ContentView: View {
             SettingsView(
                 onRequestAddTestItems: addTestItemsAction,
                 onRequestDeleteAll: clearAllAction,
+                onRequestPerformReset: performResetAction,
+                onRequestMarkIncompleteAndReset: markIncompleteAndResetAction,
+                onRequestResetWelcome: resetWelcomeAction,
                 onRequestShowWelcome: {
                     showingSettings = false
                     showWelcome = true

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -21,6 +21,9 @@ struct SettingsView: View {
     
     let onRequestAddTestItems: (() -> Void)?
     let onRequestDeleteAll: (() -> Void)?
+    let onRequestPerformReset: (() -> Void)?
+    let onRequestMarkIncompleteAndReset: (() -> Void)?
+    let onRequestResetWelcome: (() -> Void)?
     let onRequestShowWelcome: (() -> Void)?
 
     @State private var resetTime: Date
@@ -31,11 +34,17 @@ struct SettingsView: View {
         settings: AppSettings = .shared,
         onRequestAddTestItems: (() -> Void)? = nil,
         onRequestDeleteAll: (() -> Void)? = nil,
+        onRequestPerformReset: (() -> Void)? = nil,
+        onRequestMarkIncompleteAndReset: (() -> Void)? = nil,
+        onRequestResetWelcome: (() -> Void)? = nil,
         onRequestShowWelcome: (() -> Void)? = nil
     ) {
         self.settings = settings
         self.onRequestAddTestItems = onRequestAddTestItems
         self.onRequestDeleteAll = onRequestDeleteAll
+        self.onRequestPerformReset = onRequestPerformReset
+        self.onRequestMarkIncompleteAndReset = onRequestMarkIncompleteAndReset
+        self.onRequestResetWelcome = onRequestResetWelcome
         self.onRequestShowWelcome = onRequestShowWelcome
         
         // Initialisiere resetTime basierend auf resetHour
@@ -98,7 +107,12 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var debugSection: some View {
-        if onRequestAddTestItems != nil || onRequestDeleteAll != nil {
+        let hasAnyDebugAction = onRequestAddTestItems != nil
+            || onRequestDeleteAll != nil
+            || onRequestPerformReset != nil
+            || onRequestMarkIncompleteAndReset != nil
+            || onRequestResetWelcome != nil
+        if hasAnyDebugAction {
             Section {
                 if let onRequestAddTestItems {
                     Button {
@@ -108,6 +122,41 @@ struct SettingsView: View {
                         Label(
                             String(localized: "quickadd.addtestitems", defaultValue: "Add Test Items"),
                             systemImage: "wand.and.stars"
+                        )
+                    }
+                }
+
+                if let onRequestPerformReset {
+                    Button {
+                        onRequestPerformReset()
+                        dismiss()
+                    } label: {
+                        Label(
+                            String(localized: "debug.reset.now", defaultValue: "Perform Reset Now"),
+                            systemImage: "arrow.clockwise"
+                        )
+                    }
+                }
+
+                if let onRequestMarkIncompleteAndReset {
+                    Button {
+                        onRequestMarkIncompleteAndReset()
+                        dismiss()
+                    } label: {
+                        Label(
+                            String(localized: "debug.markincomplete.reset", defaultValue: "Mark Today Incomplete + Reset"),
+                            systemImage: "arrow.triangle.2.circlepath"
+                        )
+                    }
+                }
+
+                if let onRequestResetWelcome {
+                    Button {
+                        onRequestResetWelcome()
+                    } label: {
+                        Label(
+                            String(localized: "debug.reset.welcome", defaultValue: "Reset Welcome"),
+                            systemImage: "sparkles"
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

- **Perform Reset Now** — triggers `ResetEngine.performReset()` immediately, reloads all ViewModels. Lets you test the Make-it-count flow (resetCount increment, archiving at threshold) without waiting for the scheduled reset hour.
- **Mark Today Incomplete + Reset** — sets `isCompleted = false` on all Daily Focus tasks, saves, then calls `performReset()`. Simulates the scenario where all tasks were checked off but you still want to run them through the full reset path.
- **Reset Welcome** — sets `hasSeenWelcome = false`, closes Settings, shows the Welcome screen. Unlike the existing "Show welcome again" button, this resets the flag so the next cold launch also shows onboarding.

All three actions are `#if DEBUG`-gated and wired via optional closures (same pattern as the existing Add Test Items / Delete All buttons). No production code paths touched. Localized strings added for en + de.

## Test plan

- [ ] **Perform Reset Now**: Add test items → move to Today → leave some incomplete → Settings → Perform Reset Now → incomplete tasks back in Backlog, `resetCount` +1. Tap again → task reaches threshold → appears in Archive. Recurring task: stays in Backlog after any number of resets, never in Archive.
- [ ] **Mark Today Incomplete + Reset**: Move tasks to Today, check them all off → Settings → Mark Today Incomplete + Reset → same behavior as above (completed tasks treated as incomplete, reset path runs fully).
- [ ] **Reset Welcome**: Settings → Reset Welcome → Settings closes, Welcome sheet appears immediately. Fully quit and relaunch app → Welcome appears again on launch (flag was truly reset, not just shown once).
- [ ] Existing debug buttons (Add Test Items, Delete All) still work.
- [ ] Release build: debug section not visible in Settings.