### PR TITLE
Add App Store screenshot automation

### DIFF
--- a/App/Sources/DawnyApp.swift
+++ b/App/Sources/DawnyApp.swift
@@ -54,7 +54,13 @@ struct DawnyApp: App {
         
         // Cross-reference for reset engine
         resetEngine.syncEngine = syncEngine
-        
+
+        #if DEBUG
+        if ScreenshotSeeder.isActive {
+            ScreenshotSeeder.prepareForLaunch()
+        }
+        #endif
+
         // Siri Shortcuts registrieren
         DawnyShortcuts.updateAppShortcutParameters()
     }
@@ -108,7 +114,13 @@ struct DawnyApp: App {
         // 5. Initialize Categories
         let categoryService = CategoryService(modelContext: modelContainer.mainContext)
         categoryService.initializeDefaultCategories()
-        
+
+        #if DEBUG
+        if ScreenshotSeeder.isActive {
+            ScreenshotSeeder.seed(into: modelContainer.mainContext)
+        }
+        #endif
+
         // 6. Reindex entities for Spotlight / Apple Intelligence
         await EntityIndexer.reindexAll()
         

--- a/App/Sources/ScreenshotSeeder.swift
+++ b/App/Sources/ScreenshotSeeder.swift
@@ -1,0 +1,235 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  ScreenshotSeeder.swift
+//  Dawny
+//
+//  Seeds deterministic SwiftData content when the app is launched with the
+//  `--screenshots` argument. Used exclusively by the App Store screenshot
+//  workflow (scripts/take-screenshots.sh + DawnyUITests/ScreenshotTests).
+//
+
+#if DEBUG
+import Foundation
+import SwiftData
+
+enum ScreenshotSeeder {
+    /// Erkennt, ob die App im Screenshot-Modus läuft.
+    static var isActive: Bool {
+        ProcessInfo.processInfo.arguments.contains("--screenshots")
+    }
+
+    /// Synchronously prepares AppSettings before any view appears. Must be called
+    /// from `DawnyApp.init()` so the Welcome cover does not present.
+    static func prepareForLaunch() {
+        AppSettings.shared.hasSeenWelcome = true
+        AppSettings.shared.calendarSyncEnabled = false
+        AppSettings.shared.showCategories = true
+        AppSettings.shared.showCompletedTasksInToday = true
+        AppSettings.shared.hasNewArchivedTasks = false
+    }
+
+    /// Wipes existing tasks and seeds the deterministic content used in the App Store screenshots.
+    /// Must run after `CategoryService.initializeDefaultCategories()` so categories exist.
+    static func seed(into context: ModelContext) {
+        // Bundle.preferredLocalizations follows AppleLanguages directly, so seed
+        // content matches whatever the UI is rendering. Locale.current can lag
+        // behind AppleLanguages launch overrides.
+        let preferred = Bundle.main.preferredLocalizations.first ?? "en"
+        let isGerman = preferred.hasPrefix("de")
+
+        do {
+            let existing = try context.fetch(FetchDescriptor<Task>())
+            for task in existing {
+                context.delete(task)
+            }
+
+            let backlog = try fetchOrCreateBacklog(in: context)
+            let categories = try context.fetch(FetchDescriptor<Category>())
+
+            func category(_ type: TaskCategory) -> Category? {
+                categories.first { $0.categoryType == type }
+            }
+
+            let recurring = categories.first(where: { $0.isRecurring })
+
+            seedBacklog(backlog: backlog, category: category, isGerman: isGerman, in: context)
+            seedRecurring(backlog: backlog, recurring: recurring, isGerman: isGerman, in: context)
+            seedToday(backlog: backlog, isGerman: isGerman, in: context)
+            seedArchive(backlog: backlog, isGerman: isGerman, in: context)
+
+            try context.save()
+        } catch {
+            print("⚠️ ScreenshotSeeder failed: \(error)")
+        }
+    }
+
+    // MARK: - Backlog
+
+    private static func seedBacklog(
+        backlog: Backlog,
+        category: (TaskCategory) -> Category?,
+        isGerman: Bool,
+        in context: ModelContext
+    ) {
+        let items: [(String, TaskCategory)] = isGerman ? [
+            ("Konzerttickets kaufen 🎫", .quick),
+            ("Toms Nachricht beantworten 💬", .nextFewDays),
+            ("Rezept abholen", .nextFewDays),
+            ("Geburtstagsessen buchen 🎂", .nextFewWeeks),
+            ("Neue Bilder einrahmen 🖼️", .nextFewWeeks),
+            ("Sommerurlaub planen ☀️", .nextFewMonths),
+            ("Reisepass verlängern", .nextFewMonths),
+            ("Neuen Kühlschrank kaufen", .nextFewMonths)
+        ] : [
+            ("Get concert tickets 🎫", .quick),
+            ("Reply to Tom's message 💬", .nextFewDays),
+            ("Pick up prescription", .nextFewDays),
+            ("Book birthday dinner 🎂", .nextFewWeeks),
+            ("Frame and hang new pictures 🖼️", .nextFewWeeks),
+            ("Plan summer vacation ☀️", .nextFewMonths),
+            ("Renew passport", .nextFewMonths),
+            ("Buy a new fridge", .nextFewMonths)
+        ]
+
+        for (index, item) in items.enumerated() {
+            let task = Task(
+                title: item.0,
+                status: .inBacklog,
+                parentBacklogID: backlog.id,
+                sortPriority: Date().addingTimeInterval(TimeInterval(-index)),
+                category: category(item.1)
+            )
+            task.backlog = backlog
+            context.insert(task)
+        }
+    }
+
+    // MARK: - Recurring
+
+    private static func seedRecurring(
+        backlog: Backlog,
+        recurring: Category?,
+        isGerman: Bool,
+        in context: ModelContext
+    ) {
+        guard let recurring else { return }
+        let titles = isGerman
+            ? ["Haus putzen", "15 Min Dehnen"]
+            : ["Clean the house", "15 min stretch break"]
+
+        for (index, title) in titles.enumerated() {
+            let task = Task(
+                title: title,
+                status: .inBacklog,
+                parentBacklogID: backlog.id,
+                sortPriority: Date().addingTimeInterval(TimeInterval(-100 - index)),
+                category: recurring
+            )
+            task.backlog = backlog
+            context.insert(task)
+        }
+    }
+
+    // MARK: - Today
+
+    private static func seedToday(backlog: Backlog, isGerman: Bool, in context: ModelContext) {
+        let openTitle = isGerman ? "Keller aufräumen 🏠" : "Clean basement 🏠"
+        let open = Task(
+            title: openTitle,
+            status: .dailyFocus,
+            parentBacklogID: backlog.id,
+            scheduledDate: Date()
+        )
+        open.backlog = backlog
+        context.insert(open)
+
+        let completedTitles = isGerman ? [
+            "Auto zur Inspektion bringen 🚗",
+            "Paket abholen 📦",
+            "Einkaufen gehen 🛒",
+            "Mit dem Hund rausgehen 🐕"
+        ] : [
+            "Take car in for inspection 🚗",
+            "Pick up package 📦",
+            "Get groceries 🛒",
+            "Walk the dog 🐕"
+        ]
+
+        let now = Date()
+        for (index, title) in completedTitles.enumerated() {
+            let task = Task(
+                title: title,
+                status: .completed,
+                parentBacklogID: backlog.id,
+                scheduledDate: now,
+                isCompleted: true
+            )
+            task.completedAt = now.addingTimeInterval(TimeInterval(-index * 600))
+            task.modifiedAt = task.completedAt ?? now
+            task.backlog = backlog
+            context.insert(task)
+        }
+    }
+
+    // MARK: - Archive
+
+    private static func seedArchive(backlog: Backlog, isGerman: Bool, in context: ModelContext) {
+        let titles = isGerman ? [
+            "Einladung zu Carlas Hochzeit bestätigen ❤️",
+            "Arzttermin machen",
+            "Nervigen Newsletter abbestellen",
+            "YouTube 'Später ansehen'-Liste aufräumen",
+            "iPhone-Backup machen (wirklich!)",
+            "Fast-identische Selfies löschen",
+            "Sonnenfenster putzen",
+            "Kabelsalat hinter dem TV bändigen"
+        ] : [
+            "RSVP to Carla's wedding ❤️",
+            "Make doctor's appointment",
+            "Finally unsubscribe from that annoying newsletter",
+            "Clean up the YouTube 'Watch later' list",
+            "Make an iPhone backup (for real!)",
+            "Delete nearly identical selfies from gallery",
+            "Clean the window that gets full sun",
+            "Tame the cable mess behind the TV"
+        ]
+
+        let calendar = Calendar.current
+        let now = Date()
+        for (index, title) in titles.enumerated() {
+            let task = Task(
+                title: title,
+                status: .archived,
+                parentBacklogID: backlog.id
+            )
+            let archivedAt = calendar.date(
+                byAdding: .hour,
+                value: -(index + 1) * 24 - 5,
+                to: now
+            ) ?? now
+            task.archivedAt = archivedAt
+            task.modifiedAt = archivedAt
+            task.archiveReason = .makeItCount
+            task.archiveReviewed = true
+            task.backlog = backlog
+            context.insert(task)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func fetchOrCreateBacklog(in context: ModelContext) throws -> Backlog {
+        let existing = try context.fetch(FetchDescriptor<Backlog>(sortBy: [SortDescriptor(\.orderIndex)]))
+        if let first = existing.first {
+            return first
+        }
+        let title = String(localized: "backlog.default.title", defaultValue: "Backlog")
+        let backlog = Backlog(title: title, orderIndex: 0)
+        context.insert(backlog)
+        return backlog
+    }
+}
+#endif

--- a/DawnyUITests/ScreenshotTests.swift
+++ b/DawnyUITests/ScreenshotTests.swift
@@ -1,0 +1,179 @@
+// Dawny
+// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
+// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+
+//
+//  ScreenshotTests.swift
+//  DawnyUITests
+//
+//  Generates the three standardized App Store screenshots (Backlog, Today,
+//  Archive) for both English and German. Driven by scripts/take-screenshots.sh
+//  which runs both methods in a single xcodebuild invocation.
+//
+//  Output: /tmp/dawny-screenshots/<lang>/0{1,2,3}_{Backlog,Today,Archive}.png
+//
+
+import XCTest
+
+final class ScreenshotTests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        app = nil
+    }
+
+    func testTakeScreenshotsEN() throws {
+        try runScreenshots(
+            lang: "en",
+            firstArchivedSearchText: "RSVP",
+            archiveSectionTitle: "Archived"
+        )
+    }
+
+    func testTakeScreenshotsDE() throws {
+        try runScreenshots(
+            lang: "de",
+            firstArchivedSearchText: "Einladung",
+            archiveSectionTitle: "Archiviert"
+        )
+    }
+
+    // MARK: - Test driver
+
+    private func runScreenshots(
+        lang: String,
+        firstArchivedSearchText: String,
+        archiveSectionTitle: String
+    ) throws {
+        let outputDir = "/tmp/dawny-screenshots/\(lang)"
+        try FileManager.default.createDirectory(
+            atPath: outputDir,
+            withIntermediateDirectories: true
+        )
+
+        app = XCUIApplication()
+        // Pass locale as both launchArguments (writes to UserDefaults at startup,
+        // overriding any persisted AppleLanguages from a prior test run on the
+        // same simulator) AND launchEnvironment (some system APIs read the env
+        // before UserDefaults).
+        let locale = lang == "de" ? "de_DE" : "en_US"
+        app.launchArguments = [
+            "--uitesting",
+            "--screenshots",
+            "-AppleLanguages", "(\(lang))",
+            "-AppleLocale", locale
+        ]
+        app.launchEnvironment["AppleLanguages"] = "(\(lang))"
+        app.launchEnvironment["AppleLocale"] = locale
+        app.launch()
+
+        waitForSeederToFinish()
+
+        navigateToBacklog()
+        Thread.sleep(forTimeInterval: 0.6)
+        save(name: "01_Backlog", outputDir: outputDir)
+
+        navigateToToday(lang: lang)
+        Thread.sleep(forTimeInterval: 0.6)
+        save(name: "02_Today", outputDir: outputDir)
+
+        navigateToArchive()
+        Thread.sleep(forTimeInterval: 0.8)
+        partialSwipeRightOnFirstArchivedTask(
+            matching: firstArchivedSearchText,
+            sectionTitle: archiveSectionTitle
+        )
+        Thread.sleep(forTimeInterval: 0.5)
+        save(name: "03_Archive", outputDir: outputDir)
+    }
+
+    // MARK: - Navigation
+
+    private func waitForSeederToFinish() {
+        let settings = app.buttons["ToolbarSettingsButton"]
+        _ = settings.waitForExistence(timeout: 10)
+    }
+
+    private func navigateToBacklog() {
+        let backlog = app.buttons["Backlog"]
+        if backlog.waitForExistence(timeout: 3) {
+            backlog.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
+    }
+
+    private func navigateToToday(lang: String) {
+        let label = lang == "de" ? "Heute" : "Today"
+        let button = app.buttons[label]
+        if button.waitForExistence(timeout: 3) {
+            button.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
+    }
+
+    private func navigateToArchive() {
+        let archive = app.buttons["ToolbarArchiveButton"]
+        XCTAssertTrue(archive.waitForExistence(timeout: 5))
+        archive.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+    }
+
+    // MARK: - Swipe helpers
+
+    /// Targets the cell containing `searchText` (a unique substring of the first
+    /// archived task title) and drags it ~50% of the way across to reveal both
+    /// leading swipe actions without triggering the full-swipe.
+    ///
+    /// Why not `app.cells.element(boundBy: 0)`: ContentView's TabPager keeps the
+    /// Backlog and Today lists in the accessibility hierarchy (just translated
+    /// off-screen). The first cell by index belongs to the Backlog, not the
+    /// Archive.
+    ///
+    /// If the cell isn't found, the Archive section header is tapped once to
+    /// expand it (it can render collapsed on first appearance in some launch
+    /// orderings), then the search is retried.
+    private func partialSwipeRightOnFirstArchivedTask(
+        matching searchText: String,
+        sectionTitle: String
+    ) {
+        let predicate = NSPredicate(format: "label CONTAINS %@", searchText)
+        var cell = app.cells.containing(predicate).firstMatch
+
+        if !cell.waitForExistence(timeout: 2) {
+            let header = app.staticTexts[sectionTitle]
+            if header.waitForExistence(timeout: 2) {
+                header.tap()
+                Thread.sleep(forTimeInterval: 0.4)
+            }
+            cell = app.cells.containing(predicate).firstMatch
+        }
+
+        XCTAssertTrue(
+            cell.waitForExistence(timeout: 5),
+            "Archive cell containing '\(searchText)' not found."
+        )
+        let start = cell.coordinate(withNormalizedOffset: CGVector(dx: 0.05, dy: 0.5))
+        let end = cell.coordinate(withNormalizedOffset: CGVector(dx: 0.55, dy: 0.5))
+        start.press(forDuration: 0.1, thenDragTo: end)
+    }
+
+    // MARK: - Save
+
+    private func save(name: String, outputDir: String) {
+        let screenshot = app.screenshot()
+        let url = URL(fileURLWithPath: "\(outputDir)/\(name).png")
+        do {
+            try screenshot.pngRepresentation.write(to: url)
+        } catch {
+            XCTFail("Failed to write screenshot \(name): \(error)")
+        }
+
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/scripts/take-screenshots.sh
+++ b/scripts/take-screenshots.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Generates standardized App Store screenshots for both English and German.
+#
+# Runs the DawnyUITests/ScreenshotTests suite once. The suite contains two
+# test methods (testTakeScreenshotsEN, testTakeScreenshotsDE) that each launch
+# the app with the appropriate locale via XCUIApplication.launchEnvironment.
+# The app is launched with `--screenshots`, which triggers ScreenshotSeeder to
+# wipe existing tasks and insert deterministic content per locale.
+#
+# Three screenshots are captured per locale (Backlog, Today, Archive with swipe).
+#
+# Usage:
+#   ./scripts/take-screenshots.sh
+#
+# Output:
+#   screenshots/en/0{1,2,3}_*.png
+#   screenshots/de/0{1,2,3}_*.png
+#
+# Requires: Xcode with iPhone 17 Pro Max simulator installed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+SIMULATOR="iPhone 17 Pro Max"
+PROJECT="Dawny.xcodeproj"
+SCHEME="Dawny"
+OUTPUT_ROOT="$PROJECT_ROOT/screenshots"
+TEMP_ROOT="/tmp/dawny-screenshots"
+
+echo "📸 Dawny App Store screenshot run"
+echo "   Simulator: $SIMULATOR"
+echo "   Output:    $OUTPUT_ROOT"
+echo
+
+rm -rf "$TEMP_ROOT"
+mkdir -p "$TEMP_ROOT/en" "$TEMP_ROOT/de" "$OUTPUT_ROOT/en" "$OUTPUT_ROOT/de"
+
+echo "→ Running ScreenshotTests (EN + DE)…"
+
+set +e
+xcodebuild test \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -destination "platform=iOS Simulator,name=$SIMULATOR" \
+    -only-testing:DawnyUITests/ScreenshotTests \
+    -resultBundlePath "$TEMP_ROOT/result.xcresult" \
+    > "$TEMP_ROOT/xcodebuild.log" 2>&1
+XCODEBUILD_EXIT=$?
+set -e
+
+if [[ $XCODEBUILD_EXIT -ne 0 ]]; then
+    echo "  ⚠️  xcodebuild exited with code $XCODEBUILD_EXIT — see $TEMP_ROOT/xcodebuild.log"
+fi
+
+for LANG_CODE in en de; do
+    SHOTS=$(find "$TEMP_ROOT/$LANG_CODE" -maxdepth 1 -name "*.png" 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$SHOTS" -gt 0 ]]; then
+        cp "$TEMP_ROOT/$LANG_CODE"/*.png "$OUTPUT_ROOT/$LANG_CODE/"
+        echo "  ✓ $SHOTS screenshot(s) saved to screenshots/$LANG_CODE/"
+    else
+        echo "  ✗ No screenshots produced for $LANG_CODE. Inspect $TEMP_ROOT/xcodebuild.log"
+    fi
+done
+
+echo
+echo "Done."
+if command -v open >/dev/null 2>&1; then
+    open "$OUTPUT_ROOT"
+fi


### PR DESCRIPTION
## Summary
One-command generation of the three standardized App Store screenshots (Backlog, Today, Archive) in **English and German**, captured from a single `xcodebuild` run.

## How it works
- **`ScreenshotSeeder`** (`App/Sources/ScreenshotSeeder.swift`) — wipes existing tasks and seeds deterministic per-locale content. Gated behind `#if DEBUG` + the `--screenshots` launch argument, so it never affects production builds.
- **`DawnyApp`** — invokes the seeder on launch (`prepareForLaunch()` in `init`, `seed(into:)` after default categories are created) only when `--screenshots` is present.
- **`ScreenshotTests`** (`DawnyUITests/ScreenshotTests.swift`) — drives navigation and captures the three shots for each locale, forcing the locale deterministically via `launchArguments` + `launchEnvironment`.
- **`scripts/take-screenshots.sh`** — runs the suite on the iPhone 17 Pro Max simulator and copies output to `screenshots/<lang>/` (gitignored).

## Notes
- No `project.pbxproj` changes: the project uses file-system-synchronized groups, so the new files are picked up automatically.
- Generated PNGs are gitignored; only the tooling is committed.

## Files
- `App/Sources/ScreenshotSeeder.swift` *(new)*
- `DawnyUITests/ScreenshotTests.swift` *(new)*
- `scripts/take-screenshots.sh` *(new)*
- `App/Sources/DawnyApp.swift` — two `#if DEBUG` seeder hooks