### PR TITLE
feat: Auto-Tidy — backlog tasks auto-archive after configurable per-category lifespan

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -1460,20 +1460,38 @@
         }
       }
     },
-    "categoryEditor.autoArchive.section": {
-      "comment": "CategoryEditor · Section header for auto-archive setting · Noun phrase.",
+    "categoryEditor.autoArchive.enabledFooter": {
+      "comment": "CategoryEditor · Footer below auto-archive section when auto-tidy is active · Two-sentence explanation.",
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aus Backlog automatisch archivieren"
+            "value": "Nach so vielen Tagen im Backlog wandern Aufgaben ins Archiv. Der Zähler startet jedes Mal neu, wenn du eine Aufgabe in Heute ziehst."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auto-archive from backlog"
+            "value": "After this many days in the backlog, tasks move to the Archive. The countdown resets every time you pull a task into Today."
+          }
+        }
+      }
+    },
+    "categoryEditor.autoArchive.section": {
+      "comment": "CategoryEditor · Section header for auto-tidy setting · Feature name, short noun phrase.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufräumen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Tidy"
           }
         }
       }
@@ -5596,6 +5614,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "You can use Siri with Dawny — for example:\n\n“New task in Dawny”\n“Add task to today in Dawny”\n\nMore commands and Shortcuts are available."
+          }
+        }
+      }
+    },
+    "welcome.autoTidy.body": {
+      "comment": "Welcome · Onboarding Auto-Tidy page body · Two sentences explaining backlog aging and timer reset.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgaben, die zu lange im Backlog liegen, räumt Dawny still ins Archiv. Du entscheidest pro Kategorie, wie lange sie bleiben dürfen — und der Zähler startet jedes Mal neu, wenn du eine Aufgabe in Heute ziehst."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasks that sit in your backlog for too long quietly move to the Archive. You decide how long each category should hold on — and the timer resets every time you pull a task into Today."
+          }
+        }
+      }
+    },
+    "welcome.autoTidy.title": {
+      "comment": "Welcome · Onboarding Auto-Tidy page title · Short, calming headline.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Backlog bleibt leicht"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your backlog stays light"
           }
         }
       }

--- a/App/Sources/Models/Category.swift
+++ b/App/Sources/Models/Category.swift
@@ -42,9 +42,13 @@ final class Category {
     /// Solange `false`, wird `categoryType.iconName` als Default verwendet.
     var isIconCustomized: Bool = false
 
-    /// Wenn true, verhalten sich Tasks in dieser Kategorie „wiederkehrend“
+    /// Wenn true, verhalten sich Tasks in dieser Kategorie „wiederkehrend”
     /// (siehe Heute-Backlog-Clone-Logik).
     var isRecurring: Bool = false
+
+    /// Auto-Tidy: Anzahl Tage im Backlog, nach denen Tasks automatisch archiviert werden.
+    /// nil = deaktiviert. Recurring-Kategorien ignorieren diesen Wert.
+    var autoArchiveDays: Int? = nil
 
     /// Erstellungsdatum
     var createdAt: Date
@@ -67,6 +71,7 @@ final class Category {
         isNameCustomized: Bool = false,
         isIconCustomized: Bool = false,
         isRecurring: Bool = false,
+        autoArchiveDays: Int? = nil,
         createdAt: Date = Date(),
         tasks: [Task] = []
     ) {
@@ -79,6 +84,7 @@ final class Category {
         self.isNameCustomized = isNameCustomized
         self.isIconCustomized = isIconCustomized
         self.isRecurring = isRecurring
+        self.autoArchiveDays = autoArchiveDays
         self.createdAt = createdAt
         self.tasks = tasks
     }

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -64,6 +64,10 @@ final class Task {
     /// Zeitpunkt der manuellen Erledigung (nil wenn nicht oder noch nicht erledigt)
     var completedAt: Date? = nil
 
+    /// Auto-Tidy: Zeitpunkt, seit dem der Task ununterbrochen im Backlog liegt.
+    /// Wird beim Eingang ins Backlog gesetzt und beim Verschieben in Daily/Scheduled/Archive genillt.
+    var enteredBacklogAt: Date? = nil
+
     // MARK: - Relationships
     
     /// Referenz zum Parent-Backlog
@@ -102,6 +106,7 @@ final class Task {
         self.isCompleted = isCompleted
         self.recurringCloneID = recurringCloneID
         self.category = category
+        self.enteredBacklogAt = (status == .inBacklog) ? Date() : nil
     }
     
     // MARK: - Computed Properties
@@ -150,14 +155,16 @@ final class Task {
         scheduledDate = nil
         sortPriority = Date() // Move to top
         modifiedAt = Date()
+        enteredBacklogAt = Date()
     }
 
-    /// Archiviert den Task nach wiederholtem Nicht-Erledigen (Make it count).
+    /// Archiviert den Task nach wiederholtem Nicht-Erledigen (Make it count) oder Auto-Tidy.
     func archive() {
         status = .archived
         archivedAt = Date()
         scheduledDate = nil
         modifiedAt = Date()
+        enteredBacklogAt = nil
     }
 
     /// Unarchiviert den Task zurück ins Backlog. Setzt resetCount auf 0.
@@ -167,6 +174,7 @@ final class Task {
         resetCount = 0
         sortPriority = Date()
         modifiedAt = Date()
+        enteredBacklogAt = Date()
     }
 
     /// Unarchiviert den Task direkt in den Daily Focus. Setzt resetCount auf 0.
@@ -176,20 +184,23 @@ final class Task {
         archivedAt = nil
         resetCount = 0
         modifiedAt = Date()
+        enteredBacklogAt = nil
     }
-    
+
     /// Verschiebt den Task in Daily Focus
     func moveToDailyFocus(date: Date) {
         status = .dailyFocus
         scheduledDate = date
         modifiedAt = Date()
+        enteredBacklogAt = nil
     }
-    
-    /// Plant den Task für ein zukünftiges Datum
+
+    /// Plant den Task für ein zukünftiges Datum (nur via SyncEngine, keine User-UI)
     func scheduleFor(date: Date) {
         status = .scheduled
         scheduledDate = date
         modifiedAt = Date()
+        enteredBacklogAt = nil
     }
     
     /// Entfernt die Kalender-Verknüpfung

--- a/App/Sources/Models/TaskCategory.swift
+++ b/App/Sources/Models/TaskCategory.swift
@@ -144,6 +144,20 @@ enum TaskCategory: String, Codable, CaseIterable {
         }
     }
     
+    /// Auto-Tidy: Standard-Wert für `autoArchiveDays` pro Kategorie-Typ.
+    /// nil = nie automatisch archivieren.
+    var defaultAutoArchiveDays: Int? {
+        switch self {
+        case .quick: 7
+        case .nextFewDays: 21
+        case .nextFewWeeks: 60
+        case .nextFewMonths: 365
+        case .someday: nil
+        case .uncategorized: 365
+        case .custom: 365
+        }
+    }
+
     /// Standard-Reihenfolge-Index (für initiale Sortierung)
     var defaultOrderIndex: Int {
         switch self {

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -72,7 +72,7 @@ final class CategoryService {
     }
     
     /// Initialisiert die Standard-Kategorien beim ersten App-Start und
-    /// legt bei Bedarf die Standard-„Wiederkehrende Aufgaben“-Kategorie an (Idempotent / Migration).
+    /// legt bei Bedarf die Standard-„Wiederkehrende Aufgaben"-Kategorie an (Idempotent / Migration).
     func initializeDefaultCategories() {
         let descriptor = FetchDescriptor<Category>()
         do {
@@ -84,13 +84,17 @@ final class CategoryService {
                     let category = Category(
                         categoryType: categoryType,
                         orderIndex: categoryType.defaultOrderIndex,
-                        isUncategorized: categoryType == .uncategorized
+                        isUncategorized: categoryType == .uncategorized,
+                        autoArchiveDays: categoryType.defaultAutoArchiveDays
                     )
                     modelContext.insert(category)
                 }
                 try modelContext.save()
                 allCategories = try modelContext.fetch(descriptor)
             }
+
+            try migrateAutoArchiveDefaultsIfNeeded(allCategories: allCategories)
+            try migrateEnteredBacklogAtIfNeeded()
 
             if !allCategories.contains(where: { $0.isRecurring }) {
                 let defaultName = String(
@@ -189,7 +193,7 @@ final class CategoryService {
     private static let recurringOrderMigratedKey = "DawnyMigratedRecurringDefaultBeforeUncategorizedV1"
     private static let recurringOrderBeforeSomedayMigratedKey = "DawnyMigratedRecurringDefaultBeforeSomedayV2"
 
-    /// Einmal: Standard-„Wiederkehrende Aufgaben“ (falls noch unter Unkategorisiert) vorschieben. Danach bleibt die manuelle Sortierung.
+    /// Einmal: Standard-„Wiederkehrende Aufgaben" (falls noch unter Unkategorisiert) vorschieben. Danach bleibt die manuelle Sortierung.
     private func repositionDefaultRecurringBeforeUncategorizedIfNeeded() throws {
         guard !UserDefaults.standard.bool(forKey: Self.recurringOrderMigratedKey) else { return }
         defer { UserDefaults.standard.set(true, forKey: Self.recurringOrderMigratedKey) }
@@ -216,7 +220,7 @@ final class CategoryService {
         rec.orderIndex = target
     }
 
-    /// Einmal: Standard-„Wiederkehrende Aufgaben“ direkt vor „Someday“ schieben.
+    /// Einmal: Standard-„Wiederkehrende Aufgaben" direkt vor „Someday" schieben.
     private func repositionDefaultRecurringBeforeSomedayIfNeeded() throws {
         guard !UserDefaults.standard.bool(forKey: Self.recurringOrderBeforeSomedayMigratedKey) else { return }
         defer { UserDefaults.standard.set(true, forKey: Self.recurringOrderBeforeSomedayMigratedKey) }
@@ -279,9 +283,10 @@ final class CategoryService {
         }
     }
     
-    /// Legt eine neue benutzerdefinierte Kategorie an (erscheint nach bestehenden Einträgen, typisch unter „Unkategorisiert“).
+    /// Legt eine neue benutzerdefinierte Kategorie an (erscheint nach bestehenden Einträgen, typisch unter „Unkategorisiert").
     /// - Parameter isRecurring: Wenn `true`, passendes Default-Symbol und `isRecurring` auf dem Modell.
-    func createCustom(name: String, isRecurring: Bool = false) throws -> Category {
+    /// - Parameter autoArchiveDays: Auto-Tidy-Schwellenwert. Wird bei `isRecurring == true` ignoriert (nil).
+    func createCustom(name: String, isRecurring: Bool = false, autoArchiveDays: Int? = 365) throws -> Category {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw CategoryEditError.nameEmpty
@@ -303,20 +308,33 @@ final class CategoryService {
             isUncategorized: false,
             isNameCustomized: true,
             isIconCustomized: true,
-            isRecurring: isRecurring
+            isRecurring: isRecurring,
+            autoArchiveDays: isRecurring ? nil : autoArchiveDays
         )
         modelContext.insert(category)
         try save()
         return category
     }
 
-    /// Setzt die Eigenschaft „wiederkehrend“ auf einer Kategorie.
+    /// Setzt die Eigenschaft „wiederkehrend" auf einer Kategorie.
+    /// Setzt bei Aktivierung gleichzeitig `autoArchiveDays = nil` (Recurring-Invariante).
     func setRecurring(_ category: Category, to newValue: Bool) throws {
         guard category.canToggleRecurring else {
             throw CategoryEditError.protectedFromRecurring
         }
         if category.isRecurring == newValue { return }
         category.isRecurring = newValue
+        if newValue { category.autoArchiveDays = nil }
+        try save()
+    }
+
+    /// Setzt den Auto-Tidy-Schwellenwert (Tage im Backlog bis zur Archivierung).
+    /// Recurring-Kategorien dürfen keinen Wert != nil erhalten.
+    func setAutoArchiveDays(_ category: Category, to days: Int?) throws {
+        if category.isRecurring && days != nil {
+            throw CategoryEditError.protectedFromRecurring
+        }
+        category.autoArchiveDays = days
         try save()
     }
 
@@ -426,6 +444,40 @@ final class CategoryService {
 
         modelContext.delete(category)
         try save()
+    }
+
+    // MARK: - Auto-Tidy Migrations
+
+    private static let autoArchiveDefaultsMigratedKey = "DawnyMigratedAutoArchiveDefaultsV1"
+    private static let enteredBacklogAtMigratedKey = "DawnyBackfilledEnteredBacklogAtV1"
+
+    /// Einmal: bestehende Standard-Kategorien mit `defaultAutoArchiveDays` befüllen.
+    private func migrateAutoArchiveDefaultsIfNeeded(allCategories: [Category]) throws {
+        guard !UserDefaults.standard.bool(forKey: Self.autoArchiveDefaultsMigratedKey) else { return }
+        defer { UserDefaults.standard.set(true, forKey: Self.autoArchiveDefaultsMigratedKey) }
+
+        for category in allCategories {
+            if category.isRecurring {
+                category.autoArchiveDays = nil
+                continue
+            }
+            guard category.autoArchiveDays == nil else { continue }
+            category.autoArchiveDays = category.categoryType.defaultAutoArchiveDays
+        }
+        try modelContext.save()
+    }
+
+    /// Einmal: bestehende Backlog-Tasks mit `enteredBacklogAt = Date()` befüllen (sanfter Start).
+    private func migrateEnteredBacklogAtIfNeeded() throws {
+        guard !UserDefaults.standard.bool(forKey: Self.enteredBacklogAtMigratedKey) else { return }
+        defer { UserDefaults.standard.set(true, forKey: Self.enteredBacklogAtMigratedKey) }
+
+        let all = try modelContext.fetch(FetchDescriptor<Task>())
+        let now = Date()
+        for task in all where task.status == .inBacklog && task.enteredBacklogAt == nil {
+            task.enteredBacklogAt = now
+        }
+        try modelContext.save()
     }
 
     // MARK: - Private Helpers

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -61,21 +61,28 @@ final class ResetEngine {
     /// Führt den Reset durch (hauptsächlich für Tests und manuellen Aufruf)
     func performReset(referenceDate: Date = Date()) async {
         print("🔄 Performing Reset at \(referenceDate)")
-        
+
+        // Auto-Tidy: abgelaufene Backlog-Tasks zuerst archivieren
+        let staleCount = archiveStaleBacklogTasks(referenceDate: referenceDate)
+        var hasArchivedAnyTask = staleCount > 0
+        if staleCount > 0 {
+            print("🧹 Auto-Tidy archived \(staleCount) stale backlog task(s)")
+        }
+
         // Fetch alle Tasks die resettet werden müssen
         let tasksToReset = fetchTasksNeedingReset()
-        
+
         guard !tasksToReset.isEmpty else {
             print("✅ No tasks need reset")
+            if hasArchivedAnyTask { AppSettings.shared.hasNewArchivedTasks = true }
             saveLastResetDate(referenceDate)
             return
         }
-        
+
         print("📋 Resetting \(tasksToReset.count) task(s)")
 
         let threshold = AppSettings.shared.makeItCountThreshold
-        var hasArchivedAnyTask = false
-        
+
         // Reset jeden Task
         for (index, task) in tasksToReset.enumerated() {
             // Entferne aus Kalender falls synchronisiert
@@ -186,6 +193,32 @@ final class ResetEngine {
         return resetToday
     }
     
+    /// Auto-Tidy: Archiviert Backlog-Tasks, die die Lebensdauer ihrer Kategorie überschritten haben.
+    /// Gibt die Anzahl archivierter Tasks zurück.
+    private func archiveStaleBacklogTasks(referenceDate: Date) -> Int {
+        let descriptor = FetchDescriptor<Task>()
+        guard let all = try? modelContext.fetch(descriptor) else { return 0 }
+        var count = 0
+        for task in all {
+            guard
+                task.status == .inBacklog,
+                !task.isCompleted,
+                let category = task.category,
+                category.isRecurring == false,
+                let days = category.autoArchiveDays,
+                let enteredAt = task.enteredBacklogAt
+            else { continue }
+            let cutoff = timeProvider.calendar.date(
+                byAdding: .day, value: days, to: enteredAt
+            ) ?? enteredAt
+            if cutoff <= referenceDate {
+                task.archive()
+                count += 1
+            }
+        }
+        return count
+    }
+
     /// Holt alle Tasks die resettet werden müssen
     private func fetchTasksNeedingReset() -> [Task] {
         let descriptor = FetchDescriptor<Task>(

--- a/App/Sources/ViewModels/ArchiveViewModel.swift
+++ b/App/Sources/ViewModels/ArchiveViewModel.swift
@@ -103,6 +103,7 @@ final class ArchiveViewModel {
         task.status = .inBacklog
         task.sortPriority = Date()
         task.modifiedAt = Date()
+        task.enteredBacklogAt = Date()
         ensureCategoryExists(for: task)
         saveAndReload()
     }
@@ -120,6 +121,7 @@ final class ArchiveViewModel {
         task.status = .dailyFocus
         task.scheduledDate = Date()
         task.modifiedAt = Date()
+        task.enteredBacklogAt = nil
         ensureCategoryExists(for: task)
         saveAndReload()
     }

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -545,9 +545,9 @@ final class BacklogViewModel {
 
     /// Legt eine neue benutzerdefinierte Kategorie an.
     @discardableResult
-    func createCategory(name: String, isRecurring: Bool = false) -> Category? {
+    func createCategory(name: String, isRecurring: Bool = false, autoArchiveDays: Int? = 365) -> Category? {
         do {
-            let category = try categoryService.createCustom(name: name, isRecurring: isRecurring)
+            let category = try categoryService.createCustom(name: name, isRecurring: isRecurring, autoArchiveDays: autoArchiveDays)
             loadCategories()
             HapticFeedback.success()
             return category
@@ -557,6 +557,21 @@ final class BacklogViewModel {
         } catch {
             errorMessage = error.localizedDescription
             return nil
+        }
+    }
+
+    /// Setzt den Auto-Tidy-Schwellenwert einer Kategorie.
+    @discardableResult
+    func setAutoArchiveDays(_ category: Category, to days: Int?) -> Bool {
+        do {
+            try categoryService.setAutoArchiveDays(category, to: days)
+            return true
+        } catch let error as CategoryEditError {
+            errorMessage = error.errorDescription
+            return false
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -171,6 +171,7 @@ final class DailyFocusViewModel {
         task.completedAt = nil
         task.status = .dailyFocus
         task.modifiedAt = Date()
+        task.enteredBacklogAt = nil
 
         let needsCalendarSync = task.isSyncedToCalendar
 

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -54,14 +54,14 @@ struct BacklogView: View {
             .sheet(item: $editorTarget) { target in
                 switch target {
                 case .add:
-                    CategoryEditorView(mode: .add { name, icon, recurring in
-                        if let created = viewModel.createCategory(name: name, isRecurring: recurring) {
+                    CategoryEditorView(mode: .add { name, icon, recurring, days in
+                        if let created = viewModel.createCategory(name: name, isRecurring: recurring, autoArchiveDays: days) {
                             if let icon { _ = viewModel.updateCategoryIcon(created, to: icon) }
                             expandedCategories.insert(created.id)
                         }
                     })
                 case .edit(let category):
-                    CategoryEditorView(mode: .edit(category) { name, icon, recurring in
+                    CategoryEditorView(mode: .edit(category) { name, icon, recurring, days in
                         if name != category.displayName {
                             _ = viewModel.renameCategory(category, to: name)
                         }
@@ -70,6 +70,9 @@ struct BacklogView: View {
                         }
                         if recurring != category.isRecurring {
                             _ = viewModel.toggleRecurring(category)
+                        }
+                        if days != category.autoArchiveDays {
+                            _ = viewModel.setAutoArchiveDays(category, to: days)
                         }
                         HapticFeedback.success()
                     })

--- a/App/Sources/Views/Components/CategoryEditorView.swift
+++ b/App/Sources/Views/Components/CategoryEditorView.swift
@@ -16,10 +16,10 @@ struct CategoryEditorView: View {
     // MARK: - Mode
 
     enum Mode {
-        /// Creating a new category. Callback receives name, optional icon override, and recurring flag.
-        case add(onCreate: (String, String?, Bool) -> Void)
+        /// Creating a new category. Callback receives name, optional icon override, recurring flag, and auto-archive days.
+        case add(onCreate: (String, String?, Bool, Int?) -> Void)
         /// Editing an existing category. Callback receives the (possibly unchanged) values.
-        case edit(Category, onSave: (String, String, Bool) -> Void)
+        case edit(Category, onSave: (String, String, Bool, Int?) -> Void)
     }
 
     // MARK: - Properties
@@ -47,10 +47,17 @@ struct CategoryEditorView: View {
             _name = State(initialValue: "")
             _pickedIconName = State(initialValue: nil)
             _isRecurring = State(initialValue: false)
+            _autoArchive = State(initialValue: .days365)
+            _autoArchiveCustomDays = State(initialValue: 365)
+            _autoArchiveCustomText = State(initialValue: "365")
         case .edit(let category, _):
             _name = State(initialValue: category.displayName)
             _pickedIconName = State(initialValue: category.displayIconName)
             _isRecurring = State(initialValue: category.isRecurring)
+            let (option, customDays) = AutoArchiveOption.from(days: category.autoArchiveDays)
+            _autoArchive = State(initialValue: option)
+            _autoArchiveCustomDays = State(initialValue: customDays)
+            _autoArchiveCustomText = State(initialValue: "\(customDays)")
         }
     }
 
@@ -71,6 +78,10 @@ struct CategoryEditorView: View {
 
     private var isValid: Bool {
         !trimmedName.isEmpty && trimmedName.count <= CategoryService.maxNameLength
+    }
+
+    private var selectedAutoArchiveDays: Int? {
+        isRecurring ? nil : autoArchive.days(customDays: autoArchiveCustomDays)
     }
 
     // MARK: - Body
@@ -115,6 +126,9 @@ struct CategoryEditorView: View {
                 DispatchQueue.main.async {
                     isNameFocused = true
                 }
+            }
+            .onChange(of: isRecurring) { _, newValue in
+                if newValue { autoArchive = .off }
             }
         }
     }
@@ -179,10 +193,9 @@ struct CategoryEditorView: View {
             ) {
                 Text(String(localized: "categoryEditor.autoArchive.option.off", defaultValue: "Off"))
                     .tag(AutoArchiveOption.off)
-                Text(daysLabel(3)).tag(AutoArchiveOption.days3)
                 Text(daysLabel(7)).tag(AutoArchiveOption.days7)
-                Text(daysLabel(14)).tag(AutoArchiveOption.days14)
                 Text(daysLabel(30)).tag(AutoArchiveOption.days30)
+                Text(daysLabel(90)).tag(AutoArchiveOption.days90)
                 Text(daysLabel(365)).tag(AutoArchiveOption.days365)
                 Text(
                     String(localized: "categoryEditor.autoArchive.option.custom", defaultValue: "Custom…")
@@ -207,13 +220,20 @@ struct CategoryEditorView: View {
                 }
             }
         } header: {
-            Text(String(localized: "categoryEditor.autoArchive.section", defaultValue: "Auto-archive from backlog"))
+            Text(String(localized: "categoryEditor.autoArchive.section", defaultValue: "Auto-Tidy"))
         } footer: {
             if isRecurring {
                 Text(
                     String(
                         localized: "categoryEditor.autoArchive.disabledFooter",
                         defaultValue: "Recurring categories never archive — tasks always return to the backlog."
+                    )
+                )
+            } else if autoArchive != .off {
+                Text(
+                    String(
+                        localized: "categoryEditor.autoArchive.enabledFooter",
+                        defaultValue: "After this many days in the backlog, tasks move to the Archive. The countdown resets every time you pull a task into Today."
                     )
                 )
             }
@@ -230,9 +250,9 @@ struct CategoryEditorView: View {
         }
         switch mode {
         case .add(let onCreate):
-            onCreate(trimmedName, pickedIconName, isRecurring)
+            onCreate(trimmedName, pickedIconName, isRecurring, selectedAutoArchiveDays)
         case .edit(_, let onSave):
-            onSave(trimmedName, displayIconName, isRecurring)
+            onSave(trimmedName, displayIconName, isRecurring, selectedAutoArchiveDays)
         }
         dismiss()
     }
@@ -246,14 +266,38 @@ struct CategoryEditorView: View {
 // MARK: - AutoArchiveOption
 
 private enum AutoArchiveOption: Hashable {
-    case off, days3, days7, days14, days30, days365, custom
+    case off, days7, days30, days90, days365, custom
+
+    func days(customDays: Int) -> Int? {
+        switch self {
+        case .off: nil
+        case .days7: 7
+        case .days30: 30
+        case .days90: 90
+        case .days365: 365
+        case .custom: customDays
+        }
+    }
+
+    static func from(days: Int?) -> (AutoArchiveOption, Int) {
+        switch days {
+        case nil: return (.off, 7)
+        case 7: return (.days7, 7)
+        case 30: return (.days30, 30)
+        case 90: return (.days90, 90)
+        case 365: return (.days365, 365)
+        default:
+            let clamped = max(1, min(days ?? 7, 365))
+            return (.custom, clamped)
+        }
+    }
 }
 
 // MARK: - Preview
 
 #Preview("Add") {
-    CategoryEditorView(mode: .add { name, icon, recurring in
-        print("Add: \(name), icon: \(icon ?? "default"), recurring: \(recurring)")
+    CategoryEditorView(mode: .add { name, icon, recurring, days in
+        print("Add: \(name), icon: \(icon ?? "default"), recurring: \(recurring), days: \(String(describing: days))")
     })
 }
 
@@ -264,9 +308,10 @@ private enum AutoArchiveOption: Hashable {
             name: "Work",
             iconName: "briefcase.fill",
             isNameCustomized: true,
-            isIconCustomized: true
+            isIconCustomized: true,
+            autoArchiveDays: 21
         )
-    ) { name, icon, recurring in
-        print("Save: \(name), icon: \(icon), recurring: \(recurring)")
+    ) { name, icon, recurring, days in
+        print("Save: \(name), icon: \(icon), recurring: \(recurring), days: \(String(describing: days))")
     })
 }

--- a/App/Sources/Views/WelcomeView.swift
+++ b/App/Sources/Views/WelcomeView.swift
@@ -66,6 +66,18 @@ struct WelcomeView: View {
             )
         ),
         WelcomePage(
+            icon: "wind",
+            iconColor: .teal,
+            title: LocalizedStringResource(
+                "welcome.autoTidy.title",
+                defaultValue: "Your backlog stays light"
+            ),
+            body: LocalizedStringResource(
+                "welcome.autoTidy.body",
+                defaultValue: "Tasks that sit in your backlog for too long quietly move to the Archive. You decide how long each category should hold on — and the timer resets every time you pull a task into Today."
+            )
+        ),
+        WelcomePage(
             icon: "mic.fill",
             iconColor: .purple,
             title: LocalizedStringResource(
@@ -74,7 +86,7 @@ struct WelcomeView: View {
             ),
             body: LocalizedStringResource(
                 "welcome.siri.body",
-                defaultValue: "You can use Siri with Dawny — for example:\n\n“New task in Dawny”\n“Add task to today in Dawny”\n\nMore commands and Shortcuts are available."
+                defaultValue: "You can use Siri with Dawny — for example:\n\n\u{201C}New task in Dawny\u{201D}\n\u{201C}Add task to today in Dawny\u{201D}\n\nMore commands and Shortcuts are available."
             )
         ),
         WelcomePage(


### PR DESCRIPTION
## What

Introduces **Auto-Tidy**: backlog tasks that sit idle for too long are automatically moved to the Archive. The threshold is configurable per category (nil = never).

## Changes

### Schema
- `Category.autoArchiveDays: Int?` — per-category threshold (nil = off); lightweight SwiftData migration
- `Task.enteredBacklogAt: Date?` — tracks when a task last entered the backlog; reset on each backlog entry, cleared when pulled into Today

### Task lifecycle — single source of truth
All Task helper methods (`resetToBacklog`, `moveToDailyFocus`, `unarchiveToBacklog`, `unarchiveToDailyFocus`, `scheduleFor`, `archive`) now set `enteredBacklogAt` consistently. Direct-status-mutation call sites in `ArchiveViewModel` and `DailyFocusViewModel` patched separately.

### Defaults & seeding
New `TaskCategory.defaultAutoArchiveDays` computed property (Quick=7, NextFewDays=21, NextFewWeeks=60, NextFewMonths=365, Someday=nil, Uncategorized=365, Custom=365). `CategoryService.initializeDefaultCategories()` seeds with these values.

### One-shot migrations (UserDefaults-guarded)
- `DawnyMigratedAutoArchiveDefaultsV1`: back-fills `autoArchiveDays` on existing default categories
- `DawnyBackfilledEnteredBacklogAtV1`: sets `enteredBacklogAt = Date()` for existing inBacklog tasks (fresh-start, no mass-archive wave)

### Archive trigger
`ResetEngine.archiveStaleBacklogTasks(referenceDate:)` runs before the existing Make-it-Count loop on each nightly reset. Skips recurring categories (invariant preserved). Sets `hasArchivedAnyTask = true` when tasks are auto-tided, triggering the Archive badge.

### Recurring invariant
Protected at two levels: `CategoryEditorView` forces `autoArchiveDays = nil` on submit when recurring; `CategoryService.setRecurring(_:to:)` also forces nil (defense-in-depth).

### Editor wiring
`CategoryEditorView` mode callbacks extended to `(String, String?, Bool, Int?)`. Picker presets: Off / 7 / 30 / 90 / 365 / Custom. Default categories with 21 or 60 days show as "Custom" (accepted UX trade-off). Section renamed "Auto-Tidy" / "Aufräumen". Footer text explains countdown and reset.

### Welcome tile
New page inserted at index 4 (before Siri) with icon `wind`, color `.teal`, explaining the feature.

### Localization
All new strings added in both `en` and `de`.

## Notes
- No `VersionedSchema` required — both new fields are optional, SwiftData lightweight migration handles them automatically.
- The `fatalError` on schema mismatch in `DawnyApp.swift` will trigger on corrupt stores as before — not a regression.
- Backlog→Backlog category moves intentionally leave `enteredBacklogAt` unchanged (counter keeps running).