### PR TITLE
feat: persist archive badge until user leaves the view

### DIFF
--- a/App/Sources/ViewModels/ArchiveViewModel.swift
+++ b/App/Sources/ViewModels/ArchiveViewModel.swift
@@ -133,6 +133,21 @@ final class ArchiveViewModel {
         saveAndReload()
     }
 
+    // MARK: - Badge Clearing
+
+    /// Markiert alle archivierten Tasks als gesehen (archiveReviewed = true).
+    /// Wird aufgerufen wenn der Nutzer das Archiv verlässt.
+    func markAllArchiveReviewed() {
+        let descriptor = FetchDescriptor<Task>(
+            predicate: #Predicate { $0.archiveReviewed == false }
+        )
+        guard let unreviewed = try? modelContext.fetch(descriptor), !unreviewed.isEmpty else { return }
+        for task in unreviewed {
+            task.archiveReviewed = true
+        }
+        try? modelContext.save()
+    }
+
     // MARK: - Private Helpers
 
     private func task(withID id: UUID) -> Task? {

--- a/App/Sources/Views/ArchiveView.swift
+++ b/App/Sources/Views/ArchiveView.swift
@@ -269,9 +269,17 @@ private struct ArchivedTaskRowView: View {
                 HapticFeedback.light()
                 isActionDialogPresented = true
             } label: {
-                Image(systemName: "archivebox")
-                    .font(.subheadline)
-                    .foregroundStyle(.tertiary)
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: "archivebox")
+                        .font(.subheadline)
+                        .foregroundStyle(.tertiary)
+                    if !task.archiveReviewed {
+                        Circle()
+                            .fill(Color.orange)
+                            .frame(width: 7, height: 7)
+                            .offset(x: 3, y: -3)
+                    }
+                }
             }
             .buttonStyle(.plain)
 

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -48,43 +48,6 @@ struct ContentView: View {
         #endif
     }
 
-    private var performResetAction: (() -> Void)? {
-        #if DEBUG
-        return {
-            _Concurrency.Task {
-                await resetEngine?.performReset()
-                backlogViewModel?.loadBacklogs()
-                dailyFocusViewModel?.loadDailyTasks()
-                archiveViewModel?.loadAll()
-            }
-        }
-        #else
-        return nil
-        #endif
-    }
-
-    private var markIncompleteAndResetAction: (() -> Void)? {
-        #if DEBUG
-        return {
-            _Concurrency.Task {
-                let descriptor = FetchDescriptor<Task>()
-                if let allTasks = try? modelContext.fetch(descriptor) {
-                    for task in allTasks where task.status == .dailyFocus {
-                        task.isCompleted = false
-                    }
-                    try? modelContext.save()
-                }
-                await resetEngine?.performReset()
-                backlogViewModel?.loadBacklogs()
-                dailyFocusViewModel?.loadDailyTasks()
-                archiveViewModel?.loadAll()
-            }
-        }
-        #else
-        return nil
-        #endif
-    }
-
     private var resetWelcomeAction: (() -> Void)? {
         #if DEBUG
         return {
@@ -101,11 +64,14 @@ struct ContentView: View {
         #if DEBUG
         return {
             DebugTimeProvider.advance()
-            _Concurrency.Task {
+            // Snapshot der virtuellen Zeit direkt nach advance(), bevor der async-Hop passiert
+            let virtualNow = Date().addingTimeInterval(DebugTimeProvider.storedOffset)
+            _Concurrency.Task { @MainActor in
                 // Settings-Sheet braucht ~300 ms; warten bevor Notification das nächste Sheet triggert
                 try? await _Concurrency.Task.sleep(nanoseconds: 600_000_000)
-                // checkAndPerformResetIfNeeded nutzt timeProvider.currentDate (debug-verschobene Zeit)
-                await resetEngine?.checkAndPerformResetIfNeeded()
+                // performReset direkt aufrufen statt checkAndPerformResetIfNeeded,
+                // damit der Reset immer durchläuft unabhängig vom gespeicherten lastResetDate
+                await resetEngine?.performReset(referenceDate: virtualNow)
                 backlogViewModel?.loadBacklogs()
                 dailyFocusViewModel?.loadDailyTasks()
                 archiveViewModel?.loadAll()
@@ -186,8 +152,6 @@ struct ContentView: View {
             SettingsView(
                 onRequestAddTestItems: addTestItemsAction,
                 onRequestDeleteAll: clearAllAction,
-                onRequestPerformReset: performResetAction,
-                onRequestMarkIncompleteAndReset: markIncompleteAndResetAction,
                 onRequestResetWelcome: resetWelcomeAction,
                 onRequestShowWelcome: {
                     showingSettings = false
@@ -224,7 +188,7 @@ struct ContentView: View {
         #endif
         .onAppear {
             initializeViewModels()
-            
+
             if !hasSetInitialTab {
                 hasSetInitialTab = true
                 if shouldShowTodayTab() {
@@ -233,6 +197,12 @@ struct ContentView: View {
                 if !AppSettings.shared.hasSeenWelcome {
                     showWelcome = true
                 }
+            }
+        }
+        .onChange(of: selectedTab) { oldTab, newTab in
+            if oldTab == .archive && newTab != .archive {
+                settings.hasNewArchivedTasks = false
+                archiveViewModel?.markAllArchiveReviewed()
             }
         }
     }
@@ -283,7 +253,6 @@ struct ContentView: View {
             transaction.disablesAnimations = true
             withTransaction(transaction) {
                 selectedTab = .archive
-                settings.hasNewArchivedTasks = false
                 archiveViewModel?.loadAll()
             }
         } label: {

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -21,8 +21,6 @@ struct SettingsView: View {
     
     let onRequestAddTestItems: (() -> Void)?
     let onRequestDeleteAll: (() -> Void)?
-    let onRequestPerformReset: (() -> Void)?
-    let onRequestMarkIncompleteAndReset: (() -> Void)?
     let onRequestResetWelcome: (() -> Void)?
     let onRequestShowWelcome: (() -> Void)?
     let onRequestAdvanceTimeBy24h: (() -> Void)?
@@ -36,8 +34,6 @@ struct SettingsView: View {
         settings: AppSettings = .shared,
         onRequestAddTestItems: (() -> Void)? = nil,
         onRequestDeleteAll: (() -> Void)? = nil,
-        onRequestPerformReset: (() -> Void)? = nil,
-        onRequestMarkIncompleteAndReset: (() -> Void)? = nil,
         onRequestResetWelcome: (() -> Void)? = nil,
         onRequestShowWelcome: (() -> Void)? = nil,
         onRequestAdvanceTimeBy24h: (() -> Void)? = nil,
@@ -46,8 +42,6 @@ struct SettingsView: View {
         self.settings = settings
         self.onRequestAddTestItems = onRequestAddTestItems
         self.onRequestDeleteAll = onRequestDeleteAll
-        self.onRequestPerformReset = onRequestPerformReset
-        self.onRequestMarkIncompleteAndReset = onRequestMarkIncompleteAndReset
         self.onRequestResetWelcome = onRequestResetWelcome
         self.onRequestShowWelcome = onRequestShowWelcome
         self.onRequestAdvanceTimeBy24h = onRequestAdvanceTimeBy24h
@@ -115,8 +109,6 @@ struct SettingsView: View {
     private var debugSection: some View {
         let hasAnyDebugAction = onRequestAddTestItems != nil
             || onRequestDeleteAll != nil
-            || onRequestPerformReset != nil
-            || onRequestMarkIncompleteAndReset != nil
             || onRequestResetWelcome != nil
             || onRequestAdvanceTimeBy24h != nil
             || onRequestResetTimeOffset != nil
@@ -156,30 +148,6 @@ struct SettingsView: View {
                         Label(
                             String(localized: "quickadd.addtestitems", defaultValue: "Add Test Items"),
                             systemImage: "wand.and.stars"
-                        )
-                    }
-                }
-
-                if let onRequestPerformReset {
-                    Button {
-                        onRequestPerformReset()
-                        dismiss()
-                    } label: {
-                        Label(
-                            String(localized: "debug.reset.now", defaultValue: "Perform Reset Now"),
-                            systemImage: "arrow.clockwise"
-                        )
-                    }
-                }
-
-                if let onRequestMarkIncompleteAndReset {
-                    Button {
-                        onRequestMarkIncompleteAndReset()
-                        dismiss()
-                    } label: {
-                        Label(
-                            String(localized: "debug.markincomplete.reset", defaultValue: "Mark Today Incomplete + Reset"),
-                            systemImage: "arrow.triangle.2.circlepath"
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

- **Archive row dots:** Individual archived task rows now show an orange dot badge (7×7 pt `Circle` in a `ZStack`) for tasks where `archiveReviewed == false`, matching the tab icon badge
- **Badge persistence:** Both the tab icon badge and individual row dots stay visible for the full duration of the archive visit; clearing happens via `onChange(of: selectedTab)` only when navigating away
- **Debug menu cleanup:** Removed the separate "Perform Reset Now" and "Mark Incomplete + Reset" debug buttons (superseded by the advance-24h action) from `ContentView` and `SettingsView`
- **Advance-24h fix:** The debug "advance time 24h" action now calls `performReset(referenceDate:)` directly, ensuring the reset always runs regardless of `lastResetDate`

## Test plan

- [ ] Archive one or more tasks via Make It Count or Auto-Tidy
- [ ] Verify the orange dot appears on the Archive tab icon
- [ ] Tap the Archive tab — confirm the tab dot AND individual row dots are both visible
- [ ] Navigate away (swipe or tap another tab) — confirm both dots disappear
- [ ] Return to Archive — confirm dots are gone (already reviewed)
- [ ] Verify debug Settings sheet no longer shows the removed reset buttons