### PR TITLE
Refresh views on tab switch, reset, and Reminders sync

### DIFF
--- a/App/Sources/DawnyApp.swift
+++ b/App/Sources/DawnyApp.swift
@@ -131,9 +131,12 @@ struct DawnyApp: App {
     private func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase) {
         switch newPhase {
         case .active:
-            // App wurde aktiv - prüfe ob Reset nötig
+            // App wurde aktiv - prüfe ob Reset nötig, dann Reminders-Änderungen
+            // einholen (z. B. im Hintergrund abgehakte Tasks). Beide Pfade posten
+            // bei echter Änderung eine Notification, auf die ContentView neu lädt.
             _Concurrency.Task {
                 await resetEngine.checkAndPerformResetIfNeeded()
+                await syncEngine.syncNow()
             }
             
         case .background:

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -74,7 +74,11 @@ final class ResetEngine {
 
         guard !tasksToReset.isEmpty else {
             print("✅ No tasks need reset")
-            if hasArchivedAnyTask { AppSettings.shared.hasNewArchivedTasks = true }
+            if hasArchivedAnyTask {
+                AppSettings.shared.hasNewArchivedTasks = true
+                // Auto-Tidy hat Backlog-Tasks verändert → UI neu laden lassen.
+                NotificationCenter.default.post(name: .dawnyDidReset, object: nil)
+            }
             saveLastResetDate(referenceDate)
             return
         }
@@ -125,6 +129,10 @@ final class ResetEngine {
         // Speichere Reset-Zeitpunkt und zähle Event für Review-Eligibility
         AppSettings.shared.totalResetEventCount += 1
         saveLastResetDate(referenceDate)
+
+        // Der Reset hat Tasks verändert (Recurring → Backlog, resetCount, Archiv)
+        // → UI-Listen neu laden lassen.
+        NotificationCenter.default.post(name: .dawnyDidReset, object: nil)
 
         if hasArchivedAnyTask {
             NotificationCenter.default.post(name: .dawnyDidAutoArchiveTasks, object: nil)
@@ -269,6 +277,8 @@ final class ResetEngine {
 
 extension Notification.Name {
     static let dawnyDidAutoArchiveTasks = Notification.Name("dawnyDidAutoArchiveTasks")
+    /// Gepostet, nachdem ein Reset Tasks verändert hat. `ContentView` lädt darauf die ViewModel-Listen neu.
+    static let dawnyDidReset = Notification.Name("dawnyDidReset")
 }
 
 // MARK: - Testing Helpers

--- a/App/Sources/Services/SyncEngine.swift
+++ b/App/Sources/Services/SyncEngine.swift
@@ -128,10 +128,16 @@ final class SyncEngine {
     /// Synchronisiert alle Daily Focus Tasks
     func syncAllDailyFocusTasks() async {
         let tasks = fetchDailyFocusTasks()
-        
+
         for task in tasks {
             await syncTaskToCalendar(task)
         }
+    }
+
+    /// Expliziter Calendar → App Sync (z. B. beim Wechsel in den Vordergrund).
+    /// Nutzt dieselben `syncInProgress`/Debounce-Guards wie der Observer-Pfad.
+    func syncNow() async {
+        await syncFromCalendar()
     }
     
     // MARK: - Private Methods
@@ -166,38 +172,53 @@ final class SyncEngine {
         lastSyncDate = Date()
         
         let tasks = fetchDailyFocusTasks()
-        
+
+        // Sammelt, ob der Sync tatsächlich Daten verändert hat – nur dann wird
+        // anschließend ein UI-Refresh-Signal gepostet (verhindert Refresh-Stürme).
+        var didChange = false
+
         for task in tasks {
             guard let reminderID = task.externalReminderID else {
                 continue
             }
-            
+
             do {
                 guard let calendarReminder = try await calendarService.fetchReminder(id: reminderID) else {
                     // Reminder wurde im Kalender gelöscht
                     await handleReminderDeleted(task: task)
+                    didChange = true
                     continue
                 }
-                
+
                 // Prüfe auf Änderungen und löse Konflikte
-                await resolveConflicts(task: task, calendarReminder: calendarReminder)
-                
+                if await resolveConflicts(task: task, calendarReminder: calendarReminder) {
+                    didChange = true
+                }
+
             } catch {
                 print("❌ Failed to fetch reminder \(reminderID): \(error)")
             }
         }
-        
+
         // Save Context
         do {
             try modelContext.save()
         } catch {
             print("❌ Failed to save sync changes: \(error)")
         }
+
+        // UI benachrichtigen, damit die ViewModels (DailyFocus/Backlog/Archive)
+        // ihre Snapshot-Listen neu laden. Nur bei echter Änderung.
+        if didChange {
+            NotificationCenter.default.post(name: .dawnyDidSyncFromCalendar, object: nil)
+        }
     }
     
     /// Löst Konflikte zwischen App und Kalender
     /// Strategie: Last-Write-Wins basierend auf Timestamps
-    private func resolveConflicts(task: Task, calendarReminder: CalendarReminder) async {
+    /// - Returns: `true`, wenn der Task durch den Kalender verändert wurde.
+    @discardableResult
+    private func resolveConflicts(task: Task, calendarReminder: CalendarReminder) async -> Bool {
         var hasChanges = false
         
         // Vergleiche Timestamps
@@ -256,8 +277,10 @@ final class SyncEngine {
         if hasChanges {
             task.modifiedAt = Date()
         }
+
+        return hasChanges
     }
-    
+
     /// Handler wenn Reminder im Kalender gelöscht wurde
     private func handleReminderDeleted(task: Task) async {
         // MVP: Automatisch aus DailyFocus entfernen
@@ -279,6 +302,14 @@ final class SyncEngine {
             return []
         }
     }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    /// Gepostet, nachdem ein Calendar → App Sync tatsächlich Daten verändert hat.
+    /// `ContentView` lauscht darauf und lädt die ViewModel-Listen neu.
+    static let dawnyDidSyncFromCalendar = Notification.Name("dawnyDidSyncFromCalendar")
 }
 
 // MARK: - NotificationCenter Extension

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -171,6 +171,12 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .dawnyDidAutoArchiveTasks)) { _ in
             triggerAutoArchiveReviewIfNeeded()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .dawnyDidSyncFromCalendar)) { _ in
+            reloadAllViewModels()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dawnyDidReset)) { _ in
+            reloadAllViewModels()
+        }
         #if DEBUG
         .alert(
             String(localized: "quickadd.deleteall", defaultValue: "Delete All Tasks"),
@@ -204,7 +210,33 @@ struct ContentView: View {
                 settings.hasNewArchivedTasks = false
                 archiveViewModel?.markAllArchiveReviewed()
             }
+            // Beim Tab-Wechsel die Zielansicht frisch laden (die Pager-Seiten bleiben
+            // alle gemountet, daher feuert ihr onAppear nur einmal beim Start).
+            // selectedTab ändert sich nur am Gestenende/Button-Tap, nicht pro Drag-Frame.
+            loadViewModel(for: newTab)
         }
+    }
+
+    /// Lädt das ViewModel der angegebenen Seite neu.
+    private func loadViewModel(for tab: Tab) {
+        switch tab {
+        case .backlog:
+            backlogViewModel?.loadBacklogs()
+            backlogViewModel?.loadCategories()
+        case .today:
+            dailyFocusViewModel?.loadDailyTasks()
+        case .archive:
+            archiveViewModel?.loadAll()
+        }
+    }
+
+    /// Lädt alle ViewModel-Listen neu. Reaktion auf Reset-/Sync-Notifications,
+    /// damit extern (Reminders) oder durch den Reset geänderte Daten überall sichtbar werden.
+    private func reloadAllViewModels() {
+        dailyFocusViewModel?.loadDailyTasks()
+        backlogViewModel?.loadBacklogs()
+        backlogViewModel?.loadCategories()
+        archiveViewModel?.loadAll()
     }
 
     private var tabSwitcher: some View {
@@ -252,8 +284,8 @@ struct ContentView: View {
             var transaction = Transaction()
             transaction.disablesAnimations = true
             withTransaction(transaction) {
+                // loadAll() läuft zentral über onChange(of: selectedTab) → loadViewModel(for:)
                 selectedTab = .archive
-                archiveViewModel?.loadAll()
             }
         } label: {
             ZStack(alignment: .topTrailing) {

--- a/DawnyTests/Services/SyncEngineTests.swift
+++ b/DawnyTests/Services/SyncEngineTests.swift
@@ -168,20 +168,66 @@ final class SyncEngineTests: XCTestCase {
     func testSyncAllRespectsCalendarSyncEnabled() async throws {
         // Deaktiviere Kalender-Sync
         AppSettings.shared.calendarSyncEnabled = false
-        
+
         let backlog = TestModelContainer.createBacklog(in: context)
         let task1 = TestModelContainer.createTask(in: context, title: "Task 1", status: .dailyFocus, backlog: backlog)
         let task2 = TestModelContainer.createTask(in: context, title: "Task 2", status: .dailyFocus, backlog: backlog)
-        
+
         task1.scheduledDate = Date()
         task2.scheduledDate = Date()
-        
+
         // Versuche alle zu synchronisieren
         await syncEngine.syncAllDailyFocusTasks()
-        
+
         // Sollte nicht synchronisiert werden
         XCTAssertEqual(calendarService.createCallCount, 0)
         XCTAssertNil(task1.externalReminderID)
         XCTAssertNil(task2.externalReminderID)
+    }
+
+    // MARK: - UI Refresh Notification Tests
+
+    /// Wird in Reminders eine verknüpfte Aufgabe abgehakt, muss `syncNow()` ein
+    /// `.dawnyDidSyncFromCalendar`-Signal posten, damit die ViewModels neu laden.
+    func testSyncFromCalendarPostsNotificationWhenReminderChanged() async throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+        task.scheduledDate = Date()
+
+        await syncEngine.syncTaskToCalendar(task)
+        let reminderID = try XCTUnwrap(task.externalReminderID)
+
+        // Simuliere "in Reminders abgehakt": Reminder ist completed und neuer als der Task.
+        task.modifiedAt = Date(timeIntervalSinceNow: -60)
+        let existing = try XCTUnwrap(calendarService.reminders[reminderID])
+        calendarService.reminders[reminderID] = CalendarReminder(
+            id: existing.id,
+            title: existing.title,
+            notes: existing.notes,
+            isCompleted: true,
+            dueDate: existing.dueDate,
+            modificationDate: Date(timeIntervalSinceNow: 60)
+        )
+
+        let expectation = XCTNSNotificationExpectation(name: .dawnyDidSyncFromCalendar)
+        await syncEngine.syncNow()
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(task.isCompleted)
+    }
+
+    /// Ohne tatsächliche Änderung im Kalender darf kein Refresh-Signal gepostet werden
+    /// (verhindert unnötige Reloads / Refresh-Stürme).
+    func testSyncFromCalendarDoesNotPostNotificationWhenNothingChanged() async throws {
+        let backlog = TestModelContainer.createBacklog(in: context)
+        let task = TestModelContainer.createTask(in: context, title: "Test", status: .dailyFocus, backlog: backlog)
+        task.scheduledDate = Date()
+
+        await syncEngine.syncTaskToCalendar(task)
+
+        let expectation = XCTNSNotificationExpectation(name: .dawnyDidSyncFromCalendar)
+        expectation.isInverted = true
+        await syncEngine.syncNow()
+        await fulfillment(of: [expectation], timeout: 0.5)
     }
 }


### PR DESCRIPTION
## Problem

Die ViewModels (`DailyFocusViewModel`, `BacklogViewModel`, `ArchiveViewModel`) halten Snapshot-Arrays, kein Live-`@Query`. Sie aktualisierten sich nur über explizite `load…()`-Aufrufe, wodurch die Ansicht bis zu einem manuellen Pull-to-Refresh veraltet blieb:

- Der Custom-`TabPager` hält alle Seiten gleichzeitig gemountet → jedes `.onAppear` feuert nur einmal beim App-Start, nie beim Tab-Wechsel.
- `SyncEngine` schrieb Reminders-Änderungen in SwiftData, ohne die UI zu benachrichtigen.
- Scene-Phase `.active` führte nur den Reset-Check aus, lud aber keine Listen neu.

## Lösung

Alle Reloads laufen über *ein* Muster: Die Engines posten bei echter Datenänderung eine Notification, `ContentView` lauscht und lädt die ViewModels neu.

- **ContentView:** lädt beim `selectedTab`-Wechsel die Zielansicht; entfernt das nun redundante `loadAll()` aus dem Archiv-Button; lädt alle ViewModels bei `.dawnyDidSyncFromCalendar` / `.dawnyDidReset`.
- **SyncEngine:** aggregiert ein `didChange`-Flag und postet `.dawnyDidSyncFromCalendar` nach einem Sync, der Daten verändert hat; neue öffentliche `syncNow()`.
- **ResetEngine:** postet `.dawnyDidReset`, wenn ein Reset Tasks verändert hat.
- **DawnyApp:** ruft bei Scene-Phase `.active` nach dem Reset-Check zusätzlich `syncNow()`.

## Gesten / Performance

- Der Tab-Switch-Load feuert nur beim finalen `selectedTab`-Wechsel (Gestenende/Tap), **nicht** pro Drag-Frame → Drag&Drop und Wischgesten bleiben unverändert.
- Der Sync-Reload feuert nur bei echter Änderung, abgesichert durch den bestehenden 1-s-Debounce.

## Tests

- Build erfolgreich; alle 141 Unit-Tests grün.
- Zwei neue Tests in `SyncEngineTests`: Notification wird bei einer Reminders-Änderung gepostet — und *nicht*, wenn sich nichts ändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)