### PR TITLE
Update READMEs for App Store launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,14 @@
 </p>
 
 <p align="center">
-  <img alt="Platform" src="https://img.shields.io/badge/platform-iOS%2026.2%2B-blue">
+  <img alt="Platform" src="https://img.shields.io/badge/platform-iOS-blue">
   <img alt="Swift" src="https://img.shields.io/badge/Swift-6-orange">
-  <img alt="UI" src="https://img.shields.io/badge/UI-SwiftUI-0A84FF">
-  <img alt="Persistence" src="https://img.shields.io/badge/Data-SwiftData-34C759">
-  <img alt="Dependencies" src="https://img.shields.io/badge/dependencies-zero-brightgreen">
-  <img alt="Status" src="https://img.shields.io/badge/status-beta-yellow">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-lightgrey"></a>
 </p>
 
 <p align="center">
-  <a href="https://testflight.apple.com/join/758Xfan6">
-    <img alt="Join the TestFlight Beta" src="https://img.shields.io/badge/TestFlight-Join%20the%20Beta-000000?style=for-the-badge&logo=apple">
+  <a href="https://apps.apple.com/app/id6762262959">
+    <img alt="Download on the App Store" src="https://img.shields.io/badge/Download%20on%20the-App%20Store-000000?style=for-the-badge&logo=apple&logoColor=white">
   </a>
 </p>
 
@@ -35,7 +31,7 @@ The codebase is Swift 6 with SwiftUI and SwiftData, zero third-party dependencie
 
 ## Getting Dawny
 
-Install via the [TestFlight beta](https://testflight.apple.com/join/758Xfan6). Dawny will be available on the App Store soon. Any feedback before the 1.0 release is much appreciated.
+Dawny is available as a free download on the [App Store](https://apps.apple.com/app/id6762262959).
 
 ---
 

--- a/website/README.md
+++ b/website/README.md
@@ -48,7 +48,7 @@ website/
 │   ├── robots.txt
 │   └── .htaccess               # Apache config for IONOS
 ├── scripts/
-│   ├── generate-qr.mjs         # builds the TestFlight QR
+│   ├── generate-qr.mjs         # builds the App Store QR
 │   ├── generate-og.mjs         # builds the OpenGraph card
 │   └── deploy-ionos.mjs        # FTPS deploy script
 └── astro.config.mjs
@@ -69,7 +69,7 @@ matching dictionary based on the route's language prefix.
 `npm run dev` and `npm run build` both run `scripts/generate-qr.mjs` and
 `scripts/generate-og.mjs` first:
 
-- **QR code** points to the TestFlight invite (`/public/assets/qr-testflight.svg`).
+- **QR code** points to the App Store listing (`/public/assets/qr-appstore.svg`).
   Edit the URL inside `scripts/generate-qr.mjs` if it ever changes.
 - **OG image** is rendered from an inline SVG via `sharp` to
   `/public/og-image.png` (1200×630).
@@ -117,8 +117,7 @@ Add these repository secrets in **Settings → Secrets and variables → Actions
 
 ## Next steps (post-launch)
 
-- Drop in real App Store badges once Dawny exits TestFlight.
-- Add an FAQ page when 5+ recurring questions emerge from beta feedback.
+- Add an FAQ page when 5+ recurring questions emerge from user feedback.
 - Consider a press kit page with high-res logos & screenshots once requested.
 
 ## License


### PR DESCRIPTION
Brings the repo README (and the internal website README) in line with the v1.0.0 App Store release.

## Changes
- **TestFlight → App Store** everywhere: the prominent CTA badge now links to the App Store; the "Getting Dawny" section points there too
- **Slimmed the shields row** from 7 badges to the conventional set — `platform iOS`, `Swift 6`, `license` — and dropped the tech-stack badges (`UI SwiftUI`, `Data SwiftData`) plus the now-stale `status: beta`, since the stack is already described in the prose
- **Removed the overstated `iOS 26.2+`** minimum-version claim from the platform badge (project has an 18.6 target; no version number is shown now, matching the website)
- **Fixed stale references** in `website/README.md` (TestFlight QR → App Store QR; removed the "drop in real App Store badges" TODO now that they're in)