### PR TITLE
Switch project license from PolyForm Noncommercial to MIT

### DIFF
--- a/App/Sources/DawnyApp.swift
+++ b/App/Sources/DawnyApp.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  DawnyApp.swift

--- a/App/Sources/Extensions/HapticFeedback.swift
+++ b/App/Sources/Extensions/HapticFeedback.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  HapticFeedback.swift

--- a/App/Sources/Intents/AddTaskIntent.swift
+++ b/App/Sources/Intents/AddTaskIntent.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AddTaskIntent.swift

--- a/App/Sources/Intents/AddTaskTodayIntent.swift
+++ b/App/Sources/Intents/AddTaskTodayIntent.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import SwiftData

--- a/App/Sources/Intents/CategoryAppEntity.swift
+++ b/App/Sources/Intents/CategoryAppEntity.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import CoreSpotlight

--- a/App/Sources/Intents/CompleteTaskIntent.swift
+++ b/App/Sources/Intents/CompleteTaskIntent.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import SwiftData

--- a/App/Sources/Intents/DawnyShortcuts.swift
+++ b/App/Sources/Intents/DawnyShortcuts.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  DawnyShortcuts.swift

--- a/App/Sources/Intents/EntityIndexer.swift
+++ b/App/Sources/Intents/EntityIndexer.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import CoreSpotlight

--- a/App/Sources/Intents/IntentDataStore.swift
+++ b/App/Sources/Intents/IntentDataStore.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import Foundation
 import SwiftData

--- a/App/Sources/Intents/IntentTextMatcher.swift
+++ b/App/Sources/Intents/IntentTextMatcher.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import Foundation
 

--- a/App/Sources/Intents/ListTodayTasksIntent.swift
+++ b/App/Sources/Intents/ListTodayTasksIntent.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import SwiftData

--- a/App/Sources/Intents/MoveTaskToTodayIntent.swift
+++ b/App/Sources/Intents/MoveTaskToTodayIntent.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import SwiftData

--- a/App/Sources/Intents/TaskAppEntity.swift
+++ b/App/Sources/Intents/TaskAppEntity.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import AppIntents
 import CoreSpotlight

--- a/App/Sources/Models/AppSettings.swift
+++ b/App/Sources/Models/AppSettings.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AppSettings.swift

--- a/App/Sources/Models/Backlog.swift
+++ b/App/Sources/Models/Backlog.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  Backlog.swift

--- a/App/Sources/Models/BacklogTaskTransfer.swift
+++ b/App/Sources/Models/BacklogTaskTransfer.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  BacklogTaskTransfer.swift

--- a/App/Sources/Models/Category.swift
+++ b/App/Sources/Models/Category.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  Category.swift

--- a/App/Sources/Models/Task.swift
+++ b/App/Sources/Models/Task.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  Task.swift

--- a/App/Sources/Models/TaskCategory.swift
+++ b/App/Sources/Models/TaskCategory.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TaskCategory.swift

--- a/App/Sources/Models/TaskStatus.swift
+++ b/App/Sources/Models/TaskStatus.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TaskStatus.swift

--- a/App/Sources/PreviewSupport.swift
+++ b/App/Sources/PreviewSupport.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  PreviewSupport.swift

--- a/App/Sources/Protocols/CalendarServiceProtocol.swift
+++ b/App/Sources/Protocols/CalendarServiceProtocol.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CalendarServiceProtocol.swift

--- a/App/Sources/Protocols/TimeProvider.swift
+++ b/App/Sources/Protocols/TimeProvider.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TimeProvider.swift

--- a/App/Sources/ScreenshotSeeder.swift
+++ b/App/Sources/ScreenshotSeeder.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ScreenshotSeeder.swift

--- a/App/Sources/Services/CategoryService.swift
+++ b/App/Sources/Services/CategoryService.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CategoryService.swift

--- a/App/Sources/Services/EventKitCalendarService.swift
+++ b/App/Sources/Services/EventKitCalendarService.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  EventKitCalendarService.swift

--- a/App/Sources/Services/FeedbackService.swift
+++ b/App/Sources/Services/FeedbackService.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  FeedbackService.swift

--- a/App/Sources/Services/ResetEngine.swift
+++ b/App/Sources/Services/ResetEngine.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ResetEngine.swift

--- a/App/Sources/Services/SyncEngine.swift
+++ b/App/Sources/Services/SyncEngine.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  SyncEngine.swift

--- a/App/Sources/Utilities/SelectTodayTabEnvironment.swift
+++ b/App/Sources/Utilities/SelectTodayTabEnvironment.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  SelectTodayTabEnvironment.swift

--- a/App/Sources/Utilities/TriggerWelcomeFlowEnvironment.swift
+++ b/App/Sources/Utilities/TriggerWelcomeFlowEnvironment.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TriggerWelcomeFlowEnvironment.swift

--- a/App/Sources/ViewModels/ArchiveViewModel.swift
+++ b/App/Sources/ViewModels/ArchiveViewModel.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ArchiveViewModel.swift

--- a/App/Sources/ViewModels/AutoArchiveReviewViewModel.swift
+++ b/App/Sources/ViewModels/AutoArchiveReviewViewModel.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AutoArchiveReviewViewModel.swift

--- a/App/Sources/ViewModels/BacklogViewModel.swift
+++ b/App/Sources/ViewModels/BacklogViewModel.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  BacklogViewModel.swift

--- a/App/Sources/ViewModels/DailyFocusViewModel.swift
+++ b/App/Sources/ViewModels/DailyFocusViewModel.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  DailyFocusViewModel.swift

--- a/App/Sources/Views/ArchiveView.swift
+++ b/App/Sources/Views/ArchiveView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ArchiveView.swift

--- a/App/Sources/Views/AutoArchiveReviewView.swift
+++ b/App/Sources/Views/AutoArchiveReviewView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AutoArchiveReviewView.swift

--- a/App/Sources/Views/BacklogView.swift
+++ b/App/Sources/Views/BacklogView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  BacklogView.swift

--- a/App/Sources/Views/Components/AddCategoryRow.swift
+++ b/App/Sources/Views/Components/AddCategoryRow.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AddCategoryRow.swift

--- a/App/Sources/Views/Components/CategoryEditorView.swift
+++ b/App/Sources/Views/Components/CategoryEditorView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CategoryEditorView.swift

--- a/App/Sources/Views/Components/CategoryHeaderView.swift
+++ b/App/Sources/Views/Components/CategoryHeaderView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CategoryHeaderView.swift

--- a/App/Sources/Views/Components/CategorySelectionMenu.swift
+++ b/App/Sources/Views/Components/CategorySelectionMenu.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CategorySelectionMenu.swift

--- a/App/Sources/Views/Components/CategorySymbolPicker.swift
+++ b/App/Sources/Views/Components/CategorySymbolPicker.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CategorySymbolPicker.swift

--- a/App/Sources/Views/Components/EmptyStateView.swift
+++ b/App/Sources/Views/Components/EmptyStateView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  EmptyStateView.swift

--- a/App/Sources/Views/Components/ErrorBannerView.swift
+++ b/App/Sources/Views/Components/ErrorBannerView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ErrorBannerView.swift

--- a/App/Sources/Views/Components/QuickEntryRow.swift
+++ b/App/Sources/Views/Components/QuickEntryRow.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  QuickEntryRow.swift

--- a/App/Sources/Views/Components/SyncStatusIndicator.swift
+++ b/App/Sources/Views/Components/SyncStatusIndicator.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  SyncStatusIndicator.swift

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ContentView.swift

--- a/App/Sources/Views/DailyFocusView.swift
+++ b/App/Sources/Views/DailyFocusView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  DailyFocusView.swift

--- a/App/Sources/Views/MailComposeView.swift
+++ b/App/Sources/Views/MailComposeView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  MailComposeView.swift

--- a/App/Sources/Views/QuickAddView.swift
+++ b/App/Sources/Views/QuickAddView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  QuickAddView.swift

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  SettingsView.swift

--- a/App/Sources/Views/TaskRowView.swift
+++ b/App/Sources/Views/TaskRowView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TaskRowView.swift

--- a/App/Sources/Views/WelcomeView.swift
+++ b/App/Sources/Views/WelcomeView.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  WelcomeView.swift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,34 +5,24 @@ project, but contributions are welcome — within the constraints below.
 
 ## License of Contributions (important)
 
-Dawny is **source-available**, not open source. The project is licensed under the
-[PolyForm Noncommercial License 1.0.0](LICENSE). This affects how contributions
+Dawny is licensed under the [MIT License](LICENSE). This affects how contributions
 are handled.
 
 By submitting a pull request, an issue with code suggestions, or any other
 contribution to this repository, you agree that:
 
 1. **Inbound = Outbound.** Your contribution is licensed to the project under the
-   exact same terms as the rest of the project — currently the PolyForm
-   Noncommercial License 1.0.0. You cannot submit code that is incompatible with
-   that license (for example, GPL-licensed code).
+   exact same terms as the rest of the project — currently the MIT License. You
+   cannot submit code that is incompatible with that license (for example,
+   GPL-licensed code).
 
-2. **Relicensing grant.** You also grant Florian Schneider (the project owner) a
-   perpetual, worldwide, irrevocable, royalty-free license to use, reproduce,
-   modify, publish, distribute, sublicense, and **relicense** your contribution
-   under any other license — including a commercial license.
-
-   This is necessary so the project owner can offer Dawny under a commercial
-   license to paying customers, or change the project license in the future,
-   without having to track down every contributor.
-
-3. **You have the right to contribute.** You confirm that the contribution is
+2. **You have the right to contribute.** You confirm that the contribution is
    your own original work, or that you have the rights to submit it under these
    terms. If your employer has rights to your work, you confirm you have
    permission to contribute.
 
 If you do not agree with these terms, please do not submit code. Bug reports and
-feature discussions in issues are still welcome and not subject to clause 2.
+feature discussions in issues are still welcome.
 
 ## What kind of contributions fit Dawny
 

--- a/DawnyTests/Integration/PersistenceTests.swift
+++ b/DawnyTests/Integration/PersistenceTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  PersistenceTests.swift

--- a/DawnyTests/Integration/TaskLifecycleTests.swift
+++ b/DawnyTests/Integration/TaskLifecycleTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TaskLifecycleTests.swift

--- a/DawnyTests/Intents/IntentDataStoreTests.swift
+++ b/DawnyTests/Intents/IntentDataStoreTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 import SwiftData
 import XCTest

--- a/DawnyTests/Mocks/MockCalendarService.swift
+++ b/DawnyTests/Mocks/MockCalendarService.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  MockCalendarService.swift

--- a/DawnyTests/Mocks/MockTimeProvider.swift
+++ b/DawnyTests/Mocks/MockTimeProvider.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  MockTimeProvider.swift

--- a/DawnyTests/Mocks/TestModelContainer.swift
+++ b/DawnyTests/Mocks/TestModelContainer.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TestModelContainer.swift

--- a/DawnyTests/Models/AppSettingsTests.swift
+++ b/DawnyTests/Models/AppSettingsTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AppSettingsTests.swift

--- a/DawnyTests/Models/BacklogModelTests.swift
+++ b/DawnyTests/Models/BacklogModelTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  BacklogModelTests.swift

--- a/DawnyTests/Models/TaskModelTests.swift
+++ b/DawnyTests/Models/TaskModelTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TaskModelTests.swift

--- a/DawnyTests/Services/CategoryServiceTests.swift
+++ b/DawnyTests/Services/CategoryServiceTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  CategoryServiceTests.swift

--- a/DawnyTests/Services/MakeItCountResetTests.swift
+++ b/DawnyTests/Services/MakeItCountResetTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  MakeItCountResetTests.swift

--- a/DawnyTests/Services/ResetEngineTests.swift
+++ b/DawnyTests/Services/ResetEngineTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ResetEngineTests.swift

--- a/DawnyTests/Services/SyncEngineTests.swift
+++ b/DawnyTests/Services/SyncEngineTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  SyncEngineTests.swift

--- a/DawnyTests/ViewModels/ArchiveViewModelTests.swift
+++ b/DawnyTests/ViewModels/ArchiveViewModelTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ArchiveViewModelTests.swift

--- a/DawnyTests/ViewModels/AutoArchiveReviewViewModelTests.swift
+++ b/DawnyTests/ViewModels/AutoArchiveReviewViewModelTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  AutoArchiveReviewViewModelTests.swift

--- a/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
+++ b/DawnyTests/ViewModels/BacklogViewModelPlacementTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  BacklogViewModelPlacementTests.swift

--- a/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
+++ b/DawnyTests/ViewModels/DailyFocusRecurringTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  DailyFocusRecurringTests.swift

--- a/DawnyTests/ViewModels/MakeItCountDailyFocusTests.swift
+++ b/DawnyTests/ViewModels/MakeItCountDailyFocusTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  MakeItCountDailyFocusTests.swift

--- a/DawnyTests/Views/TabSelectionLogicTests.swift
+++ b/DawnyTests/Views/TabSelectionLogicTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  TabSelectionLogicTests.swift

--- a/DawnyUITests/DawnyUITests.swift
+++ b/DawnyUITests/DawnyUITests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  DawnyUITests.swift

--- a/DawnyUITests/ScreenshotTests.swift
+++ b/DawnyUITests/ScreenshotTests.swift
@@ -1,6 +1,6 @@
 // Dawny
-// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.
-// Licensed under PolyForm Noncommercial 1.0.0 — see LICENSE in the repository root.
+// Copyright (c) 2025-2026 Florian Schneider
+// Licensed under the MIT License — see LICENSE in the repository root.
 
 //
 //  ScreenshotTests.swift

--- a/LICENSE
+++ b/LICENSE
@@ -1,133 +1,24 @@
-# PolyForm Noncommercial License 1.0.0
+MIT License
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+Copyright (c) 2025-2026 Florian Schneider
 
-Required Notice: Copyright (c) 2025-2026 Florian Schneider (info@dawnyapp.com)
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-## Acceptance
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-## Copyright License
-
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose. However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Distribution License
-
-The licensor grants you an additional copyright license
-to distribute copies of the software. Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software. For example:
-
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
-
-## Changes and New Works License
-
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
-
-## Patent License
-
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
-
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
-
-## Fair Use
-
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else. These terms do not imply
-any other licenses.
-
-## Patent Defense
-
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
-
-## Violations
-
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice. Otherwise, all your licenses
-end immediately.
-
-## No Liability
-
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
-
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization. **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise. Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
+Note: this license covers the source code only. It does not grant any license
+to the "Dawny" name, logo, app icon, or other brand assets — see NOTICE.

--- a/NOTICE
+++ b/NOTICE
@@ -3,17 +3,8 @@ Dawny
 
 Required Notice: Copyright (c) 2025-2026 Florian Schneider (info@dawnyapp.com)
 
-Source code in this repository is licensed under the PolyForm Noncommercial
-License 1.0.0. See the LICENSE file in the root of this repository, or visit
-https://polyformproject.org/licenses/noncommercial/1.0.0 for the full text.
-
-This is a SOURCE-AVAILABLE project, not Open Source in the OSI sense.
-Personal study, hobby use, research, and contributions are welcome.
-Any commercial use - including, but not limited to, distributing the
-software (in original or modified form) as a paid app, a free app that
-generates revenue through ads or in-app purchases, or as part of any
-service or product that generates revenue - is NOT permitted under this
-license. For commercial licensing, contact info@dawnyapp.com.
+Source code in this repository is licensed under the MIT License. See the
+LICENSE file in the root of this repository for the full text.
 
 ------------------------------------------------------------------------
 
@@ -21,8 +12,8 @@ Trademarks
 ----------
 
 "Dawny", the Dawny name, and the Dawny logo and app icon are trademarks
-of Florian Schneider. The PolyForm Noncommercial License 1.0.0 grants
-copyright and patent licenses, but it does NOT grant any trademark license.
+of Florian Schneider. The MIT License grants copyright and patent
+licenses, but it does NOT grant any trademark license.
 
 If you fork this project, modify it, or build derivative works, you MUST:
 
@@ -37,8 +28,8 @@ If you fork this project, modify it, or build derivative works, you MUST:
 Assets and Content
 ------------------
 
-The following are NOT licensed under PolyForm Noncommercial 1.0.0 and
-remain under "All Rights Reserved":
+The following are NOT licensed under the MIT License and remain under
+"All Rights Reserved":
 
   - All image assets in App/Assets.xcassets/ (app icon, accent colors,
     image assets), including the file
@@ -46,13 +37,12 @@ remain under "All Rights Reserved":
   - The marketing copy and prose in README.md.
   - Any screenshots, App Store metadata, and TestFlight materials.
 
-You may not redistribute these assets, even for noncommercial purposes,
-without separate written permission.
+You may not redistribute these assets without separate written permission.
 
 ------------------------------------------------------------------------
 
 Contact
 -------
 
-Commercial licensing, trademark questions, security reports, or anything
-else legal: info@dawnyapp.com
+Trademark questions, security reports, or anything else legal:
+info@dawnyapp.com

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <img alt="Platform" src="https://img.shields.io/badge/platform-iOS-blue">
   <img alt="Swift" src="https://img.shields.io/badge/Swift-6-orange">
-  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-lightgrey"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-blue"></a>
 </p>
 
 <p align="center">
@@ -102,10 +102,6 @@ Dawny/
 
 ## License
 
-Dawny is **source-available, not open source**.
+The source code in this repository is licensed under the [MIT License](LICENSE).
 
-The source code in this repository is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE). In short: you may read, study, modify, and use the code for personal, educational, research, hobby, and other noncommercial purposes. You may **not** use the code (in original or modified form) as part of any product or service that generates revenue, including paid apps, ad-supported apps, or apps with in-app purchases.
-
-The name "Dawny", the Dawny logo, and the app icon are **trademarks** of Florian Schneider and are not licensed under PolyForm. Forks must be renamed and rebranded. See [NOTICE](NOTICE) for details on trademarks, asset licensing, and contact info.
-
-For commercial licensing inquiries, write to **info@dawnyapp.com**.
+The name "Dawny", the Dawny logo, and the app icon are **trademarks** of Florian Schneider and are not licensed under MIT. Forks must be renamed and rebranded. See [NOTICE](NOTICE) for details on trademarks, asset licensing, and contact info.

--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Adds a PolyForm Noncommercial 1.0.0 license header to every .swift file
-# in the project. Idempotent: skips files that already contain the header.
+# Adds an MIT license header to every .swift file in the project.
+# Idempotent: skips files that already contain the header.
 #
 # Usage:
 #   ./scripts/add-license-headers.sh         # dry-run, lists files that would change
@@ -16,9 +16,9 @@ if [[ "${1:-}" == "--write" ]]; then
   WRITE=1
 fi
 
-HEADER_MARKER="Licensed under PolyForm Noncommercial 1.0.0"
+HEADER_MARKER="Licensed under the MIT License"
 
-HEADER=$'// Dawny\n// Copyright (c) 2025-2026 Florian Schneider. All rights reserved.\n// Licensed under PolyForm Noncommercial 1.0.0 \xe2\x80\x94 see LICENSE in the repository root.\n\n'
+HEADER=$'// Dawny\n// Copyright (c) 2025-2026 Florian Schneider\n// Licensed under the MIT License \xe2\x80\x94 see LICENSE in the repository root.\n\n'
 
 DIRS=("App" "DawnyTests")
 

--- a/website/README.md
+++ b/website/README.md
@@ -122,5 +122,5 @@ Add these repository secrets in **Settings → Secrets and variables → Actions
 
 ## License
 
-Source under the same PolyForm Noncommercial 1.0.0 license as the parent
-repo. The Dawny name and logo remain trademarks of Florian Schneider.
+Source under the same MIT License as the parent repo. The Dawny name and
+logo remain trademarks of Florian Schneider.

--- a/website/src/pages/de/impressum.md
+++ b/website/src/pages/de/impressum.md
@@ -41,4 +41,4 @@ Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir
 
 ## Urheberrecht
 
-Die durch den Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Marke „Dawny", das Dawny-Logo und das App-Icon sind Marken von Florian Schneider. Der Quellcode der App ist quelloffen unter der PolyForm Noncommercial License 1.0.0 verfügbar.
+Die durch den Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Marke „Dawny", das Dawny-Logo und das App-Icon sind Marken von Florian Schneider. Der Quellcode der App ist Open Source unter der MIT-Lizenz verfügbar.

--- a/website/src/pages/en/imprint.md
+++ b/website/src/pages/en/imprint.md
@@ -41,4 +41,4 @@ Our offer contains links to external websites of third parties, on whose content
 
 ## Copyright
 
-The content and works created by the site operator on these pages are subject to German copyright law. The "Dawny" name, the Dawny logo, and the app icon are trademarks of Florian Schneider. The source code of the app is source-available under the PolyForm Noncommercial License 1.0.0.
+The content and works created by the site operator on these pages are subject to German copyright law. The "Dawny" name, the Dawny logo, and the app icon are trademarks of Florian Schneider. The source code of the app is open source under the MIT License.


### PR DESCRIPTION
## Summary
- Replaced `LICENSE` with the standard MIT License text
- Rewrote the header comment in all 75 Swift source/test files (App, DawnyTests, DawnyUITests) from the PolyForm Noncommercial header to the MIT header
- Updated `scripts/add-license-headers.sh` so future files get the MIT header
- Slimmed `NOTICE`: removed the "commercial use not permitted / source-available, not open source" language; kept the trademark (Dawny name/logo/icon) and brand-asset "All Rights Reserved" carve-outs
- Updated the license badge and License section in `README.md`
- Updated `CONTRIBUTING.md`: inbound license is now MIT; dropped the relicensing/commercial-license grant clause, which is no longer needed
- Updated the license line in `website/README.md`, `website/src/pages/en/imprint.md`, and `website/src/pages/de/impressum.md`

Rationale: Dawny is free with no revenue to protect, so the noncommercial restriction no longer serves its purpose and only kept the project from being genuine, OSI-recognized open source. Trademark protection for the "Dawny" name, logo, and app icon is unaffected — MIT doesn't grant trademark rights, and NOTICE still asks forks to rebrand.

## Test plan
- [x] Repo-wide `grep -i "polyform|noncommercial"` returns zero hits
- [x] `scripts/add-license-headers.sh` dry-run confirms all scanned Swift files already carry the new MIT header
- [x] `xcodebuild test -scheme Dawny -only-testing:DawnyTests` — 141/141 tests passed
- [ ] Spot-check the deployed website's imprint/impressum pages after the next website deploy