### PR TITLE
feat(categories): replace inline editing with modal CategoryEditorView sheet

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -1352,6 +1352,276 @@
         }
       }
     },
+    "categoryEditor.autoArchive.after": {
+      "comment": "CategoryEditor · Auto-archive picker label · Preposition introducing the time duration.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After"
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.daysFormat": {
+      "comment": "CategoryEditor · Auto-archive picker option and stepper label · printf format string, %d = number of days.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d Tage"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d days"
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.daysUnit": {
+      "comment": "CategoryEditor · Unit label next to the custom days text field.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tage"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "days"
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.disabledFooter": {
+      "comment": "CategoryEditor · Footer below auto-archive section when recurring is on · Plain sentence.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederkehrende Kategorien werden nie archiviert — Aufgaben kehren immer ins Backlog zurück."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recurring categories never archive — tasks always return to the backlog."
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.option.custom": {
+      "comment": "CategoryEditor · Auto-archive picker option · Lets the user enter a custom day count. Trailing ellipsis signals a sub-interaction.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom…"
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.option.off": {
+      "comment": "CategoryEditor · Auto-archive picker option · Disables auto-archiving. Single word.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.section": {
+      "comment": "CategoryEditor · Section header for auto-archive setting · Noun phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus Backlog automatisch archivieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-archive from backlog"
+          }
+        }
+      }
+    },
+    "categoryEditor.button.add": {
+      "comment": "CategoryEditor · Confirmation toolbar button in add mode · Single verb.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
+          }
+        }
+      }
+    },
+    "categoryEditor.button.save": {
+      "comment": "CategoryEditor · Confirmation toolbar button in edit mode · Single verb.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        }
+      }
+    },
+    "categoryEditor.iconButton.accessibility": {
+      "comment": "CategoryEditor · VoiceOver label for the icon button · Imperative phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol wählen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose icon"
+          }
+        }
+      }
+    },
+    "categoryEditor.namePlaceholder": {
+      "comment": "CategoryEditor · Name text field placeholder · Noun phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategoriename"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Category name"
+          }
+        }
+      }
+    },
+    "categoryEditor.recurring.footer": {
+      "comment": "CategoryEditor · Footer below the recurring toggle · One plain sentence explaining the effect.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgaben erscheinen direkt nach dem Erledigen oder Archivieren wieder im Backlog."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasks reappear in the backlog right after you complete or archive them."
+          }
+        }
+      }
+    },
+    "categoryEditor.recurring.title": {
+      "comment": "CategoryEditor · Toggle label for the recurring setting · Noun phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederkehrende Aufgaben"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recurring tasks"
+          }
+        }
+      }
+    },
+    "categoryEditor.title.add": {
+      "comment": "CategoryEditor · Sheet navigation title in add mode · Noun phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neue Kategorie"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Category"
+          }
+        }
+      }
+    },
+    "categoryEditor.title.edit": {
+      "comment": "CategoryEditor · Sheet navigation title in edit mode · Noun phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorie bearbeiten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Category"
+          }
+        }
+      }
+    },
     "common.delete": {
       "comment": "Common · Destructive button · Single verb.",
       "extractionState": "manual",

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -26,12 +26,10 @@ struct BacklogView: View {
 
     // MARK: - Category Editing State
 
-    /// ID der Kategorie, die gerade per Inline-TextField umbenannt wird.
-    @State private var editingCategoryID: UUID?
     /// Kategorie, für die das Aktionsmenü (Long-Press) offen ist.
     @State private var actionsCategory: Category?
-    /// Kategorie, für die der Symbol-Picker geöffnet ist.
-    @State private var iconPickerCategory: Category?
+    /// Steuert den Add/Edit-Sheet. nil = geschlossen.
+    @State private var editorTarget: CategoryEditorTarget?
     /// Kategorie, die gerade gelöscht werden soll (Confirmation Dialog).
     @State private var pendingDeleteCategory: Category?
 
@@ -53,22 +51,36 @@ struct BacklogView: View {
                 }
             }
             .toolbar(.hidden, for: .navigationBar)
-            .sheet(item: $iconPickerCategory) { category in
-                CategorySymbolPicker(currentSymbol: category.displayIconName) { newSymbol in
-                    if viewModel.updateCategoryIcon(category, to: newSymbol) {
+            .sheet(item: $editorTarget) { target in
+                switch target {
+                case .add:
+                    CategoryEditorView(mode: .add { name, icon, recurring in
+                        if let created = viewModel.createCategory(name: name, isRecurring: recurring) {
+                            if let icon { _ = viewModel.updateCategoryIcon(created, to: icon) }
+                            expandedCategories.insert(created.id)
+                        }
+                    })
+                case .edit(let category):
+                    CategoryEditorView(mode: .edit(category) { name, icon, recurring in
+                        if name != category.displayName {
+                            _ = viewModel.renameCategory(category, to: name)
+                        }
+                        if icon != category.displayIconName {
+                            _ = viewModel.updateCategoryIcon(category, to: icon)
+                        }
+                        if recurring != category.isRecurring {
+                            _ = viewModel.toggleRecurring(category)
+                        }
                         HapticFeedback.success()
-                    }
+                    })
                 }
             }
             .modifier(
                 CategoryActionMenu(
                     actionsCategory: $actionsCategory,
-                    onEdit: { category in beginRenaming(category) },
+                    onEdit: { category in editorTarget = .edit(category) },
                     onDelete: { category in requestDelete(category) },
-                    onReorder: { category in activateSortMode(startingWith: category) },
-                    onToggleRecurring: { category in
-                        _ = viewModel.toggleRecurring(category)
-                    }
+                    onReorder: { category in activateSortMode(startingWith: category) }
                 )
             )
             .modifier(
@@ -156,7 +168,6 @@ struct BacklogView: View {
             ForEach(sortedCategories, id: \.id) { category in
                 let tasks = grouped[category.id] ?? []
                 let isExpanded = expandedCategories.contains(category.id)
-                let isEditingThis = editingCategoryID == category.id
 
                 // Alle Kategorien; leere sind standardmäßig aufgeklappt, sobald der Backlog leer ist
                 Section {
@@ -179,20 +190,13 @@ struct BacklogView: View {
                         )
                     }
                 } header: {
-                    categoryHeader(
-                        for: category,
-                        taskCount: tasks.count,
-                        isExpanded: isExpanded,
-                        isEditingName: isEditingThis
-                    )
+                    categoryHeader(for: category, taskCount: tasks.count, isExpanded: isExpanded)
                 }
             }
 
             Section {
-                AddCategoryRow { name, isRecurring in
-                    if let created = viewModel.createCategory(name: name, isRecurring: isRecurring) {
-                        expandedCategories.insert(created.id)
-                    }
+                AddCategoryRow {
+                    editorTarget = .add
                 }
             }
         }
@@ -289,38 +293,18 @@ struct BacklogView: View {
     }
 
     @ViewBuilder
-    private func categoryHeader(
-        for category: Category,
-        taskCount: Int,
-        isExpanded: Bool,
-        isEditingName: Bool
-    ) -> some View {
-        let header = CategoryHeaderView(
+    private func categoryHeader(for category: Category, taskCount: Int, isExpanded: Bool) -> some View {
+        CategoryHeaderView(
             category: category,
             taskCount: taskCount,
             isExpanded: isExpanded,
-            isEditingName: isEditingName,
-            isIconPickerOpen: isEditingName && iconPickerCategory?.id == category.id,
             onToggle: { toggleCategory(category.id) },
-            onLongPress: { actionsCategory = category },
-            onCommitRename: { newName in commitRename(category, to: newName) },
-            onCancelRename: { editingCategoryID = nil },
-            onIconTap: { iconPickerCategory = category }
+            onLongPress: { actionsCategory = category }
         )
-
-        // Drop-Target nur deaktivieren, wenn diese Zeile gerade editiert wird –
-        // damit das TextField den Tap exklusiv bekommt und keine Tasks
-        // versehentlich auf den Header gezogen werden.
-        let configured = header
-            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
-            .listRowSeparator(.hidden)
-
-        if isEditingName {
-            configured
-        } else {
-            configured.dropDestination(for: BacklogTaskTransfer.self) { items, _ in
-                return handleCategoryHeaderDrop(items, targetCategory: category)
-            }
+        .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+        .listRowSeparator(.hidden)
+        .dropDestination(for: BacklogTaskTransfer.self) { items, _ in
+            return handleCategoryHeaderDrop(items, targetCategory: category)
         }
     }
     
@@ -515,8 +499,7 @@ struct BacklogView: View {
     private func activateSortMode(startingWith _: Category) {
         guard !isSortingCategories else { return }
         actionsCategory = nil
-        editingCategoryID = nil
-        iconPickerCategory = nil
+        editorTarget = nil
         focusedTaskID = nil
         expandedCategoriesBeforeSort = expandedCategories
         withAnimation(.easeInOut(duration: 0.2)) {
@@ -535,34 +518,8 @@ struct BacklogView: View {
         HapticFeedback.light()
     }
 
-    private func beginRenaming(_ category: Category) {
-        guard category.canRename else { return }
-        // Kategorie ausklappen, damit Tastatur das Feld nicht verdeckt
-        // und der visuelle Kontext klar ist.
-        if !expandedCategories.contains(category.id) {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                _ = expandedCategories.insert(category.id)
-            }
-        }
-        editingCategoryID = category.id
-    }
-
-    private func commitRename(_ category: Category, to newName: String) {
-        let success = viewModel.renameCategory(category, to: newName)
-        editingCategoryID = nil
-        if success {
-            HapticFeedback.success()
-        } else {
-            HapticFeedback.error()
-        }
-    }
-
     private func requestDelete(_ category: Category) {
         guard category.canDelete else { return }
-        // Falls die Zeile gerade editiert wird, Edit beenden, bevor der Dialog kommt.
-        if editingCategoryID == category.id {
-            editingCategoryID = nil
-        }
         HapticFeedback.warning()
         pendingDeleteCategory = category
     }
@@ -597,7 +554,6 @@ private struct CategoryActionMenu: ViewModifier {
     let onEdit: (Category) -> Void
     let onDelete: (Category) -> Void
     let onReorder: (Category) -> Void
-    let onToggleRecurring: (Category) -> Void
 
     func body(content: Content) -> some View {
         content.confirmationDialog(
@@ -606,7 +562,7 @@ private struct CategoryActionMenu: ViewModifier {
             titleVisibility: .visible,
             presenting: actionsCategory
         ) { category in
-            if category.canRename || category.canChangeIcon {
+            if category.hasAnyEditCapability {
                 Button(
                     String(
                         localized: "category.action.edit",
@@ -623,27 +579,6 @@ private struct CategoryActionMenu: ViewModifier {
                 )
             ) {
                 onReorder(category)
-            }
-            if category.canToggleRecurring {
-                Button {
-                    onToggleRecurring(category)
-                } label: {
-                    if category.isRecurring {
-                        Text(
-                            String(
-                                localized: "category.action.unmakeRecurring",
-                                defaultValue: "Remove recurring"
-                            )
-                        )
-                    } else {
-                        Text(
-                            String(
-                                localized: "category.action.makeRecurring",
-                                defaultValue: "Mark as recurring"
-                            )
-                        )
-                    }
-                }
             }
             if category.canDelete {
                 Button(
@@ -774,5 +709,19 @@ private struct CategoryDeleteConfirmation: ViewModifier {
                 if !newValue { pendingCategory = nil }
             }
         )
+    }
+}
+
+// MARK: - CategoryEditorTarget
+
+private enum CategoryEditorTarget: Identifiable {
+    case add
+    case edit(Category)
+
+    var id: String {
+        switch self {
+        case .add: return "add"
+        case .edit(let category): return "edit-\(category.id)"
+        }
     }
 }

--- a/App/Sources/Views/Components/AddCategoryRow.swift
+++ b/App/Sources/Views/Components/AddCategoryRow.swift
@@ -6,44 +6,19 @@
 //  AddCategoryRow.swift
 //  Dawny
 //
-//  „Geister-Zeile“ zum Anlegen einer neuen Kategorie (Placeholder → aktives Textfeld).
+//  Ghost row that opens the category editor sheet on tap.
 //
 
 import SwiftUI
 
 struct AddCategoryRow: View {
-    let onCreate: (String, Bool) -> Void
-
-    @State private var isEditing = false
-    @State private var draft = ""
-    @State private var isRecurring = false
-    @FocusState private var isFocused: Bool
-
-    private let maxLength = CategoryService.maxNameLength
-
-    private var trimmed: String {
-        draft.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var isValid: Bool {
-        !trimmed.isEmpty && trimmed.count <= maxLength
-    }
+    let onTap: () -> Void
 
     private var placeholder: String {
         String(localized: "category.add.placeholder", defaultValue: "New category")
     }
 
     var body: some View {
-        Group {
-            if isEditing {
-                activeRow
-            } else {
-                ghostRow
-            }
-        }
-    }
-
-    private var ghostRow: some View {
         HStack {
             Image(systemName: "plus")
                 .foregroundStyle(.secondary)
@@ -59,94 +34,12 @@ struct AddCategoryRow: View {
         }
         .contentShape(Rectangle())
         .onTapGesture {
-            isEditing = true
-            draft = ""
-            isRecurring = false
+            onTap()
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             String(localized: "category.add.accessibility", defaultValue: "Add new category")
         )
         .accessibilityAddTraits(.isButton)
-    }
-
-    private var activeRow: some View {
-        HStack(spacing: 8) {
-            Button {
-                isRecurring.toggle()
-                HapticFeedback.light()
-            } label: {
-                Image(systemName: "arrow.triangle.2.circlepath")
-                    .font(.subheadline)
-                    .foregroundStyle(isRecurring ? Color.accentColor : Color.secondary)
-                    .frame(width: 28, height: 28)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(isRecurring ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.1))
-                    )
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(
-                String(localized: "category.add.recurringToggle", defaultValue: "Recurring")
-            )
-            .accessibilityAddTraits(isRecurring ? .isSelected : [])
-
-            TextField(placeholder, text: $draft)
-                .font(.headline)
-                .foregroundStyle(.primary)
-                .textInputAutocapitalization(.sentences)
-                .autocorrectionDisabled(false)
-                .submitLabel(.done)
-                .focused($isFocused)
-                .onSubmit { submit() }
-
-            Button {
-                submit()
-            } label: {
-                Text(String(localized: "common.done", defaultValue: "Done"))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(isValid ? Color.accentColor : Color.secondary)
-            }
-            .buttonStyle(.borderless)
-            .disabled(!isValid)
-            .accessibilityLabel(String(localized: "common.done", defaultValue: "Done"))
-        }
-        .onAppear {
-            HapticFeedback.light()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                isFocused = true
-            }
-        }
-        .onChange(of: isFocused) { wasFocused, isNowFocused in
-            guard wasFocused, !isNowFocused else { return }
-            if isValid {
-                submit()
-            } else {
-                cancel()
-            }
-        }
-    }
-
-    private func submit() {
-        guard isValid else {
-            HapticFeedback.error()
-            return
-        }
-        onCreate(trimmed, isRecurring)
-        resetAfterCreate()
-    }
-
-    private func cancel() {
-        draft = ""
-        isRecurring = false
-        isEditing = false
-    }
-
-    /// Zuerst `draft` leeren, dann Fokus entfernen – sonst feuert `onChange` noch mit altem Text und legt doppelt an.
-    private func resetAfterCreate() {
-        draft = ""
-        isRecurring = false
-        isFocused = false
-        isEditing = false
     }
 }

--- a/App/Sources/Views/Components/CategoryEditorView.swift
+++ b/App/Sources/Views/Components/CategoryEditorView.swift
@@ -1,0 +1,272 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  CategoryEditorView.swift
+//  Dawny
+//
+//  Modal sheet for creating and editing categories.
+//
+
+import SwiftUI
+
+struct CategoryEditorView: View {
+
+    // MARK: - Mode
+
+    enum Mode {
+        /// Creating a new category. Callback receives name, optional icon override, and recurring flag.
+        case add(onCreate: (String, String?, Bool) -> Void)
+        /// Editing an existing category. Callback receives the (possibly unchanged) values.
+        case edit(Category, onSave: (String, String, Bool) -> Void)
+    }
+
+    // MARK: - Properties
+
+    let mode: Mode
+
+    @State private var name: String
+    /// Nil in add-mode until the user explicitly picks an icon.
+    @State private var pickedIconName: String?
+    @State private var isRecurring: Bool
+    @State private var autoArchive: AutoArchiveOption = .off
+    @State private var autoArchiveCustomDays: Int = 7
+    @State private var autoArchiveCustomText: String = "7"
+
+    @State private var showingIconPicker = false
+    @FocusState private var isNameFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Init
+
+    init(mode: Mode) {
+        self.mode = mode
+        switch mode {
+        case .add:
+            _name = State(initialValue: "")
+            _pickedIconName = State(initialValue: nil)
+            _isRecurring = State(initialValue: false)
+        case .edit(let category, _):
+            _name = State(initialValue: category.displayName)
+            _pickedIconName = State(initialValue: category.displayIconName)
+            _isRecurring = State(initialValue: category.isRecurring)
+        }
+    }
+
+    // MARK: - Computed
+
+    private var isAddMode: Bool {
+        if case .add = mode { return true }
+        return false
+    }
+
+    private var displayIconName: String {
+        pickedIconName ?? "tag"
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isValid: Bool {
+        !trimmedName.isEmpty && trimmedName.count <= CategoryService.maxNameLength
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                nameIconSection
+                recurringSection
+                autoArchiveSection
+            }
+            .navigationTitle(
+                isAddMode
+                    ? String(localized: "categoryEditor.title.add", defaultValue: "New Category")
+                    : String(localized: "categoryEditor.title.edit", defaultValue: "Edit Category")
+            )
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "quickadd.cancel", defaultValue: "Cancel")) {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(
+                        isAddMode
+                            ? String(localized: "categoryEditor.button.add", defaultValue: "Add")
+                            : String(localized: "categoryEditor.button.save", defaultValue: "Save")
+                    ) {
+                        submit()
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(!isValid)
+                }
+            }
+            .sheet(isPresented: $showingIconPicker) {
+                CategorySymbolPicker(currentSymbol: displayIconName) { newSymbol in
+                    pickedIconName = newSymbol
+                }
+            }
+            .onAppear {
+                DispatchQueue.main.async {
+                    isNameFocused = true
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var nameIconSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                Button {
+                    HapticFeedback.light()
+                    showingIconPicker = true
+                } label: {
+                    Image(systemName: displayIconName)
+                        .font(.title3)
+                        .frame(width: 36, height: 36)
+                        .foregroundStyle(Color.accentColor)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(Color.accentColor.opacity(0.15))
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    String(localized: "categoryEditor.iconButton.accessibility", defaultValue: "Choose icon")
+                )
+
+                TextField(
+                    String(localized: "categoryEditor.namePlaceholder", defaultValue: "Category name"),
+                    text: $name
+                )
+                .font(.headline)
+                .textInputAutocapitalization(.sentences)
+                .focused($isNameFocused)
+                .submitLabel(.done)
+                .onSubmit { if isValid { submit() } }
+            }
+        }
+    }
+
+    private var recurringSection: some View {
+        Section {
+            Toggle(
+                String(localized: "categoryEditor.recurring.title", defaultValue: "Recurring tasks"),
+                isOn: $isRecurring
+            )
+        } footer: {
+            Text(
+                String(
+                    localized: "categoryEditor.recurring.footer",
+                    defaultValue: "Tasks reappear in the backlog right after you complete or archive them."
+                )
+            )
+        }
+    }
+
+    private var autoArchiveSection: some View {
+        Section {
+            Picker(
+                String(localized: "categoryEditor.autoArchive.after", defaultValue: "After"),
+                selection: $autoArchive
+            ) {
+                Text(String(localized: "categoryEditor.autoArchive.option.off", defaultValue: "Off"))
+                    .tag(AutoArchiveOption.off)
+                Text(daysLabel(3)).tag(AutoArchiveOption.days3)
+                Text(daysLabel(7)).tag(AutoArchiveOption.days7)
+                Text(daysLabel(14)).tag(AutoArchiveOption.days14)
+                Text(daysLabel(30)).tag(AutoArchiveOption.days30)
+                Text(daysLabel(365)).tag(AutoArchiveOption.days365)
+                Text(
+                    String(localized: "categoryEditor.autoArchive.option.custom", defaultValue: "Custom…")
+                ).tag(AutoArchiveOption.custom)
+            }
+            .pickerStyle(.menu)
+
+            if autoArchive == .custom {
+                HStack {
+                    TextField("", text: $autoArchiveCustomText)
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: .infinity)
+                        .onChange(of: autoArchiveCustomText) { _, newValue in
+                            let digits = newValue.filter(\.isNumber)
+                            let clamped = min(max(Int(digits) ?? 1, 1), 365)
+                            autoArchiveCustomDays = clamped
+                            autoArchiveCustomText = digits.isEmpty ? "" : "\(clamped)"
+                        }
+                    Text(String(localized: "categoryEditor.autoArchive.daysUnit", defaultValue: "days"))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text(String(localized: "categoryEditor.autoArchive.section", defaultValue: "Auto-archive from backlog"))
+        } footer: {
+            if isRecurring {
+                Text(
+                    String(
+                        localized: "categoryEditor.autoArchive.disabledFooter",
+                        defaultValue: "Recurring categories never archive — tasks always return to the backlog."
+                    )
+                )
+            }
+        }
+        .disabled(isRecurring)
+    }
+
+    // MARK: - Actions
+
+    private func submit() {
+        guard isValid else {
+            HapticFeedback.error()
+            return
+        }
+        switch mode {
+        case .add(let onCreate):
+            onCreate(trimmedName, pickedIconName, isRecurring)
+        case .edit(_, let onSave):
+            onSave(trimmedName, displayIconName, isRecurring)
+        }
+        dismiss()
+    }
+
+    private func daysLabel(_ days: Int) -> String {
+        let fmt = String(localized: "categoryEditor.autoArchive.daysFormat", defaultValue: "%d days")
+        return String(format: fmt, days)
+    }
+}
+
+// MARK: - AutoArchiveOption
+
+private enum AutoArchiveOption: Hashable {
+    case off, days3, days7, days14, days30, days365, custom
+}
+
+// MARK: - Preview
+
+#Preview("Add") {
+    CategoryEditorView(mode: .add { name, icon, recurring in
+        print("Add: \(name), icon: \(icon ?? "default"), recurring: \(recurring)")
+    })
+}
+
+#Preview("Edit") {
+    CategoryEditorView(mode: .edit(
+        Category(
+            categoryType: .custom,
+            name: "Work",
+            iconName: "briefcase.fill",
+            isNameCustomized: true,
+            isIconCustomized: true
+        )
+    ) { name, icon, recurring in
+        print("Save: \(name), icon: \(icon), recurring: \(recurring)")
+    })
+}

--- a/App/Sources/Views/Components/CategoryHeaderView.swift
+++ b/App/Sources/Views/Components/CategoryHeaderView.swift
@@ -15,17 +15,8 @@ struct CategoryHeaderView: View {
     let category: Category
     let taskCount: Int
     let isExpanded: Bool
-    let isEditingName: Bool
-    /// True, solange BacklogView den Symbol-Picker als Sheet präsentiert.
-    /// Wird genutzt, um beim temporären Fokusverlust des TextFields nicht
-    /// fälschlich den Inline-Rename zu committen oder abzubrechen.
-    let isIconPickerOpen: Bool
     let onToggle: () -> Void
     let onLongPress: () -> Void
-    let onCommitRename: (String) -> Void
-    let onCancelRename: () -> Void
-    /// Wird aufgerufen, wenn der User im Edit-Modus auf das Icon tippt.
-    let onIconTap: () -> Void
 
     /// Mindestdauer für den Long-Press, der das Aktionsmenü öffnet.
     /// Gleich der Default-Dauer eines `.contextMenu`, damit es sich nativ anfühlt.
@@ -34,32 +25,24 @@ struct CategoryHeaderView: View {
     var body: some View {
         // Kein `Button`: sonst blockiert die Interaktion oft SwiftUI-`dropDestination` auf dem Header (Cross-Category-Drag).
         HStack(spacing: 8) {
-            iconView
+            Image(systemName: category.displayIconName)
+                .foregroundColor(.secondary)
+                .frame(width: 18)
 
-            if isEditingName {
-                InlineCategoryNameField(
-                    initialName: category.displayName,
-                    maxLength: CategoryService.maxNameLength,
-                    isIconPickerOpen: isIconPickerOpen,
-                    onCommit: onCommitRename,
-                    onCancel: onCancelRename
-                )
-            } else {
-                HStack(spacing: 6) {
-                    Text(category.displayName)
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                    if category.isRecurring {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                            .accessibilityLabel(
-                                String(
-                                    localized: "task.recurring.badge",
-                                    defaultValue: "Recurring"
-                                )
+            HStack(spacing: 6) {
+                Text(category.displayName)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                if category.isRecurring {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .accessibilityLabel(
+                            String(
+                                localized: "task.recurring.badge",
+                                defaultValue: "Recurring"
                             )
-                    }
+                        )
                 }
             }
 
@@ -73,20 +56,16 @@ struct CategoryHeaderView: View {
                     .padding(.vertical, 2)
                     .background(Color.secondary.opacity(0.2))
                     .clipShape(Capsule())
-                    .opacity(isEditingName ? 0.5 : 1.0)
             }
 
-            if !isEditingName {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .animation(.easeInOut(duration: 0.2), value: isExpanded)
-            }
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .animation(.easeInOut(duration: 0.2), value: isExpanded)
         }
         .contentShape(Rectangle())
         .modifier(
             CategoryHeaderGesture(
-                isEditingName: isEditingName,
                 hasEditCapability: category.hasAnyEditCapability,
                 onTap: onToggle,
                 onLongPress: {
@@ -95,156 +74,6 @@ struct CategoryHeaderView: View {
                 }
             )
         )
-    }
-
-    /// Im Anzeige-Modus dezent (sekundärfarben). Im Edit-Modus zur tappbaren
-    /// Schaltfläche aufgewertet (Akzentfarbe + Hintergrund), damit klar wird:
-    /// hier kann der User das Symbol antippen, um den Picker zu öffnen.
-    @ViewBuilder
-    private var iconView: some View {
-        if isEditingName && category.canChangeIcon {
-            Button {
-                HapticFeedback.light()
-                onIconTap()
-            } label: {
-                Image(systemName: category.displayIconName)
-                    .font(.subheadline)
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: 32, height: 32)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(Color.accentColor.opacity(0.15))
-                    )
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(
-                String(
-                    localized: "category.action.changeIcon",
-                    defaultValue: "Change symbol"
-                )
-            )
-        } else {
-            Image(systemName: category.displayIconName)
-                .foregroundColor(.secondary)
-                .frame(width: 18)
-                .opacity(isEditingName ? 0.5 : 1.0)
-        }
-    }
-}
-
-// MARK: - Inline Name Field
-
-/// Eigenständige Sub-View für das Inline-Rename-TextField.
-///
-/// Wichtiger Punkt: `@State private var draft` wird im `init` aus `initialName`
-/// initialisiert. Dadurch zeigt das Feld vom ersten Frame an den aktuellen
-/// Kategorienamen (statt eines grauen Placeholder-Texts oder eines kurzen
-/// Flackerns mit leerem Inhalt). Die Sub-View wird beim Eintritt in den
-/// Edit-Modus frisch erstellt, daher greift der Initialwert zuverlässig.
-private struct InlineCategoryNameField: View {
-    let initialName: String
-    let maxLength: Int
-    let isIconPickerOpen: Bool
-    let onCommit: (String) -> Void
-    let onCancel: () -> Void
-
-    @State private var draft: String
-    @FocusState private var isFocused: Bool
-
-    init(
-        initialName: String,
-        maxLength: Int,
-        isIconPickerOpen: Bool,
-        onCommit: @escaping (String) -> Void,
-        onCancel: @escaping () -> Void
-    ) {
-        self.initialName = initialName
-        self.maxLength = maxLength
-        self.isIconPickerOpen = isIconPickerOpen
-        self.onCommit = onCommit
-        self.onCancel = onCancel
-        _draft = State(initialValue: initialName)
-    }
-
-    private var trimmed: String {
-        draft.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var isValid: Bool {
-        !trimmed.isEmpty && trimmed.count <= maxLength
-    }
-
-    var body: some View {
-        HStack(spacing: 8) {
-            // Bewusst leerer Placeholder: der Initialwert von `draft` ist
-            // immer der aktuelle Kategoriename, sodass kein Placeholder
-            // sichtbar wird. Falls der User den Text komplett löscht, bleibt
-            // das Feld leer (Done-Button wird dann disabled).
-            TextField("", text: $draft)
-                .font(.headline)
-                .foregroundColor(.primary)
-                .textInputAutocapitalization(.sentences)
-                .autocorrectionDisabled(false)
-                .submitLabel(.done)
-                .focused($isFocused)
-                .onSubmit { submit() }
-
-            Button {
-                submit()
-            } label: {
-                Text(String(localized: "common.done", defaultValue: "Done"))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(isValid ? Color.accentColor : Color.secondary)
-            }
-            .buttonStyle(.borderless)
-            .disabled(!isValid)
-            .accessibilityLabel(String(localized: "common.done", defaultValue: "Done"))
-        }
-        .onAppear {
-            HapticFeedback.light()
-            // Async setzen, damit das TextField bereits gemountet ist und der
-            // Fokus die Tastatur zuverlässig öffnet.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                isFocused = true
-            }
-        }
-        .onChange(of: isFocused) { wasFocused, isNowFocused in
-            // Wenn der User den Fokus verliert, weil der Symbol-Picker als
-            // Sheet kommt, NICHT committen. Der Edit-Modus bleibt aktiv und
-            // wir refokussieren das Feld, sobald der Picker wieder geschlossen
-            // ist.
-            if isIconPickerOpen { return }
-            // Wenn der User ausserhalb tippt: bei gültigem Namen committen,
-            // sonst Edit abbrechen ohne Speichern.
-            guard wasFocused, !isNowFocused else { return }
-            if isValid {
-                submit()
-            } else {
-                onCancel()
-            }
-        }
-        .onChange(of: isIconPickerOpen) { wasOpen, isOpen in
-            // Picker hat sich geschlossen → Tastatur wieder einblenden, damit
-            // der User direkt am Namen weiterarbeiten kann.
-            if wasOpen && !isOpen {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                    isFocused = true
-                }
-            }
-        }
-    }
-
-    private func submit() {
-        guard isValid else {
-            HapticFeedback.error()
-            return
-        }
-        // Wenn sich nichts geändert hat: still beenden, kein Save-Roundtrip.
-        if trimmed == initialName {
-            onCancel()
-            return
-        }
-        onCommit(trimmed)
     }
 }
 
@@ -255,19 +84,13 @@ private struct InlineCategoryNameField: View {
 /// Hit-Testing der List). Wir nutzen stattdessen `.exclusively(before:)` mit
 /// einem expliziten `LongPressGesture`. So sind beide Gesten klar voneinander
 /// abgegrenzt: kurzer Tap → toggle, ≥ 0.45s halten → Aktionsmenü.
-///
-/// Während des Inline-Renames wird die Geste komplett deaktiviert, damit das
-/// `TextField` Taps exklusiv erhält.
 private struct CategoryHeaderGesture: ViewModifier {
-    let isEditingName: Bool
     let hasEditCapability: Bool
     let onTap: () -> Void
     let onLongPress: () -> Void
 
     func body(content: Content) -> some View {
-        if isEditingName {
-            content
-        } else if hasEditCapability {
+        if hasEditCapability {
             content.gesture(
                 LongPressGesture(minimumDuration: CategoryHeaderView.longPressDuration)
                     .onEnded { _ in onLongPress() }


### PR DESCRIPTION
## Summary

Replaces the fragmented inline category editing UX (inline text field in `AddCategoryRow`, `InlineCategoryNameField` in `CategoryHeaderView`, separate icon picker sheet) with a single modal `CategoryEditorView` sheet used for both creating and editing categories.

- **New `CategoryEditorView`**: `NavigationStack + Form` with `.add`/`.edit` modes. Covers name, icon (via `CategorySymbolPicker` sub-sheet), recurring toggle, and an auto-archive placeholder (Off / 3 / 7 / 14 / 30 / 365 days / Custom with a 1–365 text input). Auto-archive values are UI-only — no schema change.
- **`BacklogView`**: `editingCategoryID` and `iconPickerCategory` state replaced by a single `editorTarget: CategoryEditorTarget?` driving `.sheet(item:)`.
- **`AddCategoryRow`**: Reduced to a ghost row firing `onTap`.
- **`CategoryHeaderView`**: All inline-edit parameters removed; only `onLongPress` remains.
- **`CategoryActionMenu`**: `onToggleRecurring` removed — recurring is now set exclusively inside the editor. Edit button visible for any category where `hasAnyEditCapability == true`.
- **`Localizable.xcstrings`**: New `categoryEditor.*` namespace, all keys in en + de.

## Test plan

- [ ] Tap "+ Neue Kategorie" → sheet opens, name field auto-focused, Add button disabled
- [ ] Type a name → Add enabled; tap icon button → symbol picker opens as sub-sheet; pick symbol → returns to editor with new icon
- [ ] Enable Recurring → Auto-archive section grays out with footer explanation
- [ ] Disable Recurring, set Auto-archive to "Eigene…" → text field appears; type a value; verify clamped to 1–365
- [ ] Add → category appears in backlog with correct icon, expanded
- [ ] Long-press an editable category → "Wiederkehrend" entry is gone; tap Edit → sheet opens with current values pre-filled
- [ ] Change name / icon / recurring → Save → changes reflected immediately
- [ ] Long-press "Unkategorisiert" → Edit not shown (`hasAnyEditCapability == false`)
- [ ] DE locale: all strings translated, footer texts readable
- [ ] `xcodebuild test` passes