### PR TITLE
Make UI tests deterministic: locale and Settings scroll

### DIFF
--- a/DawnyUITests/DawnyUITests.swift
+++ b/DawnyUITests/DawnyUITests.swift
@@ -94,7 +94,15 @@ final class DawnyUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["--uitesting"]
+        // Sprache deterministisch auf Englisch zwingen. launchEnvironment allein
+        // genügt nicht — die System-Sprache (hier: Deutsch) setzt sich sonst durch.
+        // Erst die `-AppleLanguages`/`-AppleLocale` launchArguments schreiben den
+        // Override beim Start in UserDefaults (gleicher Ansatz wie ScreenshotTests).
+        app.launchArguments = [
+            "--uitesting",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US"
+        ]
         app.launchEnvironment["AppleLanguages"] = "(en)"
         app.launchEnvironment["AppleLocale"] = "en_US"
         app.launch()
@@ -208,12 +216,15 @@ final class DawnyUITests: XCTestCase {
 
         let showWelcomeButton = app.buttons["SettingsShowWelcomeButton"]
         if !showWelcomeButton.waitForExistence(timeout: 2) {
-            // Falls nicht direkt sichtbar: innerhalb des Sheets nach unten scrollen.
-            // swipeUp auf scrollViews innerhalb des Sheets (nicht auf `app` — das könnte das Sheet schließen).
-            let sheetScroll = app.scrollViews.firstMatch
+            // Das Settings-`Form` wird von einer UICollectionView getragen, nicht von
+            // einem `scrollView` — ein swipeUp auf `app.scrollViews` scrollt deshalb
+            // nichts. Stattdessen per Koordinaten innerhalb des Sheets nach oben
+            // ziehen (Inhalt hoch scrollen schließt das Sheet nicht).
             for _ in 0..<10 {
                 if showWelcomeButton.exists && showWelcomeButton.isHittable { break }
-                if sheetScroll.exists { sheetScroll.swipeUp() } else { break }
+                let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+                let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+                start.press(forDuration: 0.05, thenDragTo: end)
             }
         }
         XCTAssertTrue(showWelcomeButton.waitForExistence(timeout: 3), "Show-Welcome-Button im Settings-Sheet nicht gefunden.")


### PR DESCRIPTION
## Summary
Two reliability fixes to the functional UI test suite (`DawnyUITests`), independent of any feature work.

## Changes
- **Deterministic locale** — force English via `-AppleLanguages (en)` / `-AppleLocale en_US` **launchArguments**, not just `launchEnvironment`. The environment variables alone were overridden by the German system locale on the test device; the launch arguments write the override into `UserDefaults` at startup (same technique used by `ScreenshotTests`).
- **Settings sheet scroll** — scroll via a coordinate drag instead of `app.scrollViews.firstMatch.swipeUp()`. The Settings `Form` is backed by a `UICollectionView`, not a `scrollView`, so the old swipe scrolled nothing and `SettingsShowWelcomeButton` was sometimes never reachable.

## Files
- `DawnyUITests/DawnyUITests.swift`

## Risk
Test-only; no production code touched.