### PR TITLE
Rename welcome footer button label to Tutorial

### DIFF
--- a/App/Sources/Localizable.xcstrings
+++ b/App/Sources/Localizable.xcstrings
@@ -4587,13 +4587,13 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Willkommensnachricht erneut anzeigen"
+            "value": "Tutorial erneut anzeigen"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show welcome message again"
+            "value": "Show tutorial again"
           }
         }
       }


### PR DESCRIPTION
Renames the Settings footer button that re-opens onboarding so it reads "Tutorial" in both locales, ahead of the 1.0.0 release.

- **de:** "Willkommensnachricht erneut anzeigen" → "Tutorial erneut anzeigen"
- **en:** "Show welcome message again" → "Show tutorial again"

Only `settings.welcome.showAgain` is touched — the one string actually rendered by the footer button in `SettingsView`. The orphaned `settings.welcome.help` entry (no code reference) is left untouched.