### PR TITLE
fix(blog): wrap post body in white card for readability

### DIFF
--- a/website/src/layouts/BlogPost.astro
+++ b/website/src/layouts/BlogPost.astro
@@ -33,15 +33,17 @@ const formattedDate = pubDate.toLocaleDateString(lang === "de" ? "de-DE" : "en-U
       <p class="blog-eyebrow">
         <a href={`/${lang}/blog/`} class="blog-back">{dict.blog.backToBlog}</a>
       </p>
-      <header class="blog-header">
-        <time datetime={pubDate.toISOString()} class="blog-date">
-          {dict.blog.publishedOn} {formattedDate}
-        </time>
-        <h1 class="blog-title">{title}</h1>
-        <p class="blog-description">{description}</p>
-      </header>
-      <div class="blog-prose">
-        <slot />
+      <div class="blog-card">
+        <header class="blog-header">
+          <time datetime={pubDate.toISOString()} class="blog-date">
+            {dict.blog.publishedOn} {formattedDate}
+          </time>
+          <h1 class="blog-title">{title}</h1>
+          <p class="blog-description">{description}</p>
+        </header>
+        <div class="blog-prose">
+          <slot />
+        </div>
       </div>
     </div>
   </article>
@@ -55,22 +57,33 @@ const formattedDate = pubDate.toLocaleDateString(lang === "de" ? "de-DE" : "en-U
     min-height: 80vh;
   }
 
+  .blog-article .container-narrow {
+    max-width: min(80%, 64rem);
+  }
+
   .blog-eyebrow {
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
     font-size: 0.85rem;
-    color: var(--color-ink-soft);
+    color: rgba(255, 255, 255, 0.75);
   }
 
   .blog-back {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    color: var(--color-ink-soft);
+    color: rgba(255, 255, 255, 0.75);
     transition: color 200ms;
   }
 
   .blog-back:hover {
-    color: var(--color-ink);
+    color: white;
+  }
+
+  .blog-card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    padding: clamp(1.75rem, 5vw, 3rem);
   }
 
   .blog-header {


### PR DESCRIPTION
## Summary

Individual blog post pages were nearly unreadable — the article text sat directly on a vertical gradient (`#0e1a2e → #1a2a3e → #8b5a2b → #f5f5f0`) and the soft-gray prose color vanished against the dark navy upper third.

This PR mirrors the card treatment already used on the blog **index** page and applies it to individual posts:

- Wrap `<header>` + `<slot />` in a `.blog-card` (white background, 12px radius, soft shadow, responsive padding via `clamp(1.75rem, 5vw, 3rem)`)
- Recolor `.blog-back` / `.blog-eyebrow` to `rgba(255, 255, 255, 0.75)` so the "← Blog" link is readable on the dark gradient
- Widen the article container to `min(80%, 64rem)` so the card is more prominent than the 42rem column used by short-form pages
- Bump `.blog-eyebrow` bottom margin from `2rem` → `2.5rem` for breathing room above the card

## Scope

Single file: [`website/src/layouts/BlogPost.astro`](../blob/website-fix/website/src/layouts/BlogPost.astro). Both `/en/blog/[slug]` and `/de/blog/[slug]` route through this layout, so one change covers both locales. The blog index, base layout, global styles, and post content are untouched.

## Test plan

- [ ] `cd website && npm run dev`
- [ ] Open `/en/blog/` — index unchanged
- [ ] Click into a post — header + body sit in a white card, gradient visible above and below
- [ ] "← Blog" back link is light and readable on the dark navy portion of the gradient
- [ ] Open a `/de/blog/<slug>/` post — same treatment
- [ ] Resize to ~375px width — card padding scales down via `clamp()`, no edge-touching