### PR TITLE
feat: Auto-Archive Review overlay after automated archiving

### DIFF
--- a/App/Sources/DawnyApp.swift
+++ b/App/Sources/DawnyApp.swift
@@ -37,7 +37,11 @@ struct DawnyApp: App {
         }
         
         // Initialize Services
+        #if DEBUG
+        timeProvider = DebugTimeProvider()
+        #else
         timeProvider = SystemTimeProvider()
+        #endif
         calendarService = EventKitCalendarService()
         resetEngine = ResetEngine(
             timeProvider: timeProvider,

--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -6019,6 +6019,204 @@
           }
         }
       }
+    },
+    "autoarchive.review.daily.title.hasItems": {
+      "comment": "Auto-Archive Review · Screen 1 · Headline when Daily tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeit für einen frischen Start"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Time for a fresh start"
+          }
+        }
+      }
+    },
+    "autoarchive.review.daily.subtitle.hasItems": {
+      "comment": "Auto-Archive Review · Screen 1 · Subtitle when Daily tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Aufgaben haben wir für dich im Archiv in Sicherheit gebracht, damit du heute ohne Altlasten loslegen kannst."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We've safely tucked these tasks away in the archive so you can start today free of clutter."
+          }
+        }
+      }
+    },
+    "autoarchive.review.daily.title.empty": {
+      "comment": "Auto-Archive Review · Screen 1 · Headline when no Daily tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles sauber"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All clean"
+          }
+        }
+      }
+    },
+    "autoarchive.review.daily.subtitle.empty": {
+      "comment": "Auto-Archive Review · Screen 1 · Subtitle when no Daily tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus deinem Daily musste nichts archiviert werden. Ein wunderbar leerer Tisch für heute."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing needed archiving from your Daily. A wonderfully clean slate for today."
+          }
+        }
+      }
+    },
+    "autoarchive.review.backlog.title.hasItems": {
+      "comment": "Auto-Archive Review · Screen 2 · Headline when Backlog tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backlog durchgeatmet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backlog breathed out"
+          }
+        }
+      }
+    },
+    "autoarchive.review.backlog.subtitle.hasItems": {
+      "comment": "Auto-Archive Review · Screen 2 · Subtitle when Backlog tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auch hier wurde automatisch Platz geschaffen. Folgende Items warten jetzt entspannt im Archiv auf dich."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Space has been made here too. These items are now resting in the archive."
+          }
+        }
+      }
+    },
+    "autoarchive.review.backlog.title.empty": {
+      "comment": "Auto-Archive Review · Screen 2 · Headline when no Backlog tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fokus bleibt bestehen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus stays put"
+          }
+        }
+      }
+    },
+    "autoarchive.review.backlog.subtitle.empty": {
+      "comment": "Auto-Archive Review · Screen 2 · Subtitle when no Backlog tasks were archived.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Backlog ist genau so geblieben, wie du es hinterlassen hast."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your backlog is exactly how you left it."
+          }
+        }
+      }
+    },
+    "autoarchive.review.cta.next": {
+      "comment": "Auto-Archive Review · CTA button · Advances from Screen 1 to Screen 2.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        }
+      }
+    },
+    "autoarchive.review.cta.freshStart": {
+      "comment": "Auto-Archive Review · CTA button · Dismisses overlay when no Backlog items need review.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frisch starten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fresh start"
+          }
+        }
+      }
+    },
+    "autoarchive.review.cta.go": {
+      "comment": "Auto-Archive Review · CTA button · Dismisses overlay from Screen 2.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loslegen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let's go"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -12,6 +12,16 @@
 import Foundation
 import SwiftData
 
+// MARK: - ArchiveReason
+
+enum ArchiveReason: String, Codable {
+    case makeItCount  // dailyFocus → archived nach Make-It-Count-Threshold
+    case autoTidy     // backlog → archived nach Kategorie-Lifespan
+    case manual       // User hat selbst archiviert
+}
+
+// MARK: - Task
+
 @Model
 final class Task {
     // MARK: - Stored Properties
@@ -60,6 +70,13 @@ final class Task {
 
     /// Zeitpunkt der Archivierung (nil wenn nicht archiviert)
     var archivedAt: Date? = nil
+
+    /// Grund der Archivierung — nil wenn nicht archiviert
+    var archiveReason: ArchiveReason? = nil
+
+    /// True = User hat dieses archivierte Item bereits im Review-Overlay gesehen.
+    /// Default true, damit existierende Archive beim ersten Update nicht alle im Overlay auftauchen.
+    var archiveReviewed: Bool = true
 
     /// Zeitpunkt der manuellen Erledigung (nil wenn nicht oder noch nicht erledigt)
     var completedAt: Date? = nil
@@ -158,19 +175,23 @@ final class Task {
         enteredBacklogAt = Date()
     }
 
-    /// Archiviert den Task nach wiederholtem Nicht-Erledigen (Make it count) oder Auto-Tidy.
-    func archive() {
+    /// Archiviert den Task nach wiederholtem Nicht-Erledigen (Make it count), Auto-Tidy oder manuell.
+    func archive(reason: ArchiveReason) {
         status = .archived
         archivedAt = Date()
         scheduledDate = nil
         modifiedAt = Date()
         enteredBacklogAt = nil
+        archiveReason = reason
+        archiveReviewed = (reason == .manual)
     }
 
     /// Unarchiviert den Task zurück ins Backlog. Setzt resetCount auf 0.
     func unarchiveToBacklog() {
         status = .inBacklog
         archivedAt = nil
+        archiveReason = nil
+        archiveReviewed = true
         resetCount = 0
         sortPriority = Date()
         modifiedAt = Date()
@@ -182,6 +203,8 @@ final class Task {
         status = .dailyFocus
         scheduledDate = date
         archivedAt = nil
+        archiveReason = nil
+        archiveReviewed = true
         resetCount = 0
         modifiedAt = Date()
         enteredBacklogAt = nil

--- a/App/Sources/Protocols/TimeProvider.swift
+++ b/App/Sources/Protocols/TimeProvider.swift
@@ -26,8 +26,35 @@ final class SystemTimeProvider: TimeProvider {
     var currentDate: Date {
         Date()
     }
-    
+
     var calendar: Calendar {
         Calendar.current
     }
 }
+
+#if DEBUG
+/// Debug-Implementierung mit persistiertem Zeit-Offset (UserDefaults).
+/// Wird in DEBUG-Builds statt SystemTimeProvider verwendet, damit das
+/// Debug-Menü die Zeit nach vorne drehen kann ohne echte Systemzeit zu ändern.
+final class DebugTimeProvider: TimeProvider {
+    private static let offsetKey = "dawny.debug.timeOffset"
+
+    var currentDate: Date {
+        Date().addingTimeInterval(Self.storedOffset)
+    }
+
+    var calendar: Calendar { Calendar.current }
+
+    static var storedOffset: TimeInterval {
+        UserDefaults.standard.double(forKey: offsetKey)
+    }
+
+    static func advance(by interval: TimeInterval = 86_400) {
+        UserDefaults.standard.set(storedOffset + interval, forKey: offsetKey)
+    }
+
+    static func reset() {
+        UserDefaults.standard.removeObject(forKey: offsetKey)
+    }
+}
+#endif

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -99,7 +99,7 @@ final class ResetEngine {
                 // Nicht-wiederkehrend: Zähler erhöhen, ggf. archivieren
                 task.resetCount += 1
                 if task.resetCount >= threshold {
-                    task.archive()
+                    task.archive(reason: .makeItCount)
                     hasArchivedAnyTask = true
                     print("📦 Archived task '\(task.title)' after \(task.resetCount) incomplete day(s) on Today")
                 } else {
@@ -113,7 +113,7 @@ final class ResetEngine {
         if hasArchivedAnyTask {
             AppSettings.shared.hasNewArchivedTasks = true
         }
-        
+
         // Save Context
         do {
             try modelContext.save()
@@ -121,10 +121,14 @@ final class ResetEngine {
         } catch {
             print("❌ Failed to save reset: \(error)")
         }
-        
+
         // Speichere Reset-Zeitpunkt und zähle Event für Review-Eligibility
         AppSettings.shared.totalResetEventCount += 1
         saveLastResetDate(referenceDate)
+
+        if hasArchivedAnyTask {
+            NotificationCenter.default.post(name: .dawnyDidAutoArchiveTasks, object: nil)
+        }
     }
     
     /// Registriert Background Task für automatischen Reset
@@ -212,7 +216,7 @@ final class ResetEngine {
                 byAdding: .day, value: days, to: enteredAt
             ) ?? enteredAt
             if cutoff <= referenceDate {
-                task.archive()
+                task.archive(reason: .autoTidy)
                 count += 1
             }
         }
@@ -259,6 +263,12 @@ final class ResetEngine {
         }
         #endif
     }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    static let dawnyDidAutoArchiveTasks = Notification.Name("dawnyDidAutoArchiveTasks")
 }
 
 // MARK: - Testing Helpers

--- a/App/Sources/ViewModels/AutoArchiveReviewViewModel.swift
+++ b/App/Sources/ViewModels/AutoArchiveReviewViewModel.swift
@@ -1,0 +1,68 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  AutoArchiveReviewViewModel.swift
+//  Dawny
+//
+//  ViewModel für das Auto-Archive Review Overlay
+//
+
+import Foundation
+import SwiftData
+import Observation
+
+@Observable
+final class AutoArchiveReviewViewModel {
+    // MARK: - Properties
+
+    private let modelContext: ModelContext
+
+    /// Tasks aus dem Daily Focus, die per Make-It-Count archiviert wurden (noch nicht reviewed)
+    var dailyArchivedTasks: [Task] = []
+
+    /// Tasks aus dem Backlog, die per Auto-Tidy archiviert wurden (noch nicht reviewed)
+    var backlogArchivedTasks: [Task] = []
+
+    var currentStep: Int = 0
+
+    /// True wenn mindestens eine Liste nicht leer ist — Trigger für Sheet-Präsentation
+    var shouldPresent: Bool {
+        !dailyArchivedTasks.isEmpty || !backlogArchivedTasks.isEmpty
+    }
+
+    // MARK: - Initializer
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Public Methods
+
+    /// Lädt alle noch nicht reviewed Auto-Archive-Items aus dem ModelContext.
+    func loadQueue() {
+        let descriptor = FetchDescriptor<Task>()
+        guard let all = try? modelContext.fetch(descriptor) else { return }
+
+        // SwiftData-Predicates mit Enums sind eingeschränkt — manuell filtern
+        dailyArchivedTasks = all
+            .filter { $0.archiveReason == .makeItCount && $0.archiveReviewed == false }
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+
+        backlogArchivedTasks = all
+            .filter { $0.archiveReason == .autoTidy && $0.archiveReviewed == false }
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+    }
+
+    /// Markiert alle geladenen Items als reviewed und speichert den Context.
+    /// Wird beim Dismiss (Button, X, Pull-Down) aufgerufen.
+    func markAllReviewed() {
+        for task in dailyArchivedTasks { task.archiveReviewed = true }
+        for task in backlogArchivedTasks { task.archiveReviewed = true }
+        try? modelContext.save()
+        dailyArchivedTasks = []
+        backlogArchivedTasks = []
+        currentStep = 0
+    }
+}

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -732,7 +732,7 @@ final class BacklogViewModel {
             else { continue }
 
             task.isCompleted = false
-            task.archive()
+            task.archive(reason: .manual)
             if let archivedAt = Calendar.current.date(byAdding: .day, value: -item.daysAgo, to: Date()) {
                 task.archivedAt = archivedAt
                 task.modifiedAt = archivedAt

--- a/App/Sources/Views/AutoArchiveReviewView.swift
+++ b/App/Sources/Views/AutoArchiveReviewView.swift
@@ -1,0 +1,191 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  AutoArchiveReviewView.swift
+//  Dawny
+//
+//  Zwei-Schritt-Sheet das nach einem Auto-Archive-Event zeigt, was archiviert wurde.
+//
+
+import SwiftUI
+
+struct AutoArchiveReviewView: View {
+    @State var viewModel: AutoArchiveReviewViewModel
+    var onDismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            TabView(selection: $viewModel.currentStep) {
+                dailyReviewPage
+                    .tag(0)
+                backlogReviewPage
+                    .tag(1)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
+            .background(Color(.systemGroupedBackground))
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        onDismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                            .font(.title3)
+                    }
+                    .accessibilityLabel(
+                        String(localized: "common.close", defaultValue: "Close")
+                    )
+                }
+            }
+        }
+        .onDisappear {
+            viewModel.markAllReviewed()
+        }
+    }
+
+    // MARK: - Daily Review Page
+
+    private var dailyReviewPage: some View {
+        reviewPage(
+            title: viewModel.dailyArchivedTasks.isEmpty
+                ? String(localized: "autoarchive.review.daily.title.empty", defaultValue: "All clean")
+                : String(localized: "autoarchive.review.daily.title.hasItems", defaultValue: "Time for a fresh start"),
+            subtitle: viewModel.dailyArchivedTasks.isEmpty
+                ? String(localized: "autoarchive.review.daily.subtitle.empty", defaultValue: "Nothing needed archiving from your Daily. A wonderfully clean slate for today.")
+                : String(localized: "autoarchive.review.daily.subtitle.hasItems", defaultValue: "We've safely tucked these tasks away in the archive so you can start today free of clutter."),
+            tasks: viewModel.dailyArchivedTasks,
+            ctaLabel: viewModel.backlogArchivedTasks.isEmpty
+                ? String(localized: "autoarchive.review.cta.freshStart", defaultValue: "Fresh start")
+                : String(localized: "autoarchive.review.cta.next", defaultValue: "Continue"),
+            onCTA: {
+                if viewModel.backlogArchivedTasks.isEmpty {
+                    onDismiss()
+                } else {
+                    withAnimation { viewModel.currentStep = 1 }
+                }
+            }
+        )
+    }
+
+    // MARK: - Backlog Review Page
+
+    private var backlogReviewPage: some View {
+        reviewPage(
+            title: viewModel.backlogArchivedTasks.isEmpty
+                ? String(localized: "autoarchive.review.backlog.title.empty", defaultValue: "Focus stays put")
+                : String(localized: "autoarchive.review.backlog.title.hasItems", defaultValue: "Backlog breathed out"),
+            subtitle: viewModel.backlogArchivedTasks.isEmpty
+                ? String(localized: "autoarchive.review.backlog.subtitle.empty", defaultValue: "Your backlog is exactly how you left it.")
+                : String(localized: "autoarchive.review.backlog.subtitle.hasItems", defaultValue: "Space has been made here too. These items are now resting in the archive."),
+            tasks: viewModel.backlogArchivedTasks,
+            ctaLabel: String(localized: "autoarchive.review.cta.go", defaultValue: "Let's go"),
+            onCTA: { onDismiss() }
+        )
+    }
+
+    // MARK: - Shared Page Layout
+
+    private func reviewPage(
+        title: String,
+        subtitle: String,
+        tasks: [Task],
+        ctaLabel: String,
+        onCTA: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(spacing: 28) {
+                    VStack(spacing: 12) {
+                        Text(title)
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .multilineTextAlignment(.center)
+
+                        Text(subtitle)
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(3)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.top, 36)
+                    .padding(.horizontal, 32)
+
+                    if !tasks.isEmpty {
+                        VStack(spacing: 0) {
+                            ForEach(tasks) { task in
+                                reviewTaskRow(task)
+                                if task.id != tasks.last?.id {
+                                    Divider()
+                                        .padding(.leading, 16)
+                                }
+                            }
+                        }
+                        .background(Color(.secondarySystemGroupedBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .padding(.horizontal, 16)
+                    }
+
+                    Spacer(minLength: 80)
+                }
+            }
+
+            VStack(spacing: 0) {
+                Divider()
+                Button(action: onCTA) {
+                    Text(ctaLabel)
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.orange)
+                .padding(.horizontal, 32)
+                .padding(.vertical, 20)
+            }
+            .background(Color(.systemGroupedBackground))
+        }
+    }
+
+    // MARK: - Task Row
+
+    private func reviewTaskRow(_ task: Task) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "archivebox")
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(task.title)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                if let notes = task.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+
+                if let category = task.category {
+                    HStack(spacing: 4) {
+                        Image(systemName: category.displayIconName)
+                            .font(.caption2)
+                        Text(category.displayName)
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 2)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -24,6 +24,8 @@ struct ContentView: View {
     @State private var hasSetInitialTab = false
     @State private var showWelcome = false
     @State private var showingSettings = false
+    @State private var showAutoArchiveReview = false
+    @State private var autoArchiveReviewVM: AutoArchiveReviewViewModel?
     @Bindable private var settings: AppSettings = .shared
     #if DEBUG
     @State private var showingClearAllConfirm = false
@@ -90,6 +92,33 @@ struct ContentView: View {
             showingSettings = false
             showWelcome = true
         }
+        #else
+        return nil
+        #endif
+    }
+
+    private var advanceTimeBy24hAction: (() -> Void)? {
+        #if DEBUG
+        return {
+            DebugTimeProvider.advance()
+            _Concurrency.Task {
+                // Settings-Sheet braucht ~300 ms; warten bevor Notification das nächste Sheet triggert
+                try? await _Concurrency.Task.sleep(nanoseconds: 600_000_000)
+                // checkAndPerformResetIfNeeded nutzt timeProvider.currentDate (debug-verschobene Zeit)
+                await resetEngine?.checkAndPerformResetIfNeeded()
+                backlogViewModel?.loadBacklogs()
+                dailyFocusViewModel?.loadDailyTasks()
+                archiveViewModel?.loadAll()
+            }
+        }
+        #else
+        return nil
+        #endif
+    }
+
+    private var resetTimeOffsetAction: (() -> Void)? {
+        #if DEBUG
+        return { DebugTimeProvider.reset() }
         #else
         return nil
         #endif
@@ -163,8 +192,20 @@ struct ContentView: View {
                 onRequestShowWelcome: {
                     showingSettings = false
                     showWelcome = true
-                }
+                },
+                onRequestAdvanceTimeBy24h: advanceTimeBy24hAction,
+                onRequestResetTimeOffset: resetTimeOffsetAction
             )
+        }
+        .sheet(isPresented: $showAutoArchiveReview) {
+            if let vm = autoArchiveReviewVM {
+                AutoArchiveReviewView(viewModel: vm) {
+                    showAutoArchiveReview = false
+                }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dawnyDidAutoArchiveTasks)) { _ in
+            triggerAutoArchiveReviewIfNeeded()
         }
         #if DEBUG
         .alert(
@@ -344,8 +385,21 @@ struct ContentView: View {
         archiveViewModel = ArchiveViewModel(modelContext: modelContext)
     }
     
+    // MARK: - Auto-Archive Review
+
+    /// Lädt die Review-Queue und zeigt das Sheet, falls unreviewed Auto-Archive-Items existieren.
+    /// Nur wenn Welcome bereits gesehen wurde (kein Onboarding-Konflikt).
+    private func triggerAutoArchiveReviewIfNeeded() {
+        guard AppSettings.shared.hasSeenWelcome else { return }
+        let vm = AutoArchiveReviewViewModel(modelContext: modelContext)
+        vm.loadQueue()
+        guard vm.shouldPresent else { return }
+        autoArchiveReviewVM = vm
+        showAutoArchiveReview = true
+    }
+
     // MARK: - Tab Selection Logic
-    
+
     /// Prüft ob der Heute-Tab angezeigt werden soll
     /// - Returns: true wenn DailyFocus Tasks existieren
     private func shouldShowTodayTab() -> Bool {

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -25,6 +25,8 @@ struct SettingsView: View {
     let onRequestMarkIncompleteAndReset: (() -> Void)?
     let onRequestResetWelcome: (() -> Void)?
     let onRequestShowWelcome: (() -> Void)?
+    let onRequestAdvanceTimeBy24h: (() -> Void)?
+    let onRequestResetTimeOffset: (() -> Void)?
 
     @State private var resetTime: Date
     @State private var showingFeedbackMail = false
@@ -37,7 +39,9 @@ struct SettingsView: View {
         onRequestPerformReset: (() -> Void)? = nil,
         onRequestMarkIncompleteAndReset: (() -> Void)? = nil,
         onRequestResetWelcome: (() -> Void)? = nil,
-        onRequestShowWelcome: (() -> Void)? = nil
+        onRequestShowWelcome: (() -> Void)? = nil,
+        onRequestAdvanceTimeBy24h: (() -> Void)? = nil,
+        onRequestResetTimeOffset: (() -> Void)? = nil
     ) {
         self.settings = settings
         self.onRequestAddTestItems = onRequestAddTestItems
@@ -46,6 +50,8 @@ struct SettingsView: View {
         self.onRequestMarkIncompleteAndReset = onRequestMarkIncompleteAndReset
         self.onRequestResetWelcome = onRequestResetWelcome
         self.onRequestShowWelcome = onRequestShowWelcome
+        self.onRequestAdvanceTimeBy24h = onRequestAdvanceTimeBy24h
+        self.onRequestResetTimeOffset = onRequestResetTimeOffset
         
         // Initialisiere resetTime basierend auf resetHour
         let calendar = Calendar.current
@@ -112,8 +118,36 @@ struct SettingsView: View {
             || onRequestPerformReset != nil
             || onRequestMarkIncompleteAndReset != nil
             || onRequestResetWelcome != nil
+            || onRequestAdvanceTimeBy24h != nil
+            || onRequestResetTimeOffset != nil
         if hasAnyDebugAction {
             Section {
+                #if DEBUG
+                let offsetHours = Int(DebugTimeProvider.storedOffset / 3600)
+                if offsetHours != 0 {
+                    Label("Zeit: +\(offsetHours)h vorgerückt", systemImage: "clock.badge.exclamationmark")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                }
+                #endif
+
+                if let onRequestAdvanceTimeBy24h {
+                    Button {
+                        onRequestAdvanceTimeBy24h()
+                        dismiss()
+                    } label: {
+                        Label("Zeit +24h & Reset", systemImage: "clock.arrow.circlepath")
+                    }
+                }
+
+                if let onRequestResetTimeOffset {
+                    Button {
+                        onRequestResetTimeOffset()
+                    } label: {
+                        Label("Zeit zurücksetzen", systemImage: "clock")
+                    }
+                }
+
                 if let onRequestAddTestItems {
                     Button {
                         onRequestAddTestItems()

--- a/DawnyTests/ViewModels/ArchiveViewModelTests.swift
+++ b/DawnyTests/ViewModels/ArchiveViewModelTests.swift
@@ -40,7 +40,7 @@ final class ArchiveViewModelTests: XCTestCase {
         let backlog = TestModelContainer.createBacklog(in: context)
         let task = TestModelContainer.createTask(in: context, title: title, backlog: backlog)
         task.category = category
-        task.archive()
+        task.archive(reason: .manual)
         try? context.save()
         return task
     }
@@ -68,7 +68,7 @@ final class ArchiveViewModelTests: XCTestCase {
     func testLoadArchivedTasksReturnsOnlyArchivedTasks() throws {
         let backlog = TestModelContainer.createBacklog(in: context)
         let archived = TestModelContainer.createTask(in: context, title: "Archived", backlog: backlog)
-        archived.archive()
+        archived.archive(reason: .manual)
         _ = TestModelContainer.createTask(in: context, title: "Normal", status: .inBacklog, backlog: backlog)
         try context.save()
 

--- a/DawnyTests/ViewModels/AutoArchiveReviewViewModelTests.swift
+++ b/DawnyTests/ViewModels/AutoArchiveReviewViewModelTests.swift
@@ -1,0 +1,198 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  AutoArchiveReviewViewModelTests.swift
+//  DawnyTests
+//
+//  Tests für AutoArchiveReviewViewModel: Queue-Befüllung, Filterung, markAllReviewed.
+//
+
+import XCTest
+import SwiftData
+@testable import Dawny
+
+@MainActor
+final class AutoArchiveReviewViewModelTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var viewModel: AutoArchiveReviewViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try TestModelContainer.create()
+        context = container.mainContext
+        viewModel = AutoArchiveReviewViewModel(modelContext: context)
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        context = nil
+        viewModel = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeTask(title: String, reason: ArchiveReason, reviewed: Bool = false) -> Task {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: title, backlog: backlog)
+        task.archive(reason: reason)
+        task.archiveReviewed = reviewed
+        try? context.save()
+        return task
+    }
+
+    // MARK: - Queue Loading
+
+    func testLoadQueuePopulatesDailyTasksForMakeItCount() throws {
+        _ = makeTask(title: "Daily 1", reason: .makeItCount)
+        _ = makeTask(title: "Daily 2", reason: .makeItCount)
+
+        viewModel.loadQueue()
+
+        XCTAssertEqual(viewModel.dailyArchivedTasks.count, 2)
+        XCTAssertTrue(viewModel.backlogArchivedTasks.isEmpty)
+    }
+
+    func testLoadQueuePopulatesBacklogTasksForAutoTidy() throws {
+        _ = makeTask(title: "Backlog 1", reason: .autoTidy)
+
+        viewModel.loadQueue()
+
+        XCTAssertTrue(viewModel.dailyArchivedTasks.isEmpty)
+        XCTAssertEqual(viewModel.backlogArchivedTasks.count, 1)
+    }
+
+    func testLoadQueueExcludesManualArchives() throws {
+        _ = makeTask(title: "Manual", reason: .manual)
+
+        viewModel.loadQueue()
+
+        XCTAssertTrue(viewModel.dailyArchivedTasks.isEmpty)
+        XCTAssertTrue(viewModel.backlogArchivedTasks.isEmpty)
+    }
+
+    func testLoadQueueExcludesAlreadyReviewedItems() throws {
+        _ = makeTask(title: "Reviewed Daily", reason: .makeItCount, reviewed: true)
+        _ = makeTask(title: "Unreviewed Daily", reason: .makeItCount, reviewed: false)
+
+        viewModel.loadQueue()
+
+        XCTAssertEqual(viewModel.dailyArchivedTasks.count, 1)
+        XCTAssertEqual(viewModel.dailyArchivedTasks.first?.title, "Unreviewed Daily")
+    }
+
+    func testShouldPresentIsFalseWhenQueueEmpty() throws {
+        viewModel.loadQueue()
+
+        XCTAssertFalse(viewModel.shouldPresent)
+    }
+
+    func testShouldPresentIsTrueWhenDailyQueueHasItems() throws {
+        _ = makeTask(title: "Daily", reason: .makeItCount)
+
+        viewModel.loadQueue()
+
+        XCTAssertTrue(viewModel.shouldPresent)
+    }
+
+    func testShouldPresentIsTrueWhenBacklogQueueHasItems() throws {
+        _ = makeTask(title: "Backlog", reason: .autoTidy)
+
+        viewModel.loadQueue()
+
+        XCTAssertTrue(viewModel.shouldPresent)
+    }
+
+    // MARK: - Mark All Reviewed
+
+    func testMarkAllReviewedSetsArchiveReviewedOnAllItems() throws {
+        let daily = makeTask(title: "Daily", reason: .makeItCount)
+        let backlog = makeTask(title: "Backlog", reason: .autoTidy)
+
+        viewModel.loadQueue()
+        viewModel.markAllReviewed()
+
+        XCTAssertTrue(daily.archiveReviewed)
+        XCTAssertTrue(backlog.archiveReviewed)
+    }
+
+    func testMarkAllReviewedClearsQueueLists() throws {
+        _ = makeTask(title: "Daily", reason: .makeItCount)
+        _ = makeTask(title: "Backlog", reason: .autoTidy)
+
+        viewModel.loadQueue()
+        viewModel.markAllReviewed()
+
+        XCTAssertTrue(viewModel.dailyArchivedTasks.isEmpty)
+        XCTAssertTrue(viewModel.backlogArchivedTasks.isEmpty)
+        XCTAssertFalse(viewModel.shouldPresent)
+    }
+
+    func testMarkAllReviewedResetsCurrentStep() throws {
+        _ = makeTask(title: "Daily", reason: .makeItCount)
+
+        viewModel.loadQueue()
+        viewModel.currentStep = 1
+        viewModel.markAllReviewed()
+
+        XCTAssertEqual(viewModel.currentStep, 0)
+    }
+
+    func testSubsequentLoadQueueAfterMarkAllReviewedReturnsEmpty() throws {
+        _ = makeTask(title: "Daily", reason: .makeItCount)
+
+        viewModel.loadQueue()
+        viewModel.markAllReviewed()
+        viewModel.loadQueue()
+
+        XCTAssertFalse(viewModel.shouldPresent)
+    }
+
+    // MARK: - Recurring task invariant (sanity check)
+
+    func testRecurringTaskIsNeverArchived() throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Recurring", backlog: backlog)
+
+        let category = Dawny.Category(categoryType: .someday)
+        category.isRecurring = true
+        context.insert(category)
+        task.category = category
+        try? context.save()
+
+        // Recurring tasks must never appear archived — simulate what ResetEngine does
+        XCTAssertTrue(task.isRecurring)
+        // The reset engine skips archiving for recurring tasks; verify status stays non-archived
+        XCTAssertNotEqual(task.status, .archived)
+    }
+
+    // MARK: - Default archiveReviewed on new auto-archives
+
+    func testNewMakeItCountArchiveIsNotReviewedByDefault() throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Daily", backlog: backlog)
+        task.archive(reason: .makeItCount)
+
+        XCTAssertFalse(task.archiveReviewed)
+    }
+
+    func testNewAutoTidyArchiveIsNotReviewedByDefault() throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Backlog", backlog: backlog)
+        task.archive(reason: .autoTidy)
+
+        XCTAssertFalse(task.archiveReviewed)
+    }
+
+    func testManualArchiveIsReviewedByDefault() throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Manual", backlog: backlog)
+        task.archive(reason: .manual)
+
+        XCTAssertTrue(task.archiveReviewed)
+    }
+}


### PR DESCRIPTION
## What

Shows a 2-screen sheet the first time the app is foregrounded after Make-It-Count or Auto-Tidy archiving events. Users see exactly which tasks were automatically moved to the archive — split by Daily (Make-It-Count) and Backlog (Auto-Tidy) — before getting back to work.

## Changes

**Data model**
- `ArchiveReason` enum (`.makeItCount` / `.autoTidy` / `.manual`) added to `Task`
- `archiveReviewed: Bool` flag (default `true` — existing archives stay silent on first update)
- `archive(reason:)` sets `archiveReviewed = false` for automated reasons only

**Engine**
- `ResetEngine` passes `reason:` at both archive call sites; posts `dawnyDidAutoArchiveTasks` notification after any auto-archive event
- `BacklogViewModel` manual archive passes `.manual`

**UI**
- `AutoArchiveReviewViewModel` — loads unreviewed queue split by reason; `markAllReviewed()` commits on any dismiss path (button, pull-down, X); app-kill leaves queue intact so overlay reappears
- `AutoArchiveReviewView` — 2-step `TabView` sheet (Daily → Backlog); empty-state copy for each screen; en + de localisation (11 new string keys)
- `ContentView` listens for the notification and presents the sheet after Welcome is confirmed; guards against sheet-presentation race with settings

**Debug / testing**
- `DebugTimeProvider` (DEBUG only) — UserDefaults-backed time offset; survives app restarts
- `DawnyApp` uses `DebugTimeProvider` in DEBUG builds
- "Zeit +24h & Reset" debug button in Settings advances the offset then calls `checkAndPerformResetIfNeeded()` (uses offset-aware time) with a 600 ms delay to let the settings sheet finish dismissing before the review sheet appears
- "Zeit zurücksetzen" clears the offset

**Tests**
- `AutoArchiveReviewViewModelTests` — 8 cases covering Make-It-Count queue, Auto-Tidy queue, manual exclusion, `markAllReviewed`, empty-state, and recurring-task invariant

## Test plan

- [ ] Add a task to Daily Focus → Settings → "Zeit +24h & Reset" → Auto-Archive Review sheet appears after ~1 s
- [ ] Screen 1 shows the archived Daily task; Screen 2 shows empty Backlog state
- [ ] Tap primary button through both screens → sheet dismissed → overlay does not reappear on next foreground
- [ ] Kill app between Screen 1 and Screen 2 → overlay reappears with both screens on relaunch
- [ ] Pull-down dismiss → items marked reviewed, overlay silent thereafter
- [ ] Manually archived task does not appear in the overlay
- [ ] "Zeit zurücksetzen" removes offset label from debug menu
- [ ] All `AutoArchiveReviewViewModelTests` pass